### PR TITLE
--charset doesn't work for stdin

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -481,7 +481,7 @@ abstract class AbstractCommandLineRunner<A extends Compiler,
           throw new FlagUsageException("Bundle files cannot be generated " +
               "when the input is from stdin.");
         }
-        inputs.add(SourceFile.fromInputStream("stdin", System.in));
+        inputs.add(SourceFile.fromInputStream("stdin", System.in, inputCharset));
         usingStdin = true;
       }
     }

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1285,7 +1285,8 @@ public class CommandLineRunner extends
               // Give the files an odd prefix, so that they do not conflict
               // with the user's files.
               "externs.zip//" + entry.getName(),
-              entryStream));
+              entryStream,
+              UTF_8));
     }
 
     Preconditions.checkState(

--- a/src/com/google/javascript/jscomp/SourceFile.java
+++ b/src/com/google/javascript/jscomp/SourceFile.java
@@ -330,14 +330,34 @@ public class SourceFile implements StaticSourceFile, Serializable {
         .buildFromCode(fileName, code);
   }
 
+  /**
+   * @deprecated Use {@link #fromInputStream(String, InputStream, Charset)}
+   */
+  @Deprecated
   public static SourceFile fromInputStream(String fileName, InputStream s)
       throws IOException {
     return builder().buildFromInputStream(fileName, s);
   }
 
+  /**
+   * @deprecated Use
+   *     {@link #fromInputStream(String, String, InputStream, Charset)}
+   */
+  @Deprecated
   public static SourceFile fromInputStream(String fileName,
       String originalPath, InputStream s) throws IOException {
     return builder().withOriginalPath(originalPath)
+        .buildFromInputStream(fileName, s);
+  }
+
+  public static SourceFile fromInputStream(String fileName, InputStream s,
+      Charset charset) throws IOException {
+    return builder().withCharset(charset).buildFromInputStream(fileName, s);
+  }
+
+  public static SourceFile fromInputStream(String fileName,
+      String originalPath, InputStream s, Charset charset) throws IOException {
+    return builder().withCharset(charset).withOriginalPath(originalPath)
         .buildFromInputStream(fileName, s);
   }
 


### PR DESCRIPTION
The compiler always reads stdin as UTF-8, regardless of `--charset`.

``` bash
$ echo "var foo = '⌘';" | enconv -L none -x UCS-4 > test.js
$ java -jar compiler.js --charset=UTF-32 test.js # good
var foo="#";
$ java -jar compiler.js --charset=UTF-32 < test.js # bad
stdin:1: ERROR - Parse error. Character '' (U+0000) is not a valid identifier start char
var foo = '#';
^

1 error(s), 0 warning(s)
```

(Ignore the actual output. Not all characters came through in the paste. And note that UCS-4 and UTF-32 are synonyms.)

---

While fixing this, I deprecated the `SourceFile#fromInputStream` methods in favor of ones that accept `Charset`s.
