### PR TITLE
Added --allow_es6_to_es6 flag.

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -507,6 +507,12 @@ public class CommandLineRunner extends
         + "ECMASCRIPT6_TYPED (experimental)")
     private String languageOut = "";
 
+    @Option(name = "--allow_es6_to_es6",
+        hidden = true,
+        usage = "Experimental: Allows ES6 to ES6 compilation. "
+        + "Enabling this flag may cause the compiler to crash.")
+    private boolean allowEs6ToEs6 = false;
+
     @Option(name = "--version",
         hidden = true,
         handler = BooleanOptionHandler.class,
@@ -1072,6 +1078,7 @@ public class CommandLineRunner extends
       options.setCodingConvention(new ClosureCodingConvention());
     }
 
+    options.setAllowEs6ToEs6(flags.allowEs6ToEs6);
     options.setExtraAnnotationNames(flags.extraAnnotationName);
 
     CompilationLevel level = flags.compilationLevelParsed;

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -69,6 +69,21 @@ public class CompilerOptions implements Serializable, Cloneable {
   private LanguageMode languageOut;
 
   /**
+   * Allows ES6 to ES6 compilation.
+   */
+  private boolean allowEs6ToEs6;
+
+  /** */
+  public void setAllowEs6ToEs6(boolean value) {
+    allowEs6ToEs6 = value;
+  }
+
+  /** */
+  public boolean getAllowEs6ToEs6() {
+    return allowEs6ToEs6;
+  }
+
+  /**
    * If true, transpile ES6 to ES3 only. All others passes will be skipped.
    */
   boolean transpileOnly;
@@ -937,6 +952,9 @@ public class CompilerOptions implements Serializable, Cloneable {
     // Accepted language
     languageIn = LanguageMode.ECMASCRIPT3;
     languageOut = LanguageMode.NO_TRANSPILE;
+
+    // Experimental
+    allowEs6ToEs6 = false;
 
     // Language variation
     acceptConstKeyword = false;

--- a/src/com/google/javascript/jscomp/CompilerOptionsPreprocessor.java
+++ b/src/com/google/javascript/jscomp/CompilerOptionsPreprocessor.java
@@ -50,7 +50,7 @@ final class CompilerOptionsPreprocessor {
           options.getLanguageIn(), options.getLanguageOut());
     }
 
-    if (options.getLanguageOut().isEs6OrHigher()) {
+    if (options.getLanguageOut().isEs6OrHigher() && !options.getAllowEs6ToEs6()) {
       throw new InvalidOptionsException(
           "ES6 is only supported for transpilation to a lower ECMAScript"
           + " version. Set --language_out to ES3, ES5, or ES5_strict.");


### PR DESCRIPTION
Allows experimental ES6 to ES6 compilation but may cause the compiler to crash at the moment.

Reference: #780 #798