### PR TITLE
Invalid ObjectLiteral shorthand by QuotedString

### DIFF
--- a/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
+++ b/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
@@ -58,6 +58,10 @@ public class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapCompile
       "CLASS_REASSIGNMENT",
       "Class names defined inside a function cannot be reassigned.");
 
+  static final DiagnosticType NO_PROPERTY_VALUE = DiagnosticType.error(
+      "NO_PROPERTY_VALUE",
+      "The property does not have a value.");
+
   // The name of the vars that capture 'this' and 'arguments'
   // for converting arrow functions.
   private static final String THIS_VAR = "$jscomp$this";
@@ -266,6 +270,10 @@ public class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapCompile
    */
   private void visitStringKey(Node n) {
     if (!n.hasChildren()) {
+      if (n.isQuotedString()) {
+        compiler.report(JSError.make(n, NO_PROPERTY_VALUE));
+        return;
+      }
       Node name = IR.name(n.getString());
       name.copyInformationFrom(n);
       n.addChildToBack(name);

--- a/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
@@ -70,6 +70,8 @@ public class Es6ToEs3ConverterTest extends CompilerTestCase {
 
   public void testObjectLiteralStringKeysWithNoValue() {
     test("var x = {a, b};", "var x = {a: a, b: b};");
+    test("var x = { 'a' };", null, Es6ToEs3Converter.NO_PROPERTY_VALUE);
+    test("var x = { 123 };", null, Es6ToEs3Converter.NO_PROPERTY_VALUE);
   }
 
   public void testClassGenerator() {


### PR DESCRIPTION
``` js
// test.js
var a = { '!@#$%' };
```

```
java -jar compiler.jar --language_in ECMASCRIPT6 --language_out
ECMASCRIPT3 ../test.js
```

``` js
// invalid syntax
var a={"!@#$%":!@#$%};
```

Only a identifier, can say shorthand for object literal.
