### PR TITLE
Exception thrown during RenameLabels for bad labels

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/NewIRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/NewIRFactory.java
@@ -91,6 +91,9 @@ class NewIRFactory {
   static final String DUPLICATE_PARAMETER =
       "Duplicate parameter name \"%s\"";
 
+  static final String DUPLICATE_LABEL =
+      "Duplicate label \"%s\"";
+
   static final String UNLABELED_BREAK =
       "unlabelled break must be inside loop or switch";
 
@@ -244,6 +247,7 @@ class NewIRFactory {
     validateTypeAnnotations(n);
     validateParameters(n);
     validateBreakContinue(n);
+    validateLabel(n);
   }
 
   private void validateBreakContinue(Node n) {
@@ -410,6 +414,22 @@ class NewIRFactory {
         errorReporter.warning(MISPLACED_TYPE_ANNOTATION,
             sourceName,
             n.getLineno(), n.getCharno());
+      }
+    }
+  }
+
+  private void validateLabel(Node n) {
+    if (n.isLabel()) {
+      Node labelName = n.getFirstChild();
+      for (Node parent = n.getParent();
+           parent != null && !parent.isFunction(); parent = parent.getParent()) {
+        if (parent.isLabel() && labelsMatch(parent, labelName)) {
+          errorReporter.error(
+              String.format(DUPLICATE_LABEL, labelName.getString()),
+              sourceName,
+              n.getLineno(), n.getCharno());
+          break;
+        }
       }
     }
   }

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -129,6 +129,38 @@ public class NewParserTest extends BaseJSTypeTestCase {
         UNDEFINED_LABEL + " \"a\"");
   }
 
+  public void testLabel1() {
+    parse("foo:bar");
+  }
+
+  public void testLabel2() {
+    parse("{foo:bar}");
+  }
+
+  public void testLabel3() {
+    parse("foo:bar:baz");
+  }
+
+  public void testDuplicateLabelWithoutBraces() {
+    parseError("foo:foo:bar", "Duplicate label \"foo\"");
+  }
+
+  public void testDuplicateLabelWithBraces() {
+    parseError("foo:{bar;foo:baz}", "Duplicate label \"foo\"");
+  }
+
+  public void testDuplicateLabelWithFor() {
+    parseError("foo:for(;;){foo:bar}", "Duplicate label \"foo\"");
+  }
+
+  public void testNonDuplicateLabelSiblings() {
+    parse("foo:1;foo:2");
+  }
+
+  public void testNonDuplicateLabelCrossFunction() {
+    parse("foo:(function(){foo:2})");
+  }
+
   public void testLinenoCharnoAssign1() throws Exception {
     Node assign = parse("a = b").getFirstChild().getFirstChild();
 


### PR DESCRIPTION
**Good**

``` javascript
{foo:{foo2:"bar"}}
```

```
WARNING - Suspicious code. Is there a missing '+' on the previous line?
```

**Bad**

``` javascript
{foo:{foo:"bar"}}
```

```
WARNING - Suspicious code. Is there a missing '+' on the previous line?

0 error(s), 1 warning(s)
java.lang.RuntimeException: INTERNAL COMPILER ERROR.
Please report this problem.
null
  Node(LABEL): stdin:1:6
{foo:{foo:"bar"}}
  Parent(BLOCK): stdin:1:5
{foo:{foo:"bar"}}

    at com.google.common.base.Preconditions.checkState(Preconditions.java:161)
    at com.google.javascript.jscomp.RenameLabels$ProcessLabels.shouldTraverse(RenameLabels.java:158)
    at com.google.javascript.jscomp.NodeTraversal.traverseBranch(NodeTraversal.java:564)
    at com.google.javascript.jscomp.NodeTraversal.traverseBranch(NodeTraversal.java:578)
    at com.google.javascript.jscomp.NodeTraversal.traverseBranch(NodeTraversal.java:578)
    at com.google.javascript.jscomp.NodeTraversal.traverseBranch(NodeTraversal.java:578)
    at com.google.javascript.jscomp.NodeTraversal.traverseBranch(NodeTraversal.java:578)
    at com.google.javascript.jscomp.NodeTraversal.traverse(NodeTraversal.java:289)
    at com.google.javascript.jscomp.NodeTraversal.traverse(NodeTraversal.java:535)
    at com.google.javascript.jscomp.RenameLabels.process(RenameLabels.java:271)
    at com.google.javascript.jscomp.PhaseOptimizer$NamedPass.process(PhaseOptimizer.java:285)
    at com.google.javascript.jscomp.PhaseOptimizer.process(PhaseOptimizer.java:217)
    at com.google.javascript.jscomp.Compiler.optimize(Compiler.java:1941)
    at com.google.javascript.jscomp.Compiler.compileInternal(Compiler.java:752)
    at com.google.javascript.jscomp.Compiler.access$000(Compiler.java:92)
    at com.google.javascript.jscomp.Compiler$3.call(Compiler.java:638)
    at com.google.javascript.jscomp.Compiler$3.call(Compiler.java:635)
    at com.google.javascript.jscomp.Compiler$4.call(Compiler.java:682)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:744)
Caused by: java.lang.IllegalStateException
    ... 22 more
```

I haven't yet been able to produce any sensical code with this error.
