### PR TITLE
Added a typedef for the jQuery AJAX setting object

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -138,7 +138,7 @@ jQuery.ajax = function(arg1, settings) {};
 $.ajax = function(arg1, settings) {};
 
 /**
- * @param {function(!jQuery.event,XMLHttpRequest,(jQueryAjaxSettings|Object.<string, *>)} handler
+ * @param {function(!jQuery.event,XMLHttpRequest,(jQueryAjaxSettings|Object.<string, *>))} handler
  * @return {!jQuery}
  */
 jQuery.prototype.ajaxComplete = function(handler) {};


### PR DESCRIPTION
The jQuery AJAX setting dictionary is a defined dictionary with known fields. When the various methods accept such a dictionary, they expect very specific properties (the developer can indeed add more properties, of course). Adding a typedef for this type of dictionary reduces the need to quote properties.
Currently, $.ajax({url: "/", beforeSend: function (){} ,cache: true,username: "d",xhrFields: {}}) compiles to $.ajax({url:"/",a:function(){},b:!0,c:"d",d:{}}), causing errors.

With the use of the typedef in the various functions, $.ajax({url: "/", type: "post"}) and friends will be minified without renaming the relevant properties, causing the code not to fail anymore.
