### PR TITLE
Source mappings without line separator `;` fixed.

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
@@ -360,6 +360,17 @@ public class SourceMapConsumerV3 implements SourceMapConsumer,
           tryConsumeToken(',');
         }
       }
+      // Some source map generator (e.g.UglifyJS) generates lines without line separator ;. 
+      // If so, then add the rest of the content in entries as a single line
+      if (!entries.isEmpty()) {
+        ArrayList<Entry> result;        
+        result = entries;
+        // A new array list for the next line.
+        entries = new ArrayList<>();
+        lines.add(result);
+        entries.clear();
+        line++;
+      }
     }
 
     /**


### PR DESCRIPTION
Some source map generator (e.g.UglifyJS) generates lines without line separator ;. Fixed this in SourceMapConsumerV3 by adding the rest of the entries in mappings as a single line
