### PR TITLE
added let and const to for-loop code generation (+ test)

### DIFF
--- a/src/com/google/javascript/jscomp/CodeGenerator.java
+++ b/src/com/google/javascript/jscomp/CodeGenerator.java
@@ -591,7 +591,7 @@ class CodeGenerator {
           add("for");
           cc.maybeInsertSpace();
           add("(");
-          if (first.isVar()) {
+          if (first.isVar() || first.isLet() || first.isConst()) {
             add(first, Context.IN_FOR_INIT_CLAUSE);
           } else {
             addExpr(first, 0, Context.IN_FOR_INIT_CLAUSE);

--- a/test/com/google/javascript/jscomp/CodePrinterTest.java
+++ b/test/com/google/javascript/jscomp/CodePrinterTest.java
@@ -562,6 +562,22 @@ public class CodePrinterTest extends TestCase {
     assertPrintSame("for(var a of b)c");
   }
 
+  public void testLetFor() {
+    languageMode = LanguageMode.ECMASCRIPT6;
+
+    assertPrintSame("for(let a=0;a<5;a++)b");
+    assertPrintSame("for(let a in b)c");
+    assertPrintSame("for(let a of b)c");
+  }
+  
+  public void testConstFor() {
+    languageMode = LanguageMode.ECMASCRIPT6;
+
+    assertPrintSame("for(const a=5;b<a;b++)c");
+    assertPrintSame("for(const a in b)c");
+    assertPrintSame("for(const a of b)c");
+  }
+
   public void testLiteralProperty() {
     assertPrint("(64).toString()", "(64).toString()");
   }


### PR DESCRIPTION
Fixes issue #451

I've also added the "const" keyword for the code generation.
Yet no browser is able to use it for the "for-in" and "for-of" loops, but the es6 draft allows it at this place.

Also added the appropriate tests ...
