### PR TITLE
Fix bugs with parsing exponential literals

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/NewIRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/NewIRFactory.java
@@ -2223,6 +2223,8 @@ class NewIRFactory {
       // TODO(johnlenz): accept octal numbers in es3 etc.
       switch (value.charAt(1)) {
         case '.':
+        case 'e':
+        case 'E':
           return Double.valueOf(value);
         case 'b':
         case 'B': {

--- a/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
@@ -612,11 +612,20 @@ public class Scanner {
       skipHexDigits();
       return new LiteralToken(
           TokenType.NUMBER, getTokenString(beginToken), getTokenRange(beginToken));
+    case 'e':
+    case 'E':
+      return scanExponentOfNumericLiteral(beginToken);
     case '.':
       return scanFractionalNumericLiteral(beginToken);
     case '0': case '1': case '2': case '3': case '4':
     case '5': case '6': case '7': case '8': case '9':
-      return scanPostDigit(beginToken);
+      skipDecimalDigits();
+      if (peek('.')) {
+          nextChar();
+          skipDecimalDigits();
+      }
+      return new LiteralToken(
+          TokenType.NUMBER, getTokenString(beginToken), getTokenRange(beginToken));
     default:
       return new LiteralToken(
           TokenType.NUMBER, getTokenString(beginToken), getTokenRange(beginToken));

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -1391,6 +1391,25 @@ public class NewParserTest extends BaseJSTypeTestCase {
         "Hex digit expected");
   }
 
+  public void testExponentialLiterals() {
+    parse("0e0");
+    parse("0E0");
+    parse("0E1");
+    parse("1E0");
+    parse("1E-0");
+    parse("10E10");
+    parse("10E-10");
+    parse("1.0E1");
+    parseError("01E0",
+        "Semi-colon expected");
+    parseError("0E",
+        "Exponent part must contain at least one digit");
+    parseError("1E-",
+        "Exponent part must contain at least one digit");
+    parseError("1E1.1",
+        "Semi-colon expected");
+  }
+
   public void testBinaryLiterals() {
     mode = LanguageMode.ECMASCRIPT3;
     parseWarning("0b0001;",


### PR DESCRIPTION
Fixes https://github.com/google/closure-compiler/issues/503, in which `0E0` was treated as an invalid literal.

Also fixes the following case, which is illegal JS syntax, but throws an uncaught exception rather than printing a well formatted parsing error message.

``` javascript
var x = 01E0;
```

```
java.lang.IllegalStateException: unexpected: E
    at com.google.javascript.jscomp.parsing.NewIRFactory.octaldigit(NewIRFactory.java:2218)
    at com.google.javascript.jscomp.parsing.NewIRFactory.normalizeNumber(NewIRFactory.java:2187)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processNumberLiteral(NewIRFactory.java:1366)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processNumberLiteral(NewIRFactory.java:888)
    at com.google.javascript.jscomp.parsing.NewTypeSafeDispatcher.processLiteralExpression(NewTypeSafeDispatcher.java:156)
    at com.google.javascript.jscomp.parsing.NewTypeSafeDispatcher.process(NewTypeSafeDispatcher.java:238)
    at com.google.javascript.jscomp.parsing.NewIRFactory.justTransform(NewIRFactory.java:885)
    at com.google.javascript.jscomp.parsing.NewIRFactory.transform(NewIRFactory.java:651)
    at com.google.javascript.jscomp.parsing.NewIRFactory.access$300(NewIRFactory.java:107)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processVariableDeclaration(NewIRFactory.java:1759)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processVariableDeclaration(NewIRFactory.java:888)
    at com.google.javascript.jscomp.parsing.NewTypeSafeDispatcher.process(NewTypeSafeDispatcher.java:250)
    at com.google.javascript.jscomp.parsing.NewIRFactory.justTransform(NewIRFactory.java:885)
    at com.google.javascript.jscomp.parsing.NewIRFactory.transformNodeWithInlineJsDoc(NewIRFactory.java:686)
    at com.google.javascript.jscomp.parsing.NewIRFactory.access$1800(NewIRFactory.java:107)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processVariableDeclarationList(NewIRFactory.java:1750)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processVariableDeclarationList(NewIRFactory.java:888)
    at com.google.javascript.jscomp.parsing.NewTypeSafeDispatcher.process(NewTypeSafeDispatcher.java:248)
    at com.google.javascript.jscomp.parsing.NewIRFactory.justTransform(NewIRFactory.java:885)
    at com.google.javascript.jscomp.parsing.NewIRFactory.access$3100(NewIRFactory.java:107)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processVariableStatement(NewIRFactory.java:1714)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processVariableStatement(NewIRFactory.java:888)
    at com.google.javascript.jscomp.parsing.NewTypeSafeDispatcher.process(NewTypeSafeDispatcher.java:246)
    at com.google.javascript.jscomp.parsing.NewIRFactory.justTransform(NewIRFactory.java:885)
    at com.google.javascript.jscomp.parsing.NewIRFactory.transform(NewIRFactory.java:651)
    at com.google.javascript.jscomp.parsing.NewIRFactory.access$300(NewIRFactory.java:107)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processAstRoot(NewIRFactory.java:930)
    at com.google.javascript.jscomp.parsing.NewIRFactory$TransformDispatcher.processAstRoot(NewIRFactory.java:888)
    at com.google.javascript.jscomp.parsing.NewTypeSafeDispatcher.process(NewTypeSafeDispatcher.java:236)
    at com.google.javascript.jscomp.parsing.NewIRFactory.justTransform(NewIRFactory.java:885)
    at com.google.javascript.jscomp.parsing.NewIRFactory.transformTree(NewIRFactory.java:272)
    at com.google.javascript.jscomp.parsing.ParserRunner.parseEs6(ParserRunner.java:286)
    at com.google.javascript.jscomp.parsing.ParserRunner.parse(ParserRunner.java:130)
    at com.google.javascript.jscomp.JsAst.parse(JsAst.java:85)
    at com.google.javascript.jscomp.JsAst.getAstRoot(JsAst.java:51)
    at com.google.javascript.jscomp.CompilerInput.getAstRoot(CompilerInput.java:118)
    at com.google.javascript.jscomp.Compiler.hoistExterns(Compiler.java:1453)
    at com.google.javascript.jscomp.Compiler.parseInputs(Compiler.java:1355)
    at com.google.javascript.jscomp.Compiler.parse(Compiler.java:768)
    at com.google.javascript.jscomp.Compiler.compileInternal(Compiler.java:723)
    at com.google.javascript.jscomp.Compiler.access$000(Compiler.java:94)
    at com.google.javascript.jscomp.Compiler$3.call(Compiler.java:635)
    at com.google.javascript.jscomp.Compiler$3.call(Compiler.java:632)
    at com.google.javascript.jscomp.Compiler.runInCompilerThread(Compiler.java:704)
    at com.google.javascript.jscomp.Compiler.compile(Compiler.java:632)
    at com.google.javascript.jscomp.Compiler.compile(Compiler.java:602)
```
