### PR TITLE
Turn on the InferConsts pass by default

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -83,9 +83,9 @@ public class CompilerOptions implements Serializable, Cloneable {
    * external clients. This is a transitional flag for a new type
    * of const analysis.
    *
-   * TODO(nicksantos): Turn this on by default and remove this option.
+   * TODO(nicksantos): Remove this option.
    */
-  boolean inferConsts;
+  boolean inferConsts = true;
 
   /**
    * Whether the compiler should assume that a function's "this" value

--- a/src/com/google/javascript/jscomp/InferConsts.java
+++ b/src/com/google/javascript/jscomp/InferConsts.java
@@ -61,13 +61,14 @@ class InferConsts implements CompilerPass {
 
   private void considerVar(Var v, ReferenceCollection refCollection) {
     Node nameNode = v.getNameNode();
+    if (nameNode == null) return;
+
     JSDocInfo docInfo = v.getJSDocInfo();
     if (docInfo != null && docInfo.isConstant()) {
       nameNode.putBooleanProp(Node.IS_CONSTANT_VAR, true);
-    } else if (nameNode != null && nameNode.getParent().isConst()) {
+    } else if (nameNode.getParent().isConst()) {
       nameNode.putBooleanProp(Node.IS_CONSTANT_VAR, true);
-    } else if (nameNode != null &&
-        compiler.getCodingConvention().isConstant(nameNode.getString())) {
+    } else if (compiler.getCodingConvention().isConstant(nameNode.getString())) {
       nameNode.putBooleanProp(Node.IS_CONSTANT_VAR, true);
     } else if (refCollection != null &&
                refCollection.isWellDefined() &&

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -101,9 +101,9 @@ public class IntegrationTest extends IntegrationTestCase {
     options.generateExports = true;
     test(options,
          CLOSURE_BOILERPLATE + "/** @export */ goog.CONSTANT = 1;" +
-         "var x = goog.CONSTANT;",
+         "var x = goog.CONSTANT; alert(x);",
          "(function() {})('goog.CONSTANT', 1);" +
-         "var x = 1;");
+         "alert(1);");
   }
 
   public void testBug2410122() {
@@ -1060,11 +1060,11 @@ public class IntegrationTest extends IntegrationTestCase {
 
   public void testInlineConstants() {
     CompilerOptions options = createCompilerOptions();
-    String code = "function foo() {} var x = 3; foo(x); var YYY = 4; foo(YYY);";
+    String code = "function foo() {} var x = 3; x = 5; foo(x); var y = 4; foo(y);";
     testSame(options, code);
 
     options.inlineConstantVars = true;
-    test(options, code, "function foo() {} var x = 3; foo(x); foo(4);");
+    test(options, code, "function foo() {} var x = 3; x = 5; foo(x); foo(4);");
   }
 
   public void testMinimizeExits() {


### PR DESCRIPTION
This is going to make both type-checking and inlining a lot better. But it will probably be hard to land. If it's too hard to land, it might make sense to separate out InferConsts used in type-checking so that we can turn it on separately.
