### PR TITLE
Updated readme to point to the releases wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The [Closure Compiler](https://developers.google.com/closure/compiler/) is a tool for making JavaScript download and run faster. It is a true compiler for JavaScript. Instead of compiling from a source language to machine code, it compiles from JavaScript to better JavaScript. It parses your JavaScript, analyzes it, removes dead code and rewrites and minimizes what's left. It also checks syntax, variable references, and types, and warns about common JavaScript pitfalls.
 
 ## Getting Started
- * [Download the latest version](http://dl.google.com/closure-compiler/compiler-latest.zip)
+ * [Download the latest version](http://dl.google.com/closure-compiler/compiler-latest.zip) ([Release details here](https://github.com/google/closure-compiler/wiki/Releases))
  * See the [Google Developers Site](https://developers.google.com/closure/compiler/docs/gettingstarted_app) for documentation including instructions for running the compiler from the command line.
 
 ## Options for Getting Help


### PR DESCRIPTION
When people visit the project page to download the latest, they want to know what the latest version is! ("Has it changed since I was last here?").

Even if you download the latest you have no easy way to tell what version it is - nothing in the zip mentions current version.

I propose adding a link to the release wiki page, which is kinda buried otherwise, since there's no ToC in the wiki.
