### PR TITLE
[Issue #450] Fixed the publishing of the jar to include the Main-Class entry needed for execution

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -104,6 +104,8 @@
       <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
+
+
   </dependencies>
 
   <build>
@@ -236,9 +238,36 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>com.google.javascript.jscomp.CommandLineRunner</mainClass>
+            </manifest>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>attached</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <archive>
+                <manifest>
+                  <mainClass>com.google.javascript.jscomp.CommandLineRunner</mainClass>
+                </manifest>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/pom-main.xml
+++ b/pom-main.xml
@@ -104,8 +104,6 @@
       <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
-
-
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -165,13 +165,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.4</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <mainClass>com.google.javascript.jscomp.CommandLineRunner</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.4</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>com.google.javascript.jscomp.CommandLineRunner</mainClass>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Added the configuration needed to fix the builds that are published to maven.  Currently, the MANIFEST.MF file does not contain a Main-Class entry needed for execution.  The commit below fixes that and adds the line to the manifest file.

**Verification Instructions**
* Perform a *mvn clean package* to generate a new version
* Un-jar the generated file
* Inspect META-INF/MANIFEST.MF to ensure that the file now contains a Main-Class entry.
* Ensure that the jar is executable

**Existing Issues**
https://github.com/google/closure-compiler/issues/450
https://github.com/google/closure-compiler/issues/227
