### PR TITLE
Invalid ObjectLiteral shorthand by non-identifier

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -68,5 +68,6 @@ sheets [ashimaarts.com]
 stenrs [gmail.com]
 timwintle [gmail.com] (Tim Wintle)
 terence.honles [gmail.com] (Terence Honles)
+tuchida (Uchida Taishi)
 victor.berchet [gmail.com]
 yonathan [gmail.com] (Yonathan Randolph)

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -1669,6 +1669,9 @@ public class Parser {
     SourcePosition start = getTreeStartLocation();
     Token name = eatObjectLiteralPropertyName();
     Token colon = eatOpt(TokenType.COLON);
+    if (colon == null && name.type != TokenType.IDENTIFIER) {
+      reportExpectedError(peekToken(), TokenType.COLON);
+    }
     ParseTree value = colon == null ? null : parseAssignmentExpression();
     return new PropertyNameAssignmentTree(getTreeLocation(start), name, value);
   }

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -942,6 +942,9 @@ public class NewParserTest extends BaseJSTypeTestCase {
     testExtendedObjectLiteral("var a = {b};");
     testExtendedObjectLiteral("var a = {b, c};");
     testExtendedObjectLiteral("var a = {b, c: d, e};");
+
+    parseError("var a = { '!@#$%' };", "':' expected");
+    parseError("var a = { 123 };", "':' expected");
   }
 
   private void testExtendedObjectLiteral(String js) {
@@ -1330,7 +1333,7 @@ public class NewParserTest extends BaseJSTypeTestCase {
 
   public void testGettersForbidden4() {
     parseError("var x = {\"a\" getter:function b() { return 3; }};",
-        "'}' expected");
+        "':' expected");
   }
 
   public void testGettersForbidden5() {


### PR DESCRIPTION
ref. https://github.com/google/closure-compiler/pull/585

Fixed in Parse.java

https://github.com/google/closure-compiler/pull/585#issuecomment-52665277

> (and have you signed the CLA?) :)

Not yet. What am I supposed to do?

https://github.com/google/closure-compiler/blob/master/CONTRIBUTORS
