### PR TITLE
#658 Stripped BOM from UTF 8 encoded files

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -117,6 +117,9 @@ public class CommandLineRunner extends
   public static final String OUTPUT_MARKER =
       AbstractCommandLineRunner.OUTPUT_MARKER;
 
+  // UTF-8 BOM is 0xEF, 0xBB, 0xBF, of which character code is 65279.
+  public static final String UTF8_BOM_CODE = 65279;
+
   private static class GuardLevel {
     final String name;
     final CheckLevel level;
@@ -920,6 +923,12 @@ public class CommandLineRunner extends
     int c;
 
     while ((c = buffer.read()) != -1) {
+      
+      // Ignoring any found BOM (meaningless if not at the beginning anyway).
+      if (c == UTF8_BOM_CODE) {
+        continue;
+      }
+
       if (c == 32 || c == 9 || c == 10 || c == 13) {
         if (quoted) {
           builder.append((char) c);
@@ -1195,6 +1204,13 @@ public class CommandLineRunner extends
     String textProto = Files.toString(new File(configFile), UTF_8);
 
     ConformanceConfig.Builder builder = ConformanceConfig.newBuilder();
+
+    // Looking for BOM.
+    if ((int)textProto.charAt(0) == UTF8_BOM_CODE) {
+      // Stripping the BOM.
+      textProto = textProto.substring(1);
+    }
+
     try {
       TextFormat.merge(textProto, builder);
     } catch (Exception e) {


### PR DESCRIPTION
The compiler throws an exception when a flag file or a conformance configuration file has a UTF-8 BOM, so stripping it in both of these cases would be beneficial for people that use Visual Studio, or other IDEs that add a BOM by default.
Fixed https://github.com/google/closure-compiler/issues/658
