### PR TITLE
Expose renamePrefixNamespace with --rename_prefix_namespace paramter

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2117,6 +2117,13 @@ abstract class AbstractCommandLineRunner<A extends Compiler,
       this.useNewTypeInference = useNewTypeInference;
       return this;
     }
+
+    private String renamePrefixNamespace = null;
+
+    CommandLineConfig setRenamePrefixNamespace(String renamePrefixNamespace) {
+      this.renamePrefixNamespace = renamePrefixNamespace;
+      return this;
+    }
   }
 
   /**

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -553,6 +553,11 @@ public class CommandLineRunner extends
         usage = "A list of JS Conformance configurations in text protocol buffer format.")
     private List<String> conformanceConfigs = new ArrayList<>();
 
+    @Option(name = "--rename_prefix_namespace",
+        usage = "Specifies the name of an object that will be used to store all "
+        + "non-extern globals")
+    private String renamePrefixNamespace = null;
+
     @Argument
     private List<String> arguments = new ArrayList<>();
 
@@ -1040,7 +1045,8 @@ public class CommandLineRunner extends
           .setWarningsWhitelistFile(flags.warningsWhitelistFile)
           .setAngularPass(flags.angularPass)
           .setTracerMode(flags.tracerMode)
-          .setNewTypeInference(flags.useNewTypeInference);
+          .setNewTypeInference(flags.useNewTypeInference)
+          .setRenamePrefixNamespace(flags.renamePrefixNamespace);
     }
     errorStream = null;
   }
@@ -1089,6 +1095,8 @@ public class CommandLineRunner extends
         flags.processJqueryPrimitives;
 
     options.angularPass = flags.angularPass;
+
+    options.renamePrefixNamespace = flags.renamePrefixNamespace;
 
     if (!flags.translationsFile.isEmpty()) {
       try {


### PR DESCRIPTION
This should partially address #242.
This option, when compiling multiple modules and in conjunction with --module_wrapper, can successfully prevent global namespace pollution.
