### PR TITLE
Update externs for String.prototype.localeCompare

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,6 +42,7 @@ eric.lemoine [gmail.com]
 franck.routier [gmail.com] (Franck Routier)
 frederic.junod [gmail.com] (Frederic Junod)
 guido.tapia [gmail.com] (Guido Tapia)
+headcr4sh [gmail.com] (Benjamin P. Jung)
 ichaehoi [gmail.com] (Ibrahim Chaehoi)
 iliakan [gmail.com] (Ilya Kantor)
 ivan.kozik [gmail.com]

--- a/externs/es3.js
+++ b/externs/es3.js
@@ -1700,12 +1700,15 @@ String.prototype.link = function(hrefAttribute) {};
  * or is the same as the given string in sort order.
  *
  * @this {*}
- * @param {*} other
+ * @param {string} compareString
+ * @param {string|Array.<string>=} locales
+ * @param {Object=} options
  * @return {number}
  * @nosideeffects
- * @see http://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Objects/String/Prototype
+ * @see http://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Objects/String/localeCompare
+ * @see http://www.ecma-international.org/ecma-402/1.0/#sec-13.1.1
  */
-String.prototype.localeCompare = function(other) {};
+String.prototype.localeCompare = function(compareString, locales, options) {};
 
 /**
  * Used to retrieve the matches when matching a string against a regular


### PR DESCRIPTION
According to the ECMAScript specification the function String.prototype.localeCompare can deal with optional "locales" and "options" arguments.

See:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
http://www.ecma-international.org/ecma-402/1.0/#sec-13.1.1
