### PR TITLE
angular.Directive.controller may be an Array

### DIFF
--- a/contrib/externs/angular-1.3.js
+++ b/contrib/externs/angular-1.3.js
@@ -355,7 +355,7 @@ angular.LinkingFunctions.post = function(scope, iElement, iAttrs, controller) {
  *   bindToController: (boolean|undefined),
  *   compile: (function(
  *       !angular.JQLite=, !angular.Attributes=, Function=)|undefined),
- *   controller: (Function|string|undefined),
+ *   controller: (Function|Array.<string|Function>|string|undefined),
  *   controllerAs: (string|undefined),
  *   link: (function(
  *       !angular.Scope=, !angular.JQLite=, !angular.Attributes=,


### PR DESCRIPTION
This PR fixes a problem in the `angular-1.3.js` externs file.

Currently, if a directive's `controller` is defined as an `Array` then the compilation fails because `Array` is not a possible type for the `controller` property in the `angular.Directive` type.

The use-case:

``` js
module.directive('myDirective',
  /**
   * @return {angular.Directive} The Directive Definition Object.
   */
  function() {
    return {
        // …
        controller: ['$scope', function($scope) {
          // …
        }
    };
  });
```

Compile error:

```
ERR! compile .build/examples/all.js:402: ERROR - inconsistent return type
ERR! compile found   : {bindToController: (boolean|undefined), compile: (function (angular.JQLite=, {$attr: (Object.<string,string>|null), $normalize: function (string): string, $observe: function (string, function (*): ?): function (): ?, $set: function (string, (boolean|null|string), boolean=, string=): ?, ...}=, (Function|null)=): ?|undefined), controller: (Array|Function|null|string|undefined), controllerAs: (string|undefined), ...}
ERR! compile required: {bindToController: (boolean|undefined), compile: (function (angular.JQLite=, {$attr: (Object.<string,string>|null), $normalize: function (string): string, $observe: function (string, function (*): ?): function (): ?, $set: function (string, (boolean|null|string), boolean=, string=): ?, ...}=, (Function|null)=): ?|undefined), controller: (Function|null|string|undefined), controllerAs: (string|undefined), ...}
ERR! compile       return {
ERR! compile              ^
ERR! compile 
ERR! compile 
ERR! compile 1 error(s), 0 warning(s), 97.5% typed
```

Note: I've already signed the CLA when I submitted #523.
