### PR TITLE
Include ant CompileTask in maven jar to fix issue 121

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -91,6 +91,14 @@
       <version>1.3.9</version>
     </dependency>
 
+    <!-- Ant is a provided scope as it is only needed to compile; ant will provide itself when using the jar -->
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <scope>provided</scope>
+      <version>1.9.4</version>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -186,7 +194,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>**/com/google/javascript/jscomp/ant/**</exclude>
             <exclude>**/testing/**</exclude>
             <exclude>**/webservice/**</exclude>
           </excludes>


### PR DESCRIPTION
Fixes issue #121 

To verify this fix, simply run mvn clean install, then use the produced jar in an ant build file to be able to run CompileTask.

```
<taskdef name="closure" classname="com.google.javascript.jscomp.ant.CompileTask" classpathref="/path/to/jar"/>
<closure languageIn="ECMASCRIPT5" compilationLevel="simple" debug="true" output="/path/to/file.min.js">
  <sources dir="/path/to">
    <file name="file.js"/>
  </sources>
</closure>
```

Ping @jpitz to review
