### PR TITLE
AudioParam.setTargetValueAtTime -> AudioParam.setTargetAtTime

### DIFF
--- a/contrib/externs/w3c_audio.js
+++ b/contrib/externs/w3c_audio.js
@@ -317,6 +317,15 @@ AudioParam.prototype.setTargetAtTime = function(target, startTime,
     timeConstant) {};
 
 /**
+ * @deprecated Use setTargetAtTime instead.
+ * @param {number} target
+ * @param {number} startTime
+ * @param {number} timeConstant
+ */
+AudioParam.prototype.setTargetValueAtTime = function(target, startTime,
+    timeConstant) {};
+
+/**
  * @param {Float32Array} values
  * @param {number} startTime
  * @param {number} duration


### PR DESCRIPTION
The Web Audio spec says that AudioParam has a method setTargetAtTime, but contrib/externs/w3c_audio.js still had the old name setTargetValueAtTime.

See https://github.com/WebAudio/web-audio-api/issues/152
