### PR TITLE
Respect `let` in `for of`.

### DIFF
--- a/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
+++ b/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
@@ -441,8 +441,9 @@ public class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapCompile
 
     Node cond = IR.not(IR.getprop(iterResult.cloneTree(), IR.string("done")));
     Node incr = IR.assign(iterResult.cloneTree(), getNext.cloneTree());
-    body.addChildToFront(IR.var(IR.name(variableName),
-        IR.getprop(iterResult.cloneTree(), IR.string("value"))));
+    body.addChildToFront(IR.declaration(IR.name(variableName),
+        IR.getprop(iterResult.cloneTree(), IR.string("value")),
+        variable.isLet() ? Token.LET : Token.VAR));
 
     Node newFor = IR.forNode(init, cond, incr, body);
     newFor.useSourceInfoIfMissingFromForTree(node);

--- a/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
@@ -1154,6 +1154,21 @@ public class Es6ToEs3ConverterTest extends CompilerTestCase {
         "  console.log(i);",
         "}"
     ));
+
+    // With let variable.
+    test(Joiner.on('\n').join(
+      "var i;",
+      "for (let i of [1,2,3])",
+      "  console.log(i);"
+    ), Joiner.on('\n').join(
+        "var i;",
+        "for (var $jscomp$iter$0 = $jscomp.makeIterator([1,2,3]),",
+        "    $jscomp$key$i = $jscomp$iter$0.next();",
+        "    !$jscomp$key$i.done; $jscomp$key$i = $jscomp$iter$0.next()) {",
+        "  var i$1 = $jscomp$key$i.value;",
+        "  console.log(i$1);",
+        "}"
+    ));
   }
 
   public void testDestructuringForOf() {


### PR DESCRIPTION
Fixes #717

This changes handles `for (let x of ...)`. But `for (const x of ...)` is still treated as if it was `var`. Not sure how it should be treated.