### PR TITLE
Added --allow_es6_to_es6 flag.

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -564,6 +564,12 @@ public class CommandLineRunner extends
         usage = "A list of JS Conformance configurations in text protocol buffer format.")
     private List<String> conformanceConfigs = new ArrayList<>();
 
+    @Option(name = "--allow_es6_to_es6",
+        hidden = true,
+        usage = "Experimental: Allows ES6 to ES6 compilation. "
+        + "Enabling this flag may cause the compiler to crash.")
+    private boolean allowEs6ToEs6 = false;
+
     @Argument
     private List<String> arguments = new ArrayList<>();
 
@@ -1103,6 +1109,8 @@ public class CommandLineRunner extends
     options.angularPass = flags.angularPass;
 
     options.renamePrefixNamespace = flags.renamePrefixNamespace;
+
+    options.allowEs6ToEs6 = flags.allowEs6ToEs6;
 
     if (!flags.translationsFile.isEmpty()) {
       try {

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -69,6 +69,11 @@ public class CompilerOptions implements Serializable, Cloneable {
   private LanguageMode languageOut;
 
   /**
+   * If true, allows experimental ES6 to ES6 compilation.
+   */
+  boolean allowEs6ToEs6;
+
+  /**
    * If true, transpile ES6 to ES3 only. All others passes will be skipped.
    */
   boolean transpileOnly;

--- a/src/com/google/javascript/jscomp/CompilerOptionsPreprocessor.java
+++ b/src/com/google/javascript/jscomp/CompilerOptionsPreprocessor.java
@@ -43,14 +43,14 @@ final class CompilerOptionsPreprocessor {
 
     if (options.getLanguageIn() == options.getLanguageOut()) {
       // No conversion.
-    } else if (!options.getLanguageIn().isEs6OrHigher()) {
+    } else if (!options.getLanguageIn().isEs6OrHigher() && !options.allowEs6ToEs6) {
       throw new InvalidOptionsException(
           "Can only convert code from ES6 to a lower ECMAScript version."
           + " Cannot convert from %s to %s.",
           options.getLanguageIn(), options.getLanguageOut());
     }
 
-    if (options.getLanguageOut().isEs6OrHigher()) {
+    if (options.getLanguageOut().isEs6OrHigher() && !options.allowEs6ToEs6) {
       throw new InvalidOptionsException(
           "ES6 is only supported for transpilation to a lower ECMAScript"
           + " version. Set --language_out to ES3, ES5, or ES5_strict.");


### PR DESCRIPTION
Allows ES6 to ES6 compilation but is currently experimental and may cause the compiler to crash.

References: #780 #798