### PR TITLE
Add missing type information for Promise.all and Promise.race

### DIFF
--- a/externs/html5.js
+++ b/externs/html5.js
@@ -3386,14 +3386,16 @@ Promise.reject = function(opt_error) {};
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
- * param {!Array}
+ * @param {!Array}
+ * @return {!Promise}
  */
 Promise.all = function(iterable) {};
 
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
- * param {!Array}
+ * @param {!Array}
+ * @return {!Promise}
  */
 Promise.race = function(iterable) {};
 


### PR DESCRIPTION
`Promise.all` and `Promise.race` have broken type information. This patch fixes it by adding the missing @ character to the `param` annotation and adding a '@return` annotation.
