### PR TITLE
Reduce subtraction assignment to prefix increment/decrement

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java
+++ b/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java
@@ -66,6 +66,9 @@ class PeepholeSubstituteAlternateSyntax
   @SuppressWarnings("fallthrough")
   public Node optimizeSubtree(Node node) {
     switch(node.getType()) {
+      case Token.ASSIGN_SUB:
+        return reduceSubstractionAssignment(node);
+
       case Token.TRUE:
       case Token.FALSE:
         return reduceTrueFalse(node);
@@ -481,6 +484,24 @@ class PeepholeSubstituteAlternateSyntax
       return regexLiteral;
     }
 
+    return n;
+  }
+
+  private Node reduceSubstractionAssignment(Node n) {
+    Node right = n.getLastChild();
+    if (right.isNumber()) {
+      if (right.getDouble() == 1) {
+        Node newNode = IR.dec(n.removeFirstChild(), false);
+        n.getParent().replaceChild(n, newNode);
+        reportCodeChange();
+        return newNode;
+      } else if (right.getDouble() == -1) {
+        Node newNode = IR.inc(n.removeFirstChild(), false);
+        n.getParent().replaceChild(n, newNode);
+        reportCodeChange();
+        return newNode;
+      }
+    }
     return n;
   }
 

--- a/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java
@@ -283,6 +283,11 @@ public class PeepholeSubstituteAlternateSyntaxTest extends CompilerTestCase {
     fold("x >= true", "x >= 1");
   }
 
+  public void testFoldSubtractionAssignment() {
+    fold("x -= 1", "--x");
+    fold("x -= -1", "++x");
+  }
+
   public void testFoldReturnResult() {
     foldSame("function f(){return !1;}");
     foldSame("function f(){return null;}");


### PR DESCRIPTION
Reduces `a -= 1` to `--a`, and `a -= -1` to `++a`.

(This is not possible to extend to addition assignments, as `+=` can be string concatenation.)
