### PR TITLE
Non-standard `--version` behavior

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -441,7 +441,7 @@ public class CommandLineRunner extends
 
     @Option(name = "--version",
         handler = BooleanOptionHandler.class,
-        usage = "Prints the compiler version to stderr.")
+        usage = "Prints the compiler version to stdout.")
     private boolean version = false;
 
     @Option(name = "--translations_file",
@@ -765,12 +765,12 @@ public class CommandLineRunner extends
    */
   protected CommandLineRunner(String[] args) {
     super();
-    initConfigFromFlags(args, System.err);
+    initConfigFromFlags(args, System.out, System.err);
   }
 
   protected CommandLineRunner(String[] args, PrintStream out, PrintStream err) {
     super(out, err);
-    initConfigFromFlags(args, err);
+    initConfigFromFlags(args, out, err);
   }
 
   /**
@@ -892,7 +892,7 @@ public class CommandLineRunner extends
     }
   }
 
-  private void initConfigFromFlags(String[] args, PrintStream err) {
+  private void initConfigFromFlags(String[] args, PrintStream out, PrintStream err) {
 
     List<String> processedArgs = processArgs(args);
 
@@ -918,11 +918,11 @@ public class CommandLineRunner extends
     }
 
     if (flags.version) {
-      err.println(
+      out.println(
           "Closure Compiler (http://github.com/google/closure-compiler)\n" +
           "Version: " + Compiler.getReleaseVersion() + "\n" +
           "Built on: " + Compiler.getReleaseDate());
-      err.flush();
+      out.flush();
     }
 
     if (flags.processCommonJsModules) {
@@ -958,6 +958,8 @@ public class CommandLineRunner extends
     if (!isConfigValid || flags.displayHelp) {
       isConfigValid = false;
       flags.printUsage(err);
+    } else if (flags.version) {
+      isConfigValid = false;
     } else {
       CodingConvention conv;
       if (flags.thirdParty) {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1022,20 +1022,24 @@ public class CommandLineRunnerTest extends TestCase {
 
   public void testVersionFlag() {
     args.add("--version");
-    testSame("");
+    assertFalse(
+        createCommandLineRunner(
+            new String[] {"function f() {}"}).shouldRunCompiler());
     assertEquals(
         0,
-        new String(errReader.toByteArray(), UTF_8).indexOf(
+        new String(outReader.toByteArray(), UTF_8).indexOf(
             "Closure Compiler (http://github.com/google/closure-compiler)\n" +
             "Version: "));
   }
 
   public void testVersionFlag2() {
     lastArg = "--version";
-    testSame("");
+    assertFalse(
+        createCommandLineRunner(
+            new String[] {"function f() {}"}).shouldRunCompiler());
     assertEquals(
         0,
-        new String(errReader.toByteArray(), UTF_8).indexOf(
+        new String(outReader.toByteArray(), UTF_8).indexOf(
             "Closure Compiler (http://github.com/google/closure-compiler)\n" +
             "Version: "));
   }


### PR DESCRIPTION
`--version` is non-standard because it does not cause the compiler to exit.

Just about every other program terminates when given a similar command line option.

```
curl --version
gcc --version
google-chrome --version
ls --version
java -version
node --version
```

My opinion is also that it should also print to stdout rather than stderr, though `java` doesn't do that.
