### PR TITLE
Substitute number equivalents when comparing to booleans

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java
+++ b/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java
@@ -486,6 +486,19 @@ class PeepholeSubstituteAlternateSyntax
 
   private Node reduceTrueFalse(Node n) {
     if (late) {
+      switch (n.getParent().getType()) {
+        case Token.EQ:
+        case Token.GT:
+        case Token.GE:
+        case Token.LE:
+        case Token.LT:
+        case Token.NE:
+          Node number = IR.number(n.isTrue() ? 1 : 0);
+          n.getParent().replaceChild(n, number);
+          reportCodeChange();
+          return number;
+      }
+
       Node not = IR.not(IR.number(n.isTrue() ? 0 : 1));
       not.copyInformationFromForTree(n);
       n.getParent().replaceChild(n, not);

--- a/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java
@@ -273,6 +273,16 @@ public class PeepholeSubstituteAlternateSyntaxTest extends CompilerTestCase {
     fold("x = false", "x = !1");
   }
 
+  public void testFoldTrueFalseComparison() {
+    fold("x == true", "x == 1");
+    fold("x == false", "x == 0");
+    fold("x != true", "x != 1");
+    fold("x < true", "x < 1");
+    fold("x <= true", "x <= 1");
+    fold("x > true", "x > 1");
+    fold("x >= true", "x >= 1");
+  }
+
   public void testFoldReturnResult() {
     foldSame("function f(){return !1;}");
     foldSame("function f(){return null;}");


### PR DESCRIPTION
Resolves https://github.com/google/closure-compiler/issues/369.

I included `<`, `<=`, `>`, `>=` in addition to the `==` and `!=` operators requested originally.
