### PR TITLE
Add iOS extensions to DeviceOrientationEvent externs

### DIFF
--- a/externs/w3c_device_sensor_event.js
+++ b/externs/w3c_device_sensor_event.js
@@ -43,6 +43,18 @@ DeviceOrientationEvent.prototype.gamma;
 DeviceOrientationEvent.prototype.absolute;
 
 /**
+ * @type {?number}
+ * @see https://developer.apple.com/library/safari/documentation/SafariDOMAdditions/Reference/DeviceOrientationEventClassRef/DeviceOrientationEvent/DeviceOrientationEvent.html#//apple_ref/javascript/instp/DeviceOrientationEvent/webkitCompassAccuracy
+ */
+DeviceOrientationEvent.prototype.webkitCompassAccuracy;
+
+/**
+ * @type {?number}
+ * @see https://developer.apple.com/library/safari/documentation/SafariDOMAdditions/Reference/DeviceOrientationEventClassRef/DeviceOrientationEvent/DeviceOrientationEvent.html#//apple_ref/javascript/instp/DeviceOrientationEvent/webkitCompassHeading
+ */
+DeviceOrientationEvent.prototype.webkitCompassHeading;
+
+/**
  * @constructor
  */
 function DeviceAcceleration() {}


### PR DESCRIPTION
Only available in iOS 5.0 and later.
See https://developer.apple.com/library/safari/documentation/SafariDOMAdditions/Reference/DeviceOrientationEventClassRef/DeviceOrientationEvent/DeviceOrientationEvent.html

Closes #130
