### PR TITLE
ArrayBufferView added to WebSocket.send() as valid parameter type

### DIFF
--- a/externs/html5.js
+++ b/externs/html5.js
@@ -2033,7 +2033,7 @@ WebSocket.prototype.onclose;
 
 /**
  * Transmits data using the connection.
- * @param {string|ArrayBuffer} data
+ * @param {string|ArrayBuffer|ArrayBufferView} data
  * @return {boolean}
  */
 WebSocket.prototype.send = function(data) {};


### PR DESCRIPTION
According to W3C (see http://www.w3.org/TR/websockets/#dom-websocket-send), the WebSocket.send() method also accepts ArrayBufferView in addition to string and ArrayBuffer. It works in all current browsers (Chrome, Firefox, Safari, and IE). I added ArrayBufferView to the list of valid parameter types of WebSocket.send() in externs/html5.js
