### PR TITLE
Add comment explaining why Node.prototype.contains doesn't exist

### DIFF
--- a/externs/ie_dom.js
+++ b/externs/ie_dom.js
@@ -1007,6 +1007,10 @@ Element.prototype.classid;
 Element.prototype.componentFromPoint = function(iCoordX, iCoordY) {};
 
 /**
+ * This should really accept a Node, but IE only supports this
+ * with Elements.
+ * @see https://github.com/google/closure-compiler/issues/470 
+ *
  * @param {Element} el The element to check
  * @return {boolean} If the element is contained within this one.
  * @see http://msdn.microsoft.com/en-us/library/ms536377(VS.85).aspx


### PR DESCRIPTION
Clarifies why we can't fix #470.
