### PR TITLE
Add support for Object.defineProperty

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -240,6 +240,9 @@ public class DefaultPassConfig extends PassConfig {
       checks.add(angularPass);
     }
 
+    // This pass should be before any check for properties, types and this
+    checks.add(objectDefinePropertyPreprocess);
+
     checks.add(checkSideEffects);
 
     if (options.checkSuspiciousCode ||
@@ -1167,6 +1170,15 @@ public class DefaultPassConfig extends PassConfig {
           cssNames = newCssNames;
         }
       };
+    }
+  };
+
+  /** Pre-process Object.defineProperty */
+  final PassFactory objectDefinePropertyPreprocess =
+      new PassFactory("ObjectDefinePropertyPreprocess", true) {
+    @Override
+    protected CompilerPass create(AbstractCompiler compiler) {
+      return new ObjectDefinePropertyPreprocess(compiler);
     }
   };
 

--- a/src/com/google/javascript/jscomp/ObjectDefinePropertyPreprocess.java
+++ b/src/com/google/javascript/jscomp/ObjectDefinePropertyPreprocess.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import com.google.common.base.Preconditions;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.rhino.IR;
+import com.google.javascript.rhino.JSDocInfo;
+import com.google.javascript.rhino.JSDocInfoBuilder;
+import com.google.javascript.rhino.JSTypeExpression;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.Token;
+
+/**
+ * Rewrites <code>Object.defineProperty(foo, 'bar', {});</code> to
+ * <code>/** @expose * /foo.bar; Object.defineProperty...</code>
+ *
+ * These phase is for Object.defineProperty and will also annotate the functions
+ * presented into the ObjectLit for "this" object when the defineProperty object
+ * is prototype.
+ */
+public class ObjectDefinePropertyPreprocess implements CompilerPass {
+  static final String OBJECT_DEFINE_PROPERTY =
+      "Object.defineProperty";
+
+  public static final DiagnosticType DYNAMIC_DEFINE_PROPERTY_NAME_WARNING =
+    DiagnosticType.warning(
+        "DYNAMIC_DEFINE_PROPERTY_NAME_WARNING",
+        "The use of dynamic name for Object.defineProperty is not supported");
+
+  private final AbstractCompiler compiler;
+
+  ObjectDefinePropertyPreprocess(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    NodeTraversal.traverse(compiler, root, new Callback());
+  }
+
+  private class Callback extends AbstractPostOrderCallback {
+    @Override
+    public void visit(NodeTraversal t, Node n, Node parent) {
+      if (n.isCall() &&
+          n.getFirstChild().matchesQualifiedName(OBJECT_DEFINE_PROPERTY)) {
+        annotateSetterGetters(n, parent);
+      }
+    }
+
+    /**
+     * Mark creation of setter/getter functions added to object using
+     * Object.defineProperty(object, 'name', setter/getter);
+     */
+    private void annotateSetterGetters(Node n, Node parent) {
+      Preconditions.checkState(
+          n.getFirstChild().matchesQualifiedName("Object.defineProperty"));
+
+      Node propertyName = n.getChildAtIndex(2);
+      Node obj = n.getChildAtIndex(1);
+
+      if (!propertyName.isString()) {
+        /* Cannot handle non literal strings as properties */
+        compiler.report(JSError.make(propertyName,
+            DYNAMIC_DEFINE_PROPERTY_NAME_WARNING));
+        return;
+      }
+
+      String objName = obj.getQualifiedName();
+
+      /* create a JSDocInfo for the property */
+      JSDocInfoBuilder infoBuilder;
+      JSDocInfo propInfo = NodeUtil.getBestJSDocInfo(n);
+      if (propInfo == null) {
+        infoBuilder = new JSDocInfoBuilder(false);
+      } else {
+        infoBuilder = JSDocInfoBuilder.copyFrom(propInfo);
+      }
+      infoBuilder.recordExpose();
+      propInfo = infoBuilder.build(n);
+
+      /* add the property to the AST, so the JSDoc info can be attached */
+      String propName = objName + "." + propertyName.getString();
+      Node namedProperty = NodeUtil.newQualifiedNameNodeDeclaration(
+          compiler.getCodingConvention(), propName, null, propInfo);
+
+      NodeUtil.setDebugInformation(namedProperty, n, propName);
+      namedProperty.copyInformationFrom(n);
+      parent.getParent().addChildBefore(namedProperty, parent);
+      compiler.reportCodeChange();
+
+      if (objName.endsWith(".prototype")) {
+        /* this is a prototype - annotate "this" */
+        Node descriptor = n.getChildAtIndex(3);
+        Node classNode = NodeUtil.getPrototypeClassName(obj);
+        JSTypeExpression type = new JSTypeExpression(
+            new Node(Token.BANG, IR.string(classNode.getQualifiedName())),
+            classNode.getSourceFileName());
+        for (int i = 0; i < descriptor.getChildCount(); i++) {
+          Node child = descriptor.getChildAtIndex(i);
+          /* if the child is [sg]et: function() mark @this */
+          if (child != null && child.getFirstChild() != null &&
+              child.getFirstChild().isFunction()) {
+            markThisFunction(child.getFirstChild(), type);
+          }
+        }
+      }
+    }
+
+    /**
+     * Mark the "@this" in functions in defineProperty
+     *
+     * @param func - the node of the function
+     * @param type - the type of "this"
+     */
+    private void markThisFunction(Node func, JSTypeExpression type) {
+      Preconditions.checkState(func.isFunction());
+
+      JSDocInfoBuilder infoBuilder;
+      JSDocInfo funcInfo;
+      funcInfo = NodeUtil.getBestJSDocInfo(func);
+      if (funcInfo == null) {
+        infoBuilder = new JSDocInfoBuilder(false);
+      } else {
+        infoBuilder = JSDocInfoBuilder.copyFrom(funcInfo);
+      }
+      infoBuilder.recordThisType(type);
+
+      funcInfo = infoBuilder.build(func);
+      func.setJSDocInfo(funcInfo);
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/ObjectDefinePropertyPreprocessTest.java
+++ b/test/com/google/javascript/jscomp/ObjectDefinePropertyPreprocessTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/**
+ * Tests for {@link ObjectDefinePropertyPreprocess}
+ *
+ */
+public class ObjectDefinePropertyPreprocessTest extends CompilerTestCase {
+  @Override
+  protected CompilerPass getProcessor(final Compiler compiler) {
+    return new ObjectDefinePropertyPreprocess(compiler);
+  }
+
+  @Override
+  protected int getNumRepetitions() {
+    return 1;
+  }
+
+  @Override
+  protected void setUp() {
+    super.allowExternsChanges(true);
+  }
+
+  public void testObjectDefinePropery() {
+    test("var foo = function() {};" +
+         "Object.defineProperty(foo, 'bar', {" +
+           "get: function() { return 1; }" +
+         "});",
+         "var foo = function() {};" +
+         "/** @expose */foo.bar;" +
+         "Object.defineProperty(foo, 'bar', {" +
+           "get: function() { return 1; }" +
+         "});");
+    test("/** @constructor */var foo = function() {};" +
+         "Object.defineProperty(foo.prototype, 'bar', {" +
+           "get: function() { return 1; }" +
+         "});",
+         "/** @constructor */var foo = function() {};" +
+         "/** @expose */foo.prototype.bar;" +
+         "Object.defineProperty(foo.prototype, 'bar', {" +
+           "get: /** @this {foo} */ function () { return 1; }" +
+         "});");
+  }
+}


### PR DESCRIPTION
There are many libraries which have extensive use of
Object.defineProperty. The problem with all of them is they cannot be
compiled in advanced mode without a heavy modifications, due to the
property rename issues.

So far there is already a support for setter and getters using the
"set foo() {}" and "get foo() {}", but having setters/getters defined
using Object.defineProperty was not yet supported.

Due to the fact that the property name is declared using a pure string
there is no way for the compiler to rename the string (without breaking
the assumption that string should not be renamed) so it is assumed that
every property access to the defined property should be treated as
exposed. While this have the negative impact of a bit increased output
size, this can be neglected by the fact that:
    1. There are currently no uses of ADVANCED_COMPILATION with
    setter/getters from Object.defineProperty which are not already
    using the array access notation (because it was simply not working
    until now).
    2. Benefit that more of the already available libraries can be used
    for compilation without any modifications.

Still there is no way for the compiler to handle non literal strings for
the property name. This limitation is even harder (impossible?) to
outcome when the property name is generated dynamically at run time.
