### PR TITLE
Fix typo in Google Maps API externs

### DIFF
--- a/contrib/externs/maps/google_maps_api_v3.js
+++ b/contrib/externs/maps/google_maps_api_v3.js
@@ -1679,7 +1679,7 @@ google.maps.KmlLayer.prototype.setUrl = function(url) {};
  * @param {number} zIndex
  * @return {undefined}
  */
-google.maps.KmlLayer.prototype.setZIndex = function(The) {};
+google.maps.KmlLayer.prototype.setZIndex = function(zIndex) {};
 
 /**
  * @constructor


### PR DESCRIPTION
This PR fixes a trivial typo in the Google Maps API v3 externs. This avoids the warning:

```
closure-compiler/contrib/externs/maps/google_maps_api_v3.js:1682: WARNING - parameter zIndex does not appear in google.maps.KmlLayer.prototype.setZIndex's parameter list
google.maps.KmlLayer.prototype.setZIndex = function(The) {};
                                           ^
```
