### PR TITLE
Fix index.js resolution for non-relative require invocations.

### DIFF
--- a/src/com/google/javascript/jscomp/ES6ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/ES6ModuleLoader.java
@@ -107,7 +107,7 @@ abstract class ES6ModuleLoader {
 
     private NaiveModuleLoader(AbstractCompiler compiler, String moduleRoot) {
       this.moduleRoot = moduleRoot;
-      this.moduleRootURI = new File(moduleRoot).toURI();
+      this.moduleRootURI = createUri(moduleRoot);
 
       // Precompute the module name of each source file.
       for (CompilerInput input : compiler.getInputsInOrder()) {
@@ -118,7 +118,7 @@ abstract class ES6ModuleLoader {
     @Override
     String locate(String name, CompilerInput referrer) {
       URI base = isRelativeIdentifier(name) ? createUri(referrer)
-          : createUri(moduleRoot);
+          : moduleRootURI;
 
       return convertSourceUriToModuleAddress(base.resolve(createUri(name)));
     }

--- a/src/com/google/javascript/jscomp/ES6ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/ES6ModuleLoader.java
@@ -117,11 +117,10 @@ abstract class ES6ModuleLoader {
 
     @Override
     String locate(String name, CompilerInput referrer) {
-      if (isRelativeIdentifier(name)) {
-        return convertSourceUriToModuleAddress(
-            createUri(referrer).resolve(createUri(name)));
-      }
-      return createUri(name).normalize().toString();
+      URI base = isRelativeIdentifier(name) ? createUri(referrer)
+          : createUri(moduleRoot);
+
+      return convertSourceUriToModuleAddress(base.resolve(createUri(name)));
     }
 
     @Override

--- a/test/com/google/javascript/jscomp/ES6ModuleLoaderFileSystemTest.java
+++ b/test/com/google/javascript/jscomp/ES6ModuleLoaderFileSystemTest.java
@@ -96,5 +96,6 @@ public class ES6ModuleLoaderFileSystemTest {
     Assert.assertEquals("A/index.js", loader.getLoadAddress(inputA));
     Assert.assertEquals("A/index.js", loader.locate("../A", inputB));
     Assert.assertEquals("A/index.js", loader.locate("./A", inputApp));
+    Assert.assertEquals("A/index.js", loader.locate("A", inputApp));
   }
 }


### PR DESCRIPTION
Resolve absolute references against the module root, so directories containing index.js files will be handled as they are for relative references.