### PR TITLE
Decouple jsdoc documentation parsing from IDE mode.

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -2175,6 +2175,7 @@ public class Compiler extends AbstractCompiler {
   protected Config createConfig(Config.LanguageMode mode) {
     return ParserRunner.createConfig(
         isIdeMode(),
+        options.isParseJsDocDocumentation(),
         mode,
         acceptConstKeyword(),
         options.extraAnnotationNames);

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -121,6 +121,8 @@ public class CompilerOptions implements Serializable, Cloneable {
    */
   public boolean ideMode;
 
+  private boolean parseJsDocDocumentation = false;
+
   boolean saveDataStructures = false;
 
   /**
@@ -1741,6 +1743,26 @@ public class CompilerOptions implements Serializable, Cloneable {
 
   public void setIdeMode(boolean ideMode) {
     this.ideMode = ideMode;
+  }
+
+  /**
+   * Enables or disables the parsing of JSDoc documentation. When IDE mode is
+   * enabled then documentation is always parsed.
+   *
+   * @param parseJsDocDocumentation
+   *           True to enable JSDoc documentation parsing, false to disable it.
+   */
+  public void setParseJsDocDocumentation(boolean parseJsDocDocumentation) {
+    this.parseJsDocDocumentation = parseJsDocDocumentation;
+  }
+
+  /**
+   * Checks JSDoc documentation will be parsed.
+   *
+   * @return True when JSDoc documentation will be parsed, false if not.
+   */
+  public boolean isParseJsDocDocumentation() {
+    return this.ideMode || this.parseJsDocDocumentation;
   }
 
   /**

--- a/src/com/google/javascript/jscomp/parsing/Config.java
+++ b/src/com/google/javascript/jscomp/parsing/Config.java
@@ -72,8 +72,14 @@ public class Config {
   Config(Set<String> annotationWhitelist, Set<String> suppressionNames,
       boolean isIdeMode, LanguageMode languageMode,
       boolean acceptConstKeyword) {
+    this(annotationWhitelist, suppressionNames, isIdeMode, isIdeMode, languageMode, acceptConstKeyword);
+  }
+
+  Config(Set<String> annotationWhitelist, Set<String> suppressionNames,
+      boolean isIdeMode, boolean parseJsDocDocumentation, LanguageMode languageMode,
+      boolean acceptConstKeyword) {
     this.annotationNames = buildAnnotationNames(annotationWhitelist);
-    this.parseJsDocDocumentation = isIdeMode;
+    this.parseJsDocDocumentation = parseJsDocDocumentation;
     this.suppressionNames = suppressionNames;
     this.isIdeMode = isIdeMode;
     this.languageMode = languageMode;

--- a/src/com/google/javascript/jscomp/parsing/ParserRunner.java
+++ b/src/com/google/javascript/jscomp/parsing/ParserRunner.java
@@ -54,6 +54,14 @@ public class ParserRunner {
                                     LanguageMode languageMode,
                                     boolean acceptConstKeyword,
                                     Set<String> extraAnnotationNames) {
+    return createConfig(isIdeMode, isIdeMode, languageMode, acceptConstKeyword, extraAnnotationNames);
+  }
+
+  public static Config createConfig(boolean isIdeMode,
+                                    boolean parseJsDocDocumentation,
+                                    LanguageMode languageMode,
+                                    boolean acceptConstKeyword,
+                                    Set<String> extraAnnotationNames) {
     initResourceConfig();
     Set<String> effectiveAnnotationNames;
     if (extraAnnotationNames == null) {
@@ -63,7 +71,7 @@ public class ParserRunner {
       effectiveAnnotationNames.addAll(extraAnnotationNames);
     }
     return new Config(effectiveAnnotationNames, suppressionNames,
-        isIdeMode, languageMode, acceptConstKeyword);
+        isIdeMode, parseJsDocDocumentation, languageMode, acceptConstKeyword);
   }
 
   public static Set<String> getReservedVars() {


### PR DESCRIPTION
Currently the parsing of JSDoc documentation is coupled to the IDE mode
option so normally JSDoc documentation strings are not parsed.  This
prevents the implementation of custom compiler passes like API Documentation
generation.  This patch introduces a new compiler option
(parseJsDocDocumentation) which can be used to enable the documentation
parsing even when not in IDE mode.  The functionality is backward
compatible, when IDE mode is enabled then documentation parsing is always
enabled)