### PR TITLE
Infer JSDoc for STRING_KEY tokens

### DIFF
--- a/src/com/google/javascript/jscomp/InferJSDocInfo.java
+++ b/src/com/google/javascript/jscomp/InferJSDocInfo.java
@@ -147,6 +147,8 @@ class InferJSDocInfo extends AbstractPostOrderCallback
         break;
 
       case Token.STRING_KEY:
+      case Token.GETTER_DEF:
+      case Token.SETTER_DEF:
         docInfo = n.getJSDocInfo();
         if (docInfo == null) {
           return;

--- a/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
+++ b/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
@@ -489,6 +489,26 @@ public class CheckAccessControlsTest extends CompilerTestCase {
     }, null, BAD_PRIVATE_PROPERTY_ACCESS);
   }
 
+  public void testNoPrivateAccessForProperties11() {
+    test(new String[] {
+      "/** @constructor */ function Foo() {}" +
+      "Foo.prototype = {" +
+      "/** @private */ get bar_() { return 1; }" +
+      "}",
+      "var a = new Foo().bar_;"
+    }, null, BAD_PRIVATE_PROPERTY_ACCESS);
+  }
+
+  public void testNoPrivateAccessForProperties12() {
+    test(new String[] {
+      "/** @constructor */ function Foo() {}" +
+      "Foo.prototype = {" +
+      "/** @private */ set bar_(x) { this.barValue = x; }" +
+      "}",
+      "new Foo().bar_ = 1;"
+    }, null, BAD_PRIVATE_PROPERTY_ACCESS);
+  }
+
   public void testProtectedAccessForProperties1() {
     testSame(new String[] {
       "/** @constructor */ function Foo() {}" +


### PR DESCRIPTION
This PR allows the JSDoc inference for object properties defined in an object literal, like 

```
Foo.prototype = {
  /** @private */
  bar: function() {}
};
```
