### PR TITLE
Fix typo errors which caused rollback

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ benjamin.j.mccann [gmail.com]
 bitwiseman [gmail.com] (Liam Newman)
 cpeisert [gmail.com] (Christopher Peisert)
 chadkillingsworth [missouristate.edu] (Chad Killingsworth)
+dlochrie (Daniel Lochrie)
 dunbarb2 [gmail.com]
 edo999 [gmail.com]
 eric.lemoine [gmail.com]

--- a/contrib/externs/angular_ui_router.js
+++ b/contrib/externs/angular_ui_router.js
@@ -36,7 +36,6 @@ var ui = {};
 ui.router = {};
 
 
-// TODO: Provide stronger types for properties on $state.
 /**
  * @typedef {{
  *   params: Object,
@@ -52,6 +51,93 @@ ui.router = {};
  * }}
  */
 ui.router.$state;
+
+
+/**
+ * @type {ui.router.State}
+ */
+ui.router.$state.current;
+
+
+/**
+ * @type {Object}
+ */
+ui.router.$state.params;
+
+
+/**
+ * @type {?angular.$q.Promise}
+ */
+ui.router.$state.transition;
+
+
+/**
+ * @param {?string|Object=} stateOrName
+ * @param {?string|Object=} context
+ * @return {Object|Array}
+ */
+ui.router.$state.get = function(stateOrName, context) {};
+
+
+/**
+ * @param {string} to
+ * @param {Object=} params
+ * @param {(ui.router.$state.GoOptions_|Object)=} options
+ * @returns {angular.$q.Promise}
+ */
+ui.router.$state.go = function(to, params, options) {};
+
+
+/**
+ * @param {?string|Object} stateOrName
+ * @param {Object=} params
+ * @param {Object=} options
+ * @returns {string} compiled state url
+ */
+ui.router.$state.href = function(stateOrName, params, options) {};
+
+
+/**
+ * @param {?string} stateOrName
+ * @param {Object=} params
+ * @param {Object=} options
+ */
+ui.router.$state.includes = function(stateOrName, params, options) {};
+
+
+/**
+ * @param {?string|Object} stateOrName
+ * @param {Object=} params
+ * @param {Object=} options
+ * @returns {boolean}
+ */
+ui.router.$state.is = function(stateOrName, params, options) {};
+
+
+/**
+ * @returns {angular.$q.Promise}
+ */
+ui.router.$state.reload = function() {};
+
+
+/**
+ * @param {string} to
+ * @param {Object=} toParams
+ * @param {Object=} options
+ */
+ui.router.$state.transitionTo = function(to, toParams, options) {};
+
+
+/**
+ * @typedef {{
+ *   location: (boolean|string|undefined),
+ *   inherit: (boolean|undefined),
+ *   relative: (Object|undefined),
+ *   notify: (boolean|undefined),
+ *   reload: (boolean|undefined)
+ * }}
+ */
+ui.router.$state.GoOptions_;
 
 
 /**
@@ -137,5 +223,4 @@ ui.router.$stateProvider = function(
  * @param {Object} definition
  * @return {!ui.router.$stateProvider}
  */
-ui.router.$stateProvider.prototype.state = function(
-    name, definition) {};
+ui.router.$stateProvider.prototype.state = function(name, definition) {};

--- a/contrib/externs/angular_ui_router.js
+++ b/contrib/externs/angular_ui_router.js
@@ -78,6 +78,16 @@ ui.router.$state.transition;
  */
 ui.router.$state.get = function(stateOrName, context) {};
 
+/**
+ * @typedef {{
+ *   location: (boolean|string|undefined),
+ *   inherit: (boolean|undefined),
+ *   relative: (Object|undefined),
+ *   notify: (boolean|undefined),
+ *   reload: (boolean|undefined)
+ * }}
+ */
+ui.router.$state.GoOptions_;
 
 /**
  * @param {string} to
@@ -126,18 +136,6 @@ ui.router.$state.reload = function() {};
  * @param {Object=} options
  */
 ui.router.$state.transitionTo = function(to, toParams, options) {};
-
-
-/**
- * @typedef {{
- *   location: (boolean|string|undefined),
- *   inherit: (boolean|undefined),
- *   relative: (Object|undefined),
- *   notify: (boolean|undefined),
- *   reload: (boolean|undefined)
- * }}
- */
-ui.router.$state.GoOptions_;
 
 
 /**


### PR DESCRIPTION
aea6e011c13bb183d1bbc74b1f30d240e976ccb7 mentions a typo caused the rollback. I manual review and local tests of the externs brought me to these corrections. However, if this isn't the correct change, can someone chime in with more details?