### PR TITLE
Ensure any output_wrapper flags contain a valid marker

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -728,6 +728,14 @@ public class CommandLineRunner extends
       flags.closureEntryPoint = Lists.newArrayList(
           ProcessCommonJSModules.toModuleName(flags.commonJsEntryModule));
     }
+    
+    if (!(flags.outputWrapper == null ||
+        flags.outputWrapper.contains(CommandLineRunner.OUTPUT_MARKER)))
+    {
+      err.println("ERROR - invalid output_wrapper specified. Missing '" +
+          CommandLineRunner.OUTPUT_MARKER + "'.");
+      isConfigValid = false;
+    }
 
     if (!isConfigValid || flags.displayHelp) {
       isConfigValid = false;

--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -330,6 +330,9 @@ public final class CompileTask
             int suffixStart = pos + CommandLineRunner.OUTPUT_MARKER.length();
             String suffix = this.outputWrapper.substring(suffixStart);
             source.append(suffix);
+          } else {
+            throw new BuildException("Invalid output_wrapper specified. " +
+                "Missing '" + CommandLineRunner.OUTPUT_MARKER + "'.");
           }
         }
 

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1217,6 +1217,16 @@ public class CommandLineRunnerTest extends TestCase {
     args.add("--js_output_file=" + getFilename(0));
     test("", AbstractCommandLineRunner.OUTPUT_SAME_AS_INPUT_ERROR);
   }
+  
+  public void testOutputWrapperFlag() {
+    // if the output wrapper flag is specified without a valid output marker,
+    // ensure that the compiler displays an error and exits.
+    // See github issue 123
+    args.add("--output_wrapper=output");
+    assertFalse(
+        createCommandLineRunner(
+            new String[] {"function f() {}"}).shouldRunCompiler());
+  }
 
   /* Helper functions */
 


### PR DESCRIPTION
Fixes #123. Halt compilation if an output_wrapper flag is specified without a valid output marker.
