### PR TITLE
[Issue #624] Make the JsDoc in Block Comments warning able to be controlled by the setWarningLevels method

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -121,7 +121,8 @@ public class DiagnosticGroups {
   public static final DiagnosticGroup NON_STANDARD_JSDOC =
       DiagnosticGroups.registerGroup("nonStandardJsDocs",
           RhinoErrorReporter.BAD_JSDOC_ANNOTATION,
-          RhinoErrorReporter.INVALID_PARAM);
+          RhinoErrorReporter.INVALID_PARAM,
+          RhinoErrorReporter.JSDOC_IN_BLOCK_COMMENT);
 
   public static final DiagnosticGroup INVALID_CASTS =
       DiagnosticGroups.registerGroup("invalidCasts",

--- a/src/com/google/javascript/jscomp/RhinoErrorReporter.java
+++ b/src/com/google/javascript/jscomp/RhinoErrorReporter.java
@@ -54,6 +54,9 @@ class RhinoErrorReporter {
   static final DiagnosticType BAD_JSDOC_ANNOTATION =
       DiagnosticType.warning("JSC_BAD_JSDOC_ANNOTATION", "Parse error. {0}");
 
+  static final DiagnosticType JSDOC_IN_BLOCK_COMMENT =
+      DiagnosticType.warning("JSC_JSDOC_IN_BLOCK_COMMENT", "Parse error. {0}");
+
   static final DiagnosticType MISPLACED_TYPE_ANNOTATION =
       DiagnosticType.warning("JSC_MISPLACED_TYPE_ANNOTATION",
           "Type annotations are not allowed here. " +
@@ -113,6 +116,11 @@ class RhinoErrorReporter {
         .put(replacePlaceHolders(
             SimpleErrorReporter.getMessage0("msg.bad.jsdoc.tag")),
             BAD_JSDOC_ANNOTATION)
+
+        .put(Pattern.compile(
+            "^\\QNon-JSDoc comment has annotations. " +
+            "Did you mean to start it with '/**'?\\E"),
+            JSDOC_IN_BLOCK_COMMENT)
 
         // Unexpected @type annotations
         .put(Pattern.compile("^Type annotations are not allowed here.*"),


### PR DESCRIPTION
See Issue #624 for the related issue.

Basically, I needed to be able to disable the warning for JSDoc annotations in non-JSDoc block comments. This exists in some older libraries that my team uses. I decided that this fit well in the "nonStandardJsDocs" group since its indicative of non-standard behavior.
