### PR TITLE
Mark document.createElement as having no side effects.

### DIFF
--- a/externs/w3c_dom1.js
+++ b/externs/w3c_dom1.js
@@ -384,12 +384,10 @@ Document.prototype.createCDATASection = function(data) {};
 Document.prototype.createDocumentFragment = function() {};
 
 /**
- * Create a DOM element. Surprisingly, this has side-effects on IE
- * (creating and element with a custom tag boots up a sub-system that
- * handles custom tags).
  * @param {string} tagName
  * @return {!Element}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createElement
+ * @nosideeffects
  */
 Document.prototype.createElement = function(tagName) {};
 


### PR DESCRIPTION
Relies on changes in ae4e25a77d21031051bfad4391d736712af7b949 to preserve HTML5 SHIM code.

If ae4e25a77d21031051bfad4391d736712af7b949  is rolled back, this commit will need to be as well. See discussion at https://groups.google.com/forum/#%21searchin/closure-compiler-discuss/createElements/closure-compiler-discuss/JzeqEHmEQAQ/vCeT40K1Lm0J
