### PR TITLE
Various corrections to jQuery 1.9 externs

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -602,7 +602,7 @@ jQuery.prototype.detach = function(selector) {};
 
 /**
  * @param {Object} collection
- * @param {function(?,?)} callback
+ * @param {function((number|string),?)} callback
  * @return {Object}
  */
 jQuery.each = function(collection, callback) {};
@@ -615,7 +615,7 @@ jQuery.prototype.each = function(fnc) {};
 
 /**
  * @param {Object} collection
- * @param {function(?,?)} callback
+ * @param {function((number|string),?)} callback
  * @return {Object}
  */
 $.each = function(collection, callback) {};


### PR DESCRIPTION
- Corrects type of jQuery.each callback's first parameter to `(number|string)` instead of `string`.
- Deprecates jQuery.support (see jquery/api.jquery.com#454).
- Adds other possible return values to jQuery.parseJSON (see jquery/api.jquery.com#490).
- Loosens return type of `dataFilter` function passed to $.ajax (see jquery/api.jquery.com#492).
- Updates `@see` reference to link to proper issue in old tracker.
