### PR TITLE
Correction to jQuery 1.9 extern annotation for `.text`

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -1999,7 +1999,7 @@ jQuery.support.tbody;
 $.support.tbody;
 
 /**
- * @param {(string|function(number,string))=} arg1
+ * @param {(string|number|boolean|function(number,string))=} arg1
  * @return {(string|!jQuery)}
  */
 jQuery.prototype.text = function(arg1) {};


### PR DESCRIPTION
Adds `number` and `boolean` as possible parameter types.

Resolves google/closure-compiler#774.