### PR TITLE
Fix Ant warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -133,14 +133,18 @@
     <javac srcdir="${gen.dir}"
            destdir="${classes.dir}"
            excludes=".svn,.git"
-           debug="${javac.debug}">
+           debug="${javac.debug}"
+           includeantruntime="false">
       <classpath refid="srcclasspath.path" />
+      <compilerarg value="-Xlint:unchecked"/>
     </javac>
     <javac srcdir="${src.dir}"
            destdir="${classes.dir}"
            excludes=".svn,.git,**/webservice/**,**/testing/**"
-           debug="${javac.debug}">
+           debug="${javac.debug}"
+           includeantruntime="true">
       <classpath refid="srcclasspath.path" />
+      <compilerarg value="-Xlint:unchecked"/>
     </javac>
 
     <!-- Move Messages.properties where ScriptRuntime.java expects it. -->
@@ -193,14 +197,18 @@
     <javac srcdir="${src.dir}"
            destdir="${testClasses.dir}"
            excludes=".svn,.git"
-           debug="on">
+           debug="on"
+           includeantruntime="false">
       <classpath refid="allclasspath.path" />
+      <compilerarg value="-Xlint:unchecked"/>
     </javac>
     <javac srcdir="${test.dir}"
            destdir="${testClasses.dir}"
            excludes=".svn,.git"
-           debug="on">
+           debug="on"
+           includeantruntime="false">
       <classpath refid="allclasspath.path" />
+      <compilerarg value="-Xlint:unchecked"/>
     </javac>
   </target>
 

--- a/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Iterator;
 
 /**
  * Class for parsing version 3 of the SourceMap format, as produced by the
@@ -136,8 +137,9 @@ public class SourceMapConsumerV3 implements SourceMapConsumer,
         sourceRoot = sourceMapRoot.getString("sourceRoot");
       }
 
-      for (Object objkey : Lists.newArrayList(sourceMapRoot.keys())) {
-        String key = (String) objkey;
+      @SuppressWarnings("unchecked")
+      Iterator<String> keys = sourceMapRoot.keys();
+      for (String key : Lists.newArrayList(keys)) {
         if (key.startsWith("x_")) {
           extensions.put(key, sourceMapRoot.get(key));
         }

--- a/src/com/google/javascript/jscomp/lint/CheckNullableReturn.java
+++ b/src/com/google/javascript/jscomp/lint/CheckNullableReturn.java
@@ -92,7 +92,7 @@ public class CheckNullableReturn implements CompilerPass, NodeTraversal.Callback
   /**
    * @return True if the given ControlFlowGraph could return null.
    */
-  private static boolean canReturnNull(ControlFlowGraph graph) {
+  private static boolean canReturnNull(ControlFlowGraph<Node> graph) {
     DiGraph.DiGraphNode<Node, ControlFlowGraph.Branch> ir = graph.getImplicitReturn();
     for (DiGraph.DiGraphEdge<Node, ControlFlowGraph.Branch> inEdge : ir.getInEdges()) {
       DiGraph.DiGraphNode<Node, ControlFlowGraph.Branch> graphNode = inEdge.getSource();

--- a/src/com/google/javascript/jscomp/newtypes/NaivePersistentMap.java
+++ b/src/com/google/javascript/jscomp/newtypes/NaivePersistentMap.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 /** A naive persistent map that does too many copies */
 public class NaivePersistentMap<K, V> extends PersistentMap<K, V> {
-  private Map map;
+  private Map<K, V> map;
 
   private NaivePersistentMap(Map<K, V> m) {
     this.map = m;

--- a/src/com/google/javascript/jscomp/newtypes/PersistentMap.java
+++ b/src/com/google/javascript/jscomp/newtypes/PersistentMap.java
@@ -21,17 +21,19 @@ import java.util.AbstractMap;
 /** A persistent map with non-destructive additions and removals  */
 public abstract class PersistentMap<K, V> extends AbstractMap<K, V> {
 
+  private static final PersistentMap EMPTY = NaivePersistentMap.create();
+
   public abstract PersistentMap<K, V> with(K key, V value);
 
   public abstract PersistentMap<K, V> without(K key);
 
+  @SuppressWarnings("unchecked")
   public static <K, V> PersistentMap<K, V> create() {
-    return (PersistentMap<K, V>) EMPTY;
+    return EMPTY;
   }
 
   public static <K, V> PersistentMap<K, V> of(K key, V value) {
-    return (PersistentMap<K, V>) EMPTY.with(key, value);
+    return PersistentMap.<K, V>create().with(key, value);
   }
 
-  private static final PersistentMap EMPTY = NaivePersistentMap.create();
 }

--- a/src/com/google/javascript/jscomp/newtypes/PersistentSet.java
+++ b/src/com/google/javascript/jscomp/newtypes/PersistentSet.java
@@ -21,13 +21,15 @@ import java.util.AbstractSet;
 /** A persistent set with non-destructive additions and removals */
 public abstract class PersistentSet<K> extends AbstractSet<K> {
 
+  private static final PersistentSet EMPTY = NaivePersistentSet.create();
+
   public abstract PersistentSet<K> with(K key);
 
   public abstract PersistentSet<K> without(K key);
 
+  @SuppressWarnings("unchecked")
   public static <K> PersistentSet<K> create() {
-    return (PersistentSet<K>) EMPTY;
+    return EMPTY;
   }
 
-  private static final PersistentSet EMPTY = NaivePersistentSet.create();
 }


### PR DESCRIPTION
Ant complains about `includeantruntime` not being set.

```
[javac] build.xml:136: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
```

The Ant runtime was required for one javac, but not the rest.

Java complains unchecked operations.

```
[javac] Note: Some input files use unchecked or unsafe operations.
[javac] Note: Recompile with -Xlint:unchecked for details.
```

I added `-Xlint:unchecked` and then resolved all existing warnings.
