### PR TITLE
Add compiler pass to remove console statements

### DIFF
--- a/src/com/google/javascript/jscomp/CompilationLevel.java
+++ b/src/com/google/javascript/jscomp/CompilationLevel.java
@@ -111,7 +111,6 @@ public enum CompilationLevel {
     options.convertToDottedProperties = true;
     options.labelRenaming = true;
     options.removeDeadCode = true;
-    options.consoleLogElimination = true;
     options.optimizeArgumentsArray = true;
     options.setRemoveUnusedVariables(Reach.LOCAL_ONLY);
     options.collapseObjectLiterals = true;

--- a/src/com/google/javascript/jscomp/CompilationLevel.java
+++ b/src/com/google/javascript/jscomp/CompilationLevel.java
@@ -111,6 +111,7 @@ public enum CompilationLevel {
     options.convertToDottedProperties = true;
     options.labelRenaming = true;
     options.removeDeadCode = true;
+    options.consoleLogElimination = true;
     options.optimizeArgumentsArray = true;
     options.setRemoveUnusedVariables(Reach.LOCAL_ONLY);
     options.collapseObjectLiterals = true;
@@ -137,6 +138,7 @@ public enum CompilationLevel {
     options.convertToDottedProperties = true;
     options.labelRenaming = true;
     options.removeDeadCode = true;
+    options.consoleLogElimination = true;
     options.optimizeArgumentsArray = true;
     options.collapseObjectLiterals = true;
     options.protectHiddenSideEffects = true;

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -356,6 +356,9 @@ public class CompilerOptions implements Serializable, Cloneable {
   /** Removes code that will never execute */
   public boolean removeDeadCode;
 
+  /** Removes console.log statements */
+  public boolean consoleLogElimination;
+
   public CheckLevel checkMissingReturn;
 
   /** Checks for missing return statements */
@@ -1000,6 +1003,7 @@ public class CompilerOptions implements Serializable, Cloneable {
     smartNameRemoval = false;
     extraSmartNameRemoval = false;
     removeDeadCode = false;
+    consoleLogElimination = false;
     extractPrototypeMemberDeclarations =
         ExtractPrototypeMemberDeclarationsMode.OFF;
     removeUnusedPrototypeProperties = false;
@@ -1864,6 +1868,12 @@ public class CompilerOptions implements Serializable, Cloneable {
   public void setRemoveDeadCode(boolean removeDeadCode) {
     this.removeDeadCode = removeDeadCode;
   }
+
+
+  public void setConsoleLogElimination(boolean consoleLogElimination) {
+    this.consoleLogElimination = consoleLogElimination;
+  }
+
 
   public void setExtractPrototypeMemberDeclarations(boolean enabled) {
     this.extractPrototypeMemberDeclarations =

--- a/src/com/google/javascript/jscomp/ConsoleLogElimination.java
+++ b/src/com/google/javascript/jscomp/ConsoleLogElimination.java
@@ -16,6 +16,7 @@
 
 package com.google.javascript.jscomp;
 
+import static java.lang.String.format;
 import static java.util.logging.Logger.getLogger;
 
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
@@ -61,7 +62,8 @@ public class ConsoleLogElimination extends AbstractPostOrderCallback implements 
   private void removeExpressionResult(Node fnCall) {
     for (int i = 1; i < fnCall.getChildCount(); i++) {
       if (NodeUtil.mayHaveSideEffects(fnCall.getChildAtIndex(i))) {
-        throw new IllegalStateException("Cannot remove console statement with side effects on line " + fnCall.getLineno());
+        logger.warning(format("Removing console statement with possible side effects on line %d of '%s'", fnCall.getLineno(), fnCall.getSourceFileName()));
+        break;
       }
     }
     fnCall.getParent().getParent().removeChild(fnCall.getParent());

--- a/src/com/google/javascript/jscomp/ConsoleLogElimination.java
+++ b/src/com/google/javascript/jscomp/ConsoleLogElimination.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2006 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import static java.util.logging.Logger.getLogger;
+
+import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.rhino.Node;
+
+import java.util.logging.Logger;
+
+
+public class ConsoleLogElimination extends AbstractPostOrderCallback implements CompilerPass {
+
+  private static final Logger logger = getLogger(ConsoleLogElimination.class.getName());
+
+  private AbstractCompiler compiler;
+
+
+  public ConsoleLogElimination(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+
+  @Override
+  public void process(Node node, Node root) {
+    NodeTraversal.traverse(compiler, root, this);
+  }
+
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    if (parent == null || !parent.isGetProp())
+      return;
+    Node secondAncestor = parent.getParent();
+    Node thirdAncestor = secondAncestor.getParent();
+    if (n.isName() && "console".equals(n.getQualifiedName()) && secondAncestor.isCall() && thirdAncestor.isExprResult()) {
+      removeExpressionResult(secondAncestor);
+      return;
+    } else if (n.isString() && "console".equals(n.getString()) && "window".equals(parent.getFirstChild().getString())) {
+      removeExpressionResult(thirdAncestor);
+      return;
+    }
+  }
+
+
+  private void removeExpressionResult(Node fnCall) {
+    for (int i = 1; i < fnCall.getChildCount(); i++) {
+      if (NodeUtil.mayHaveSideEffects(fnCall.getChildAtIndex(i))) {
+        throw new IllegalStateException("Cannot remove console statement with side effects on line " + fnCall.getLineno());
+      }
+    }
+    fnCall.getParent().getParent().removeChild(fnCall.getParent());
+    compiler.reportCodeChange();
+  }
+
+}

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -867,6 +867,10 @@ public class DefaultPassConfig extends PassConfig {
       passes.add(removeUnreachableCode);
     }
 
+    if (options.consoleLogElimination) {
+      passes.add(consoleLogElimination);
+    }
+
     if (options.removeUnusedPrototypeProperties) {
       passes.add(removeUnusedPrototypeProperties);
     }
@@ -1941,6 +1945,17 @@ public class DefaultPassConfig extends PassConfig {
     @Override
     protected CompilerPass create(AbstractCompiler compiler) {
       return new UnreachableCodeElimination(compiler, true);
+    }
+  };
+
+  /**
+   * Use data flow analysis to remove dead branches.
+   */
+  final PassFactory consoleLogElimination =
+      new PassFactory("consoleLogElimination", false) {
+    @Override
+    protected CompilerPass create(AbstractCompiler compiler) {
+      return new ConsoleLogElimination(compiler);
     }
   };
 

--- a/test/com/google/javascript/jscomp/ConsoleLogEliminationTest.java
+++ b/test/com/google/javascript/jscomp/ConsoleLogEliminationTest.java
@@ -60,20 +60,10 @@ public class ConsoleLogEliminationTest extends CompilerTestCase {
   }
 
   public void testConsoleSideEffect() {
-    try {
-      test("var a; console.log(a++);", "var a; console.log(a++);");
-      fail("Expected an Exception");
-    } catch (RuntimeException ex) {
-      assertTrue(ex.getMessage().contains("Cannot remove console statement with side effects on line 1"));
-    }
+    test("var a; console.log(a++);", "var a;");
   }
 
   public void testWindowConsoleSideEffect() {
-    try {
-      test("var a; window.console.log(a++);", "var a; window.console.log(a++);");
-      fail("Expected an Exception");
-    } catch (RuntimeException ex) {
-      assertTrue(ex.getMessage().contains("Cannot remove console statement with side effects on line 1"));
-    }
+    test("var a; window.console.log(a++);", "var a;");
   }
 }

--- a/test/com/google/javascript/jscomp/ConsoleLogEliminationTest.java
+++ b/test/com/google/javascript/jscomp/ConsoleLogEliminationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2006 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/**
+ * Tests for {@link com.google.javascript.jscomp.AliasExternals}.
+ *
+ */
+public class ConsoleLogEliminationTest extends CompilerTestCase {
+
+  public ConsoleLogEliminationTest() {
+    super();
+  }
+
+
+  @Override
+  public void setUp() {
+    super.enableLineNumberCheck(true);
+  }
+
+  @Override
+  protected CompilerPass getProcessor(Compiler compiler) {
+    return new ConsoleLogElimination(compiler);
+  }
+
+  @Override
+  protected int getNumRepetitions() {
+    return 1;
+  }
+
+  public void testConsole() {
+    test("var a; console.log(a);", "var a;");
+    test("var a,b; console.log(a,b);", "var a,b;");
+    test("var a; console.debug(a);", "var a;");
+  }
+
+  public void testWindowConsole() {
+    test("var a; window.console.log(a);", "var a;");
+    test("var a,b; window.console.log(a,b);", "var a,b;");
+    test("var a; window.console.debug(a);", "var a;");
+  }
+
+  public void testMisses() {
+    test("var a; consola.log(a);", "var a; consola.log(a);");
+    test("var a; window.consola.log(a);", "var a; window.consola.log(a);");
+  }
+
+  public void testConsoleSideEffect() {
+    try {
+      test("var a; console.log(a++);", "var a; console.log(a++);");
+      fail("Expected an Exception");
+    } catch (RuntimeException ex) {
+      assertTrue(ex.getMessage().contains("Cannot remove console statement with side effects on line 1"));
+    }
+  }
+
+  public void testWindowConsoleSideEffect() {
+    try {
+      test("var a; window.console.log(a++);", "var a; window.console.log(a++);");
+      fail("Expected an Exception");
+    } catch (RuntimeException ex) {
+      assertTrue(ex.getMessage().contains("Cannot remove console statement with side effects on line 1"));
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -171,7 +171,7 @@ public class IntegrationTest extends IntegrationTestCase {
     testSame(
         options,
         "var goog = {}; goog.getCssName = function(x) {};" +
-        "goog.getCssName('foo');");
+            "goog.getCssName('foo');");
   }
 
   public void testClosurePassOn() {
@@ -184,11 +184,11 @@ public class IntegrationTest extends IntegrationTestCase {
     test(
         options,
         "/** @define {boolean} */ var COMPILED = false;" +
-        "var goog = {}; goog.getCssName = function(x) {};" +
-        "goog.getCssName('foo');",
+            "var goog = {}; goog.getCssName = function(x) {};" +
+            "goog.getCssName('foo');",
         "var COMPILED = true;" +
-        "var goog = {}; goog.getCssName = function(x) {};" +
-        "'foo';");
+            "var goog = {}; goog.getCssName = function(x) {};" +
+            "'foo';");
   }
 
   public void testCssNameCheck() {
@@ -241,13 +241,13 @@ public class IntegrationTest extends IntegrationTestCase {
     options.checkMissingGetCssNameBlacklist = "foo";
     test(options,
         "var goog = {};\n" +
-        "/**\n" +
-        " * @param {string} className\n" +
-        " * @param {string=} opt_modifier\n" +
-        " * @return {string}\n" +
-        "*/\n" +
-        "goog.getCssName = function(className, opt_modifier) {}\n" +
-        "var x = goog.getCssName(123, 'a');",
+            "/**\n" +
+            " * @param {string} className\n" +
+            " * @param {string=} opt_modifier\n" +
+            " * @return {string}\n" +
+            "*/\n" +
+            "goog.getCssName = function(className, opt_modifier) {}\n" +
+            "var x = goog.getCssName(123, 'a');",
         TypeValidator.TYPE_MISMATCH_WARNING);
   }
 
@@ -319,9 +319,9 @@ public class IntegrationTest extends IntegrationTestCase {
   public void testCheckRequiresOn() {
     CompilerOptions options = createCompilerOptions();
     options.checkRequires = CheckLevel.ERROR;
-    test(options, new String[] {
-      "/** @constructor */ function Foo() {}",
-      "new Foo();"
+    test(options, new String[]{
+        "/** @constructor */ function Foo() {}",
+        "new Foo();"
     }, CheckRequiresForConstructors.MISSING_REQUIRE_WARNING);
   }
 
@@ -342,16 +342,16 @@ public class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.generateExports = true;
     test(options, "/** @export */ function f() {}",
-         "/** @export */ function f() {} goog.exportSymbol('f', f);");
+        "/** @export */ function f() {} goog.exportSymbol('f', f);");
   }
 
   public void testInstrumentMemoryAllocationPassOff() {
     testSame(createCompilerOptions(),
         "var obj = new Object(); " +
-        "var o = {}; " +
-        "var a = []; " +
-        "var f = function() {};" +
-        "var s = 'a' + 'b'");
+            "var o = {}; " +
+            "var a = []; " +
+            "var f = function() {};" +
+            "var s = 'a' + 'b'");
   }
 
   public void testInstrumentMemoryAllocationPassOn() {
@@ -361,24 +361,24 @@ public class IntegrationTest extends IntegrationTestCase {
 
     test(options,
         "var obj = new Object(); " +
-        "var o = {}; " +
-        "var a = []; " +
-        "var f = function() {};" +
-        "var s = 'a' + 'b'",
+            "var o = {}; " +
+            "var a = []; " +
+            "var f = function() {};" +
+            "var s = 'a' + 'b'",
 
         InstrumentMemoryAllocPass.JS_INSTRUMENT_ALLOCATION_CODE +
-        "var obj=__alloc(new Object(),\"i0:1\",1,\"new Unknown\");" +
-        "var o=__alloc({},\"i0:1\",2,\"Object\");" +
-        "var a=__alloc([],\"i0:1\",3,\"Array\");" +
-        "var f=__alloc(function() {},\"i0:1\",4,\"Function\");" +
-        "var s=\"a\"+\"b\";");
+            "var obj=__alloc(new Object(),\"i0:1\",1,\"new Unknown\");" +
+            "var o=__alloc({},\"i0:1\",2,\"Object\");" +
+            "var a=__alloc([],\"i0:1\",3,\"Array\");" +
+            "var f=__alloc(function() {},\"i0:1\",4,\"Function\");" +
+            "var s=\"a\"+\"b\";");
   }
 
   public void testAngularPassOff() {
     testSame(createCompilerOptions(),
         "/** @ngInject */ function f() {} " +
-        "/** @ngInject */ function g(a){} " +
-        "/** @ngInject */ var b = function f(a) {} ");
+            "/** @ngInject */ function g(a){} " +
+            "/** @ngInject */ var b = function f(a) {} ");
   }
 
   public void testAngularPassOn() {
@@ -386,12 +386,12 @@ public class IntegrationTest extends IntegrationTestCase {
     options.angularPass = true;
     test(options,
         "/** @ngInject */ function f() {} " +
-        "/** @ngInject */ function g(a){} " +
-        "/** @ngInject */ var b = function f(a, b, c) {} ",
+            "/** @ngInject */ function g(a){} " +
+            "/** @ngInject */ var b = function f(a, b, c) {} ",
 
         "function f() {} " +
-        "function g(a) {} g['$inject']=['a'];" +
-        "var b = function f(a, b, c) {}; b['$inject']=['a', 'b', 'c']");
+            "function g(a) {} g['$inject']=['a'];" +
+            "var b = function f(a, b, c) {}; b['$inject']=['a', 'b', 'c']");
   }
 
   public void testExportTestFunctionsOff() {
@@ -402,8 +402,8 @@ public class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.exportTestFunctions = true;
     test(options, "function testFoo() {}",
-         "/** @export */ function testFoo() {}" +
-         "goog.exportSymbol('testFoo', testFoo);");
+        "/** @export */ function testFoo() {}" +
+            "goog.exportSymbol('testFoo', testFoo);");
   }
 
   public void testExpose() {
@@ -450,7 +450,7 @@ public class IntegrationTest extends IntegrationTestCase {
     options.checkSymbols = true;
     options.aggressiveVarCheck = CheckLevel.ERROR;
     test(options, "x = 3; var x = 5;",
-         VariableReferenceCheck.EARLY_REFERENCE);
+        VariableReferenceCheck.EARLY_REFERENCE);
   }
 
   public void testInferTypes() {
@@ -483,7 +483,7 @@ public class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.checkTypes = true;
     test(options, "/** @type {n} */ var n = window.name;",
-         RhinoErrorReporter.TYPE_PARSE_ERROR);
+        RhinoErrorReporter.TYPE_PARSE_ERROR);
   }
 
   // This tests that the TypedScopeCreator is memoized so that it only creates a
@@ -555,14 +555,14 @@ public class IntegrationTest extends IntegrationTestCase {
     }));
 
     test(options, "/** @idGenerator {mapped} */"
-         + "var xid = function() {};\n"
-         + "function f() {\n"
-         + "  return xid('foo');\n"
-         + "}",
-         "var xid = function() {};\n"
-         + "function f() {\n"
-         + "  return ':foo:';\n"
-         + "}");
+            + "var xid = function() {};\n"
+            + "function f() {\n"
+            + "  return xid('foo');\n"
+            + "}",
+        "var xid = function() {};\n"
+            + "function f() {\n"
+            + "  return ':foo:';\n"
+            + "}");
   }
 
   public void testRemoveClosureAsserts() {
@@ -570,7 +570,7 @@ public class IntegrationTest extends IntegrationTestCase {
     options.closurePass = true;
     testSame(options,
         "var goog = {};"
-        + "goog.asserts.assert(goog);");
+            + "goog.asserts.assert(goog);");
     options.removeClosureAsserts = true;
     test(options,
         "var goog = {};"
@@ -756,10 +756,10 @@ public class IntegrationTest extends IntegrationTestCase {
     options.collapseObjectLiterals = true;
     test(options, code,
         "function f(){" +
-        "var JSCompiler_object_inline_FOO_0;" +
-        "var JSCompiler_object_inline_bar_1;" +
-        "JSCompiler_object_inline_FOO_0=5;" +
-        "JSCompiler_object_inline_bar_1=3}");
+            "var JSCompiler_object_inline_FOO_0;" +
+            "var JSCompiler_object_inline_bar_1;" +
+            "JSCompiler_object_inline_FOO_0=5;" +
+            "JSCompiler_object_inline_bar_1=3}");
   }
 
   public void testDisambiguateProperties() {
@@ -876,12 +876,12 @@ public class IntegrationTest extends IntegrationTestCase {
     testSame(
         options,
         "/** @param {number} x */ function f(x) {}" +
-        "function g() {" +
-        " synStart('foo');" +
-        " var progress = 1;" +
-        " f(progress);" +
-        " synEnd('foo');" +
-        "}");
+            "function g() {" +
+            " synStart('foo');" +
+            " var progress = 1;" +
+            " f(progress);" +
+            " synEnd('foo');" +
+            "}");
   }
 
   public void testCompilerDoesNotBlowUpIfUndefinedSymbols() {
@@ -1290,6 +1290,15 @@ public class IntegrationTest extends IntegrationTestCase {
 
     options.removeUnusedVars = true;
     test(options, code, "function f() { var x = 3; 4; x = 5; return x; } f();");
+  }
+
+  public void testConsoleLogElimination() {
+    CompilerOptions options = createCompilerOptions();
+    String code = "function f() { var x = 3; console.log(x); return x; } f(); ";
+    testSame(options, code);
+
+    options.consoleLogElimination = true;
+    test(options, code, "function f() { var x = 3; return x; } f(); ");
   }
 
   public void testInlineFunctions() {


### PR DESCRIPTION
There doesn't seem to be any non-intrusive way to remove 'console.log' statements from JavaScript source (for example see http://www.elijahmanor.com/grunt-away-those-pesky-console-log-statements/). Attached is a patch to try to achieve this via a compiler pass.

Produces a warning if it detects that removal of the 'console.log' statement has any side-effects.

Any chance of working this into the compiler, and perhaps adding a specific command-line switch? Any feedback is welcome.