### PR TITLE
Number.prototype.toLocaleString([locales[, options]]) extern

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -134,8 +134,7 @@ Object.is;
 
 /**
  * Returns a language-sensitive string representation of this number.
- * @this {Number|number}
- * @param {(string|Array.<string>)=} opt_locales
+ * @param {(string|!Array<string>)=} opt_locales
  * @param {Object=} opt_options
  * @return {string}
  * @nosideeffects


### PR DESCRIPTION
There is an extern for `Object.prototype.toLocaleString()` in [es3.js](/google/closure-compiler/blob/master/externs/es3.js).

Should there also be an overriding extern for [`Number.prototype.toLocaleString()`](//developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) with its two optional parameters, perhaps in one of either the ES5 or (more likely) ES6 extern files? Or was this intentionally left out?

Right now, passing anything to the method gives me a warning based on `Object.prototype.toLocaleString()`, which expects exactly zero arguments.
