### PR TITLE
only rewrite ambiguous functions if the warnings about them are on. For ...

### DIFF
--- a/src/com/google/javascript/jscomp/Normalize.java
+++ b/src/com/google/javascript/jscomp/Normalize.java
@@ -454,10 +454,17 @@ class Normalize implements CompilerPass {
     /**
      * Rewrite named unhoisted functions declarations to a known
      * consistent behavior so we don't to different logic paths for the same
-     * code. From:
+     * code.
+     *
+     * From:
      *    function f() {}
      * to:
      *    var f = function () {};
+     * and move it to the top of the block. This actually breaks
+     * semantics, but the semantics are also not well-defined
+     * cross-browser.
+     *
+     * @see https://github.com/google/closure-compiler/pull/429
      */
     private void normalizeFunctionDeclaration(Node n) {
       Preconditions.checkState(n.isFunction());
@@ -494,7 +501,8 @@ class Normalize implements CompilerPass {
 
       // Move the function
       Node parent = n.getParent();
-      parent.replaceChild(n, var);
+      parent.removeChild(n);
+      parent.addChildToFront(var);
       fnNameNode.addChildToFront(n);
 
       reportCodeChange("Function declaration");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -584,6 +584,18 @@ public class CommandLineRunnerTest extends TestCase {
             new String[] {"function f() {}"}).shouldRunCompiler());
   }
 
+  public void testHoistedFunction1() {
+    args.add("--jscomp_off=es5Strict");
+    args.add("-W=VERBOSE");
+    test("if (true) { f(); function f() {} }",
+         VariableReferenceCheck.UNDECLARED_REFERENCE);
+  }
+
+  public void testHoistedFunction2() {
+    test("if (window) { f(); function f() {} }",
+         "if (window) { var f = function() {}; f(); }");
+  }
+
   public void testExternsLifting1() throws Exception{
     String code = "/** @externs */ function f() {}";
     test(new String[] {code},

--- a/test/com/google/javascript/jscomp/NormalizeTest.java
+++ b/test/com/google/javascript/jscomp/NormalizeTest.java
@@ -215,6 +215,8 @@ public class NormalizeTest extends CompilerTestCase {
     testSame("switch (function g() {}) {}");
     test("switch (1) { case 1: function g() {}}",
          "switch (1) { case 1: var g = function () {}}");
+    test("if (true) {function g() {} function h() {}}",
+         "if (true) {var h = function() {}; var g = function () {}}");
 
 
     testSameInFunction("function f() {}");


### PR DESCRIPTION
...#428
