### PR TITLE
Remove unchecked compile warnings

### DIFF
--- a/src/com/google/javascript/jscomp/newtypes/PersistentMap.java
+++ b/src/com/google/javascript/jscomp/newtypes/PersistentMap.java
@@ -17,6 +17,7 @@
 package com.google.javascript.jscomp.newtypes;
 
 import java.util.AbstractMap;
+import java.util.Map;
 
 /** A persistent map with non-destructive additions and removals  */
 public abstract class PersistentMap<K, V> extends AbstractMap<K, V> {
@@ -24,7 +25,9 @@ public abstract class PersistentMap<K, V> extends AbstractMap<K, V> {
   private static PersistentMap EMPTY;
   static {
     try {
-      Class c = Class.forName("clojure.lang.PersistentHashMap");
+      @SuppressWarnings("unchecked")
+      Class<? extends Map> c =
+          (Class<? extends Map>)Class.forName("clojure.lang.PersistentHashMap");
       EMPTY = ClojurePersistentHashMap.create(c);
     } catch (ClassNotFoundException e) {
       EMPTY = NaivePersistentMap.create();

--- a/src/com/google/javascript/jscomp/newtypes/PersistentSet.java
+++ b/src/com/google/javascript/jscomp/newtypes/PersistentSet.java
@@ -17,6 +17,7 @@
 package com.google.javascript.jscomp.newtypes;
 
 import java.util.AbstractSet;
+import java.util.Set;
 
 /** A persistent set with non-destructive additions and removals */
 public abstract class PersistentSet<K> extends AbstractSet<K> {
@@ -25,7 +26,9 @@ public abstract class PersistentSet<K> extends AbstractSet<K> {
 
   static {
     try {
-      Class c = Class.forName("clojure.lang.PersistentHashSet");
+      @SuppressWarnings("unchecked")
+      Class<? extends Set> c =
+          (Class<? extends Set>)Class.forName("clojure.lang.PersistentHashSet");
       EMPTY = ClojurePersistentHashSet.create(c);
     } catch (ClassNotFoundException e) {
       EMPTY = NaivePersistentSet.create();


### PR DESCRIPTION
Removes compile warnings due to unchecked type conversion.

```
    [javac] /home/paul/dev/closure-compiler/src/com/google/javascript/jscomp/newtypes/PersistentMap.java:28: warning: [unchecked] unchecked conversion
    [javac]       EMPTY = ClojurePersistentHashMap.create(c);
    [javac]                                               ^
    [javac]   required: Class<? extends Map>
    [javac]   found:    Class
    [javac] /home/paul/dev/closure-compiler/src/com/google/javascript/jscomp/newtypes/PersistentMap.java:28: warning: [unchecked] unchecked method invocation: method create in class ClojurePersistentHashMap is applied to given types
    [javac]       EMPTY = ClojurePersistentHashMap.create(c);
    [javac]                                              ^
    [javac]   required: Class<? extends Map>
    [javac]   found: Class
    [javac] /home/paul/dev/closure-compiler/src/com/google/javascript/jscomp/newtypes/PersistentSet.java:29: warning: [unchecked] unchecked conversion
    [javac]       EMPTY = ClojurePersistentHashSet.create(c);
    [javac]                                               ^
    [javac]   required: Class<? extends Set>
    [javac]   found:    Class
    [javac] /home/paul/dev/closure-compiler/src/com/google/javascript/jscomp/newtypes/PersistentSet.java:29: warning: [unchecked] unchecked method invocation: method create in class ClojurePersistentHashSet is applied to given types
    [javac]       EMPTY = ClojurePersistentHashSet.create(c);
    [javac]                                              ^
    [javac]   required: Class<? extends Set>
    [javac]   found: Class
```
