### PR TITLE
Reinstate command line flags for variable and property output maps

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1227,7 +1227,12 @@ abstract class AbstractCommandLineRunner<A extends Compiler,
             outputFileName.substring(0, outputFileName.length() - 3);
       }
 
-      basePath = file.getParent() + File.separatorChar + outputFileName;
+      String fileParent = file.getParent();
+      if (fileParent == null) {
+    	basePath = outputFileName;
+      } else {
+    	basePath = file.getParent() + File.separatorChar + outputFileName;
+      }
     }
 
     return basePath;
@@ -1248,8 +1253,8 @@ abstract class AbstractCommandLineRunner<A extends Compiler,
     if (config.createNameMapFiles) {
       String basePath = getMapPath(config.jsOutputFile);
 
-      propertyMapOutputPath = basePath + "_props_map.out";
-      variableMapOutputPath = basePath + "_vars_map.out";
+      propertyMapOutputPath = basePath + "_props_renaming_report.out";
+      variableMapOutputPath = basePath + "_vars_renaming_report.out";
       functionInformationMapOutputPath = basePath + "_functions_map.out";
     }
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -189,6 +189,25 @@ public class CommandLineRunner extends
         + "modules.")
     private List<String> module = new ArrayList<>();
 
+    @Option(name = "--variable_renaming_report",
+        usage = "File where the serialized version of the variable "
+        + "renaming map produced should be saved")
+    private String variableMapOutputFile = "";
+
+    @Option(name = "--create_renaming_reports",
+        handler = BooleanOptionHandler.class,
+        usage = "If true, variable renaming and property renaming report "
+        + "files will be produced as {binary name}_vars_renaming_report.out "
+        + "and {binary name}_props_renaming_report.out. Note that this flag "
+        + "cannot be used in conjunction with either variable_renaming_report "
+        + "or property_renaming_report")
+    private boolean createNameMapFiles = false;
+
+    @Option(name = "--property_renaming_report",
+        usage = "File where the serialized version of the property "
+        + "renaming map produced should be saved")
+    private String propertyMapOutputFile = "";
+
     @Option(name = "--third_party",
         handler = BooleanOptionHandler.class,
         usage = "Check source validity but do not enforce Closure style "
@@ -919,6 +938,9 @@ public class CommandLineRunner extends
           .setJs(jsFiles)
           .setJsOutputFile(flags.jsOutputFile)
           .setModule(flags.module)
+          .setVariableMapOutputFile(flags.variableMapOutputFile)
+          .setCreateNameMapFiles(flags.createNameMapFiles)
+          .setPropertyMapOutputFile(flags.propertyMapOutputFile)
           .setCodingConvention(conv)
           .setSummaryDetailLevel(flags.summaryDetailLevel)
           .setOutputWrapper(flags.outputWrapper)


### PR DESCRIPTION
Fixes #433

Based on discussion at today's meeting, this reinstates the output maps for property and variable renaming, but renames the options to indicate that they are only a report. The input map flags were not re-added but still exist as options for a custom build or as part of the Java API.
