### PR TITLE
Allow usage of goog.require from processed CommonJS modules.

### DIFF
--- a/src/com/google/javascript/jscomp/deps/DefaultDependencyResolver.java
+++ b/src/com/google/javascript/jscomp/deps/DefaultDependencyResolver.java
@@ -44,6 +44,12 @@ public class DefaultDependencyResolver implements DependencyResolver  {
   /** Provide for Closure's base.js. */
   static final String CLOSURE_BASE_PROVIDE = "goog";
 
+  /** Whether a require is in the Closure base namespace */
+  public static final boolean IsClosureBaseRequire(String s) {
+    return (s == DefaultDependencyResolver.CLOSURE_BASE_PROVIDE ||
+            s.startsWith(DefaultDependencyResolver.CLOSURE_BASE_PROVIDE + "."));
+  }
+
   /** Source files used to look up the dependencies. */
   private final List<DependencyFile> depsFiles;
 


### PR DESCRIPTION
This patch works, but leaves the assumption that all inputs are CommonJS,
guarded only by a null check after ProcessCommonJSModules.getModule near
line 1564 of Compiler.java.

I'll add some tests if this is an acceptable approach.
