### PR TITLE
Allow literal as method names in ObjectLiteral.

### DIFF
--- a/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
+++ b/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
@@ -401,6 +401,9 @@ public class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapCompile
   private void visitMemberDefInObjectLit(Node n, Node parent) {
     String name = n.getString();
     Node stringKey = IR.stringKey(name, n.getFirstChild().detachFromParent());
+    if (n.isQuotedString()) {
+      stringKey.setQuotedString();
+    }
     parent.replaceChild(n, stringKey);
     compiler.reportCodeChange();
   }

--- a/src/com/google/javascript/jscomp/parsing/NewIRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/NewIRFactory.java
@@ -1268,10 +1268,14 @@ class NewIRFactory {
         }
       }
 
-      IdentifierToken name = functionTree.name;
+      com.google.javascript.jscomp.parsing.parser.Token name = functionTree.name;
       Node newName;
       if (name != null) {
-        newName = processNameWithInlineJSDoc(name);
+        if (name.type == TokenType.IDENTIFIER) {
+          newName = processNameWithInlineJSDoc(name.asIdentifier());
+        } else {
+          newName = processObjectLitKeyAsString(name);
+        }
       } else {
         if (isDeclaration || isMember) {
           errorReporter.error(
@@ -1321,7 +1325,8 @@ class NewIRFactory {
 
       if (functionTree.kind == FunctionDeclarationTree.Kind.MEMBER) {
         setSourceInfo(node, functionTree);
-        Node member = newStringNode(Token.MEMBER_DEF, name.value);
+        Node member = newName.cloneNode();
+        member.setType(Token.MEMBER_DEF);
         member.addChildToBack(node);
         member.setStaticMember(functionTree.isStatic);
         result = member;

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -453,11 +453,10 @@ public class Parser {
       isStatic = true;
     }
     boolean isGenerator = eatOpt(TokenType.STAR) != null;
-    TokenType type = peekType();
-    if (type == TokenType.IDENTIFIER || Keywords.isKeyword(type)) {
-      IdentifierToken name = eatIdOrKeywordAsId();
+    if (peekPropertyName(0)) {
+      Token propertyName = eatObjectLiteralPropertyName();
       return parseFunctionTail(
-          start, name, isStatic, isGenerator,
+          start, propertyName, isStatic, isGenerator,
           FunctionDeclarationTree.Kind.MEMBER);
     } else {
       ParseTree name = parseComputedPropertyName();
@@ -469,7 +468,7 @@ public class Parser {
   }
 
   private ParseTree parseFunctionTail(
-      SourcePosition start, IdentifierToken name,
+      SourcePosition start, Token name,
       boolean isStatic, boolean isGenerator,
       FunctionDeclarationTree.Kind kind) {
 

--- a/src/com/google/javascript/jscomp/parsing/parser/trees/FunctionDeclarationTree.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/trees/FunctionDeclarationTree.java
@@ -16,7 +16,7 @@
 
 package com.google.javascript.jscomp.parsing.parser.trees;
 
-import com.google.javascript.jscomp.parsing.parser.IdentifierToken;
+import com.google.javascript.jscomp.parsing.parser.Token;
 import com.google.javascript.jscomp.parsing.parser.util.SourceRange;
 
 public class FunctionDeclarationTree extends ParseTree {
@@ -28,14 +28,14 @@ public class FunctionDeclarationTree extends ParseTree {
     ARROW
   }
 
-  public final IdentifierToken name;
+  public final Token name;
   public final FormalParameterListTree formalParameterList;
   public final ParseTree functionBody;
   public final boolean isStatic;
   public final boolean isGenerator;
   public final Kind kind;
 
-  public FunctionDeclarationTree(SourceRange location, IdentifierToken name,
+  public FunctionDeclarationTree(SourceRange location, Token name,
       boolean isStatic, boolean isGenerator, Kind kind,
       FormalParameterListTree formalParameterList,
       ParseTree functionBody) {

--- a/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
@@ -1274,6 +1274,20 @@ public class Es6ToEs3ConverterTest extends CompilerTestCase {
         "  f: function() { alert(1); },",
         "  x: x",
         "};"));
+
+    test(Joiner.on('\n').join(
+        "var obj = {",
+        "  if() { alert(1); },",
+        "  0() { alert(2); },",
+        "  'abc'() { alert(3); },",
+        "  \"while\"() { alert(4); },",
+        "};"), Joiner.on('\n').join(
+        "var obj = {",
+        "  if: function() { alert(1); },",
+        "  0: function() { alert(2); },",
+        "  \"abc\": function() { alert(3); },",
+        "  \"while\": function() { alert(4); },",
+        "};"));
   }
 
   public void testComputedPropertiesWithMethod() {

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -952,6 +952,10 @@ public class NewParserTest extends BaseJSTypeTestCase {
   public void testMethodInObjectLiteral() {
     testMethodInObjectLiteral("var a = {b() {}};");
     testMethodInObjectLiteral("var a = {b() { alert('b'); }};");
+    testMethodInObjectLiteral("var a = {if() {}};");
+    testMethodInObjectLiteral("var a = {0() {}};");
+    testMethodInObjectLiteral("var a = {'abc'() {}};");
+    testMethodInObjectLiteral("var a = {\"while\"() {}};");
 
     // Static methods not allowed in object literals.
     parseError("var a = {static b() { alert('b'); }};",


### PR DESCRIPTION
```js
// test.js
var a = { 0 () {} };
```

```
$ java -jar compiler.jar --language_in ECMASCRIPT6 --language_out ECMASCRIPT3 test.js
test.js:1: ERROR - Parse error. '[' expected
var a = { 0 () {} };
          ^
```

NumericLiteral and StringLiteral is valid methods name.
https://people.mozilla.org/~jorendorff/es6-draft.html#sec-method-definitions

I was confirmed that the code is valid on Firefox37 and Chrome41.
