### PR TITLE
Stripped BOM from UTF 8 encoded files

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -927,9 +927,11 @@ public class CommandLineRunner extends
     while ((c = buffer.read()) != -1) {
       
       // Ignoring the BOM.
-      if (isFirstCharacter && c == UTF8_BOM_CODE) {
+      if (isFirstCharacter) {
         isFirstCharacter = false;
-        continue;
+        if (c == UTF8_BOM_CODE) {
+          continue;
+        }
       }
 
       if (c == 32 || c == 9 || c == 10 || c == 13) {


### PR DESCRIPTION
The compiler throws an exception when a flag file or a conformance configuration file has a UTF-8 BOM, so stripping it in both of these cases would be beneficial for people that use Visual Studio, or other IDEs that add a BOM by default.
Fixed https://github.com/google/closure-compiler/issues/658
