### PR TITLE
Externs cleanups

### DIFF
--- a/externs/w3c_dom2.js
+++ b/externs/w3c_dom2.js
@@ -228,7 +228,6 @@ function NodeFilter() {}
 /** @const {number} */ NodeFilter.SHOW_ENTITY_REFERENCE;
 /** @const {number} */ NodeFilter.SHOW_NOTATION;
 /** @const {number} */ NodeFilter.SHOW_PROCESSING_INSTRUCTION;
-/** @const {number} */ NodeFilter.SHOW_TEXT;
 
 /* Consants for acceptNode */
 /** @const {number} */ NodeFilter.FILTER_ACCEPT;


### PR DESCRIPTION
Remove duplicate `NodeFilter.SHOW_TEXT` in externs ( already defined in the same file (line 218))
