### PR TITLE
add externs file for W3C Encoding API, fixes gh-763

### DIFF
--- a/externs/w3c_encoding.js
+++ b/externs/w3c_encoding.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's Encoding specification
+ *     https://encoding.spec.whatwg.org
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @param {string=} encoding
+ * @param {Object=} options
+ */
+function TextDecoder(encoding, options) {}
+
+/** @type {string} **/ TextDecoder.prototype.encoding;
+/** @type {boolean} **/ TextDecoder.prototype.fatal;
+/** @type {boolean} **/ TextDecoder.prototype.ignoreBOM;
+
+/**
+ * @param {!Uint8Array} bytes
+ * @param {Object=} options
+ * @return {string}
+ */
+TextDecoder.prototype.decode = function decode(input, options) {};
+
+/**
+ * @constructor
+ * @param {string=} encoding
+ * @param {Object=} options
+ */
+function TextEncoder(encoding, options) {}
+
+/** @type {string} **/ TextEncoder.prototype.encoding;
+
+/**
+ * @param {!string=}
+ * @param {Object=} options
+ * @return {!Uint8Array}
+ */
+TextEncoder.prototype.encode = function(string, options) {};
+
+

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1227,6 +1227,7 @@ public class CommandLineRunner extends
     "v8.js",
     "webstorage.js",
     "w3c_anim_timing.js",
+    "w3c_encoding.js",
     "w3c_css3d.js",
     "w3c_elementtraversal.js",
     "w3c_geolocation.js",


### PR DESCRIPTION
I'm using this successfully in a couple of projects. CLA was filed this morning.