### PR TITLE
Mark the conformance configs command line option as hidden

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -550,6 +550,7 @@ public class CommandLineRunner extends
     private boolean useNewTypeInference = false;
 
     @Option(name = "--conformance_configs",
+        hidden = true,
         usage = "A list of JS Conformance configurations in text protocol buffer format.")
     private List<String> conformanceConfigs = new ArrayList<>();
 


### PR DESCRIPTION
This is so it doesn't show in the sample usage shown on flag errors.
