### PR TITLE
Add 'parallel-test' profile to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,4 +176,21 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>parallel-test</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <forkCount>1C</forkCount>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Running `mvn test -P parallel-test` can cut down the test times considerably, at the cost of potential flakiness.
