### PR TITLE
Remove compile warnings

### DIFF
--- a/src/com/google/javascript/jscomp/newtypes/ClojurePersistentHashMap.java
+++ b/src/com/google/javascript/jscomp/newtypes/ClojurePersistentHashMap.java
@@ -24,36 +24,39 @@ import java.util.Set;
 public class ClojurePersistentHashMap<K, V> extends PersistentMap<K, V> {
   private static Method assoc;
   private static Method without;
-  private final Map map;
+  private final Map<K, V> map;
 
-  private ClojurePersistentHashMap(Map m) {
+  private ClojurePersistentHashMap(Map<K, V> m) {
     this.map = m;
   }
 
+  @SuppressWarnings("unchecked")
   public static <K, V> PersistentMap<K, V> create(Class<? extends Map> cls)  {
     try {
       assoc = cls.getDeclaredMethod("assoc", Object.class, Object.class);
       without = cls.getDeclaredMethod("without", Object.class);
-      Map m = (Map) cls.getDeclaredField("EMPTY").get(null);
-      return new ClojurePersistentHashMap<>(m);
+      Map<K, V> m = (Map<K, V>) cls.getDeclaredField("EMPTY").get(null);
+      return new ClojurePersistentHashMap(m);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }
 
+  @SuppressWarnings("unchecked")
   public PersistentMap<K, V> with(K key, V value) {
     try {
-      Map m = (Map) assoc.invoke(map, key, value);
-      return new ClojurePersistentHashMap<>(m);
+      Map<K, V> m = (Map<K, V>) assoc.invoke(map, key, value);
+      return new ClojurePersistentHashMap(m);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }
 
+  @SuppressWarnings("unchecked")
   public PersistentMap<K, V> without(K key) {
     try {
-      Map m = (Map) without.invoke(map, key);
-      return new ClojurePersistentHashMap<>(m);
+      Map<K, V> m = (Map<K, V>) without.invoke(map, key);
+      return new ClojurePersistentHashMap(m);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
@@ -61,7 +64,7 @@ public class ClojurePersistentHashMap<K, V> extends PersistentMap<K, V> {
 
   @Override
   public V get(Object key) {
-    return (V) map.get(key);
+    return map.get(key);
   }
 
   @Override

--- a/src/com/google/javascript/jscomp/newtypes/ClojurePersistentHashSet.java
+++ b/src/com/google/javascript/jscomp/newtypes/ClojurePersistentHashSet.java
@@ -24,36 +24,39 @@ import java.util.Set;
 public class ClojurePersistentHashSet<K> extends PersistentSet<K> {
   private static Method cons;
   private static Method disjoin;
-  private final Set set;
+  private final Set<K> set;
 
-  private ClojurePersistentHashSet(Set s) {
+  private ClojurePersistentHashSet(Set<K> s) {
     this.set = s;
   }
 
+  @SuppressWarnings("unchecked")
   public static <K> PersistentSet<K> create(Class<? extends Set> cls)  {
     try {
       cons = cls.getDeclaredMethod("cons", Object.class);
       disjoin = cls.getDeclaredMethod("disjoin", Object.class);
-      Set m = (Set) cls.getDeclaredField("EMPTY").get(null);
-      return new ClojurePersistentHashSet<>(m);
+      Set<K> m = (Set<K>) cls.getDeclaredField("EMPTY").get(null);
+      return new ClojurePersistentHashSet(m);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }
 
+  @SuppressWarnings("unchecked")
   public PersistentSet<K> with(K key) {
     try {
-      Set s = (Set) cons.invoke(set, key);
-      return new ClojurePersistentHashSet<>(s);
+      Set<K> s = (Set<K>) cons.invoke(set, key);
+      return new ClojurePersistentHashSet(s);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }
 
+  @SuppressWarnings("unchecked")
   public PersistentSet<K> without(K key) {
     try {
-      Set s = (Set) disjoin.invoke(set, key);
-      return new ClojurePersistentHashSet<>(s);
+      Set<K> s = (Set<K>) disjoin.invoke(set, key);
+      return new ClojurePersistentHashSet(s);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }

--- a/src/com/google/javascript/jscomp/newtypes/PersistentMap.java
+++ b/src/com/google/javascript/jscomp/newtypes/PersistentMap.java
@@ -23,12 +23,17 @@ public abstract class PersistentMap<K, V> extends AbstractMap<K, V> {
 
   private static PersistentMap EMPTY;
   static {
-    try {
-      Class c = Class.forName("clojure.lang.PersistentHashMap");
-      EMPTY = ClojurePersistentHashMap.create(c);
-    } catch (ClassNotFoundException e) {
-      EMPTY = NaivePersistentMap.create();
-    }
+    setupEmpty();
+  }
+
+  @SuppressWarnings("unchecked") //we cannot cast to 'Class<PersistentHashMap>' because it is not in scope at compile time
+  private static void setupEmpty(){
+      try {
+        Class c = Class.forName("clojure.lang.PersistentHashMap");
+        EMPTY = ClojurePersistentHashMap.create(c);
+      } catch (ClassNotFoundException e) {
+        EMPTY = NaivePersistentMap.create();
+      }
   }
 
   public abstract PersistentMap<K, V> with(K key, V value);

--- a/src/com/google/javascript/jscomp/newtypes/PersistentSet.java
+++ b/src/com/google/javascript/jscomp/newtypes/PersistentSet.java
@@ -24,6 +24,11 @@ public abstract class PersistentSet<K> extends AbstractSet<K> {
   private static PersistentSet EMPTY;
 
   static {
+      setupEmpty();
+  }
+
+  @SuppressWarnings("unchecked") //we cannot cast to 'Class<PersistentHashSet>' because it is not in scope at compile time
+  private static void setupEmpty(){
     try {
       Class c = Class.forName("clojure.lang.PersistentHashSet");
       EMPTY = ClojurePersistentHashSet.create(c);


### PR DESCRIPTION
Remove unchecked  warnings by fixing generics or suppressing the warnings when no other fix is easy achievable.
