### PR TITLE
Add @nocollapse annotation

### DIFF
--- a/src/com/google/javascript/jscomp/GlobalNamespace.java
+++ b/src/com/google/javascript/jscomp/GlobalNamespace.java
@@ -907,9 +907,10 @@ class GlobalNamespace
 
     Type type;
     private boolean declaredType = false;
-    private boolean hasDeclaredTypeDescendant = false;
+    private boolean isDeclared = false;
     int globalSets = 0;
     int localSets = 0;
+    int localSetsWithNoCollapse = 0;
     int aliasingGets = 0;
     int totalGets = 0;
     int callGets = 0;
@@ -964,6 +965,7 @@ class GlobalNamespace
 
     void addRef(Ref ref) {
       addRefInternal(ref);
+      JSDocInfo info;
       switch (ref.type) {
         case SET_FROM_GLOBAL:
           if (declaration == null) {
@@ -974,6 +976,11 @@ class GlobalNamespace
           break;
         case SET_FROM_LOCAL:
           localSets++;
+          info = ref.getNode() == null ? null :
+              NodeUtil.getBestJSDocInfo(ref.getNode());
+          if (info != null && info.isNoCollapse()) {
+            localSetsWithNoCollapse++;
+          }
           break;
         case PROTOTYPE_GET:
         case DIRECT_GET:
@@ -1009,12 +1016,18 @@ class GlobalNamespace
           }
         }
 
+        JSDocInfo info;
         switch (ref.type) {
           case SET_FROM_GLOBAL:
             globalSets--;
             break;
           case SET_FROM_LOCAL:
             localSets--;
+            info = ref.getNode() == null ? null :
+                NodeUtil.getBestJSDocInfo(ref.getNode());
+            if (info != null && info.isNoCollapse()) {
+              localSetsWithNoCollapse--;
+            }
             break;
           case PROTOTYPE_GET:
           case DIRECT_GET:
@@ -1074,10 +1087,28 @@ class GlobalNamespace
       return false;
     }
 
+    boolean isCollapsingExplicitlyDenied() {
+      // Enum keys are always collapsed. @nocollapse annotations are ignored
+      if (isDescendantOfEnum()) {
+        return false;
+      }
+
+      if (docInfo == null) {
+        Ref ref = getDeclaration();
+        if (ref != null) {
+          docInfo = getDocInfoForDeclaration(ref);
+        }
+      }
+
+      return docInfo != null && docInfo.isNoCollapse();
+    }
+
     boolean canCollapse() {
-      return !inExterns && !isGetOrSetDefinition() && (declaredType ||
+      return !inExterns && !isGetOrSetDefinition() &&
+          !isCollapsingExplicitlyDenied() &&
+          (declaredType ||
           (parent == null || parent.canCollapseUnannotatedChildNames()) &&
-          (globalSets > 0 || localSets > 0) &&
+          (globalSets > 0 || localSets > 0) && localSetsWithNoCollapse == 0 &&
           deleteProps == 0);
     }
 
@@ -1096,6 +1127,10 @@ class GlobalNamespace
       // it's probably not worth the effort.
       Preconditions.checkNotNull(declaration);
       if (declaration.getTwin() != null) {
+        return false;
+      }
+
+      if (isCollapsingExplicitlyDenied()) {
         return false;
       }
 
@@ -1119,18 +1154,20 @@ class GlobalNamespace
 
     /** Whether this is an object literal that needs to keep its keys. */
     boolean shouldKeepKeys() {
-      return type == Type.OBJECTLIT && aliasingGets > 0;
+      return type == Type.OBJECTLIT &&
+          (aliasingGets > 0 || isCollapsingExplicitlyDenied());
     }
 
     boolean needsToBeStubbed() {
-      return globalSets == 0 && localSets > 0;
+      return globalSets == 0 && localSets > 0 && localSetsWithNoCollapse == 0 &&
+          !isCollapsingExplicitlyDenied();
     }
 
     void setDeclaredType() {
       declaredType = true;
       for (Name ancestor = parent; ancestor != null;
            ancestor = ancestor.parent) {
-        ancestor.hasDeclaredTypeDescendant = true;
+        ancestor.isDeclared = true;
       }
     }
 
@@ -1155,7 +1192,7 @@ class GlobalNamespace
      * considered namespaces.
      */
     boolean isNamespaceObjectLit() {
-      return hasDeclaredTypeDescendant && type == Type.OBJECTLIT;
+      return isDeclared && type == Type.OBJECTLIT;
     }
 
     /**
@@ -1164,6 +1201,24 @@ class GlobalNamespace
      */
     boolean isSimpleName() {
       return parent == null;
+    }
+
+    /**
+     * Determines whether a node is a property of an enum.
+     * This is recursive because static properties can be added to enums after
+     * declaration.
+     */
+    boolean isDescendantOfEnum() {
+      if (parent == null) {
+        return false;
+      }
+
+      if (parent.type == Type.OBJECTLIT && parent.docInfo != null &&
+          parent.docInfo.hasEnumParameterType()) {
+        return true;
+      }
+
+      return parent.isDescendantOfEnum();
     }
 
     @Override public String toString() {
@@ -1190,6 +1245,8 @@ class GlobalNamespace
           case Token.VAR:
             return ref.node == refParent.getFirstChild() ?
                 refParent.getJSDocInfo() : ref.node.getJSDocInfo();
+          case Token.OBJECTLIT:
+            return ref.node.getJSDocInfo();
         }
       }
 

--- a/src/com/google/javascript/jscomp/parsing/Annotation.java
+++ b/src/com/google/javascript/jscomp/parsing/Annotation.java
@@ -56,6 +56,7 @@ enum Annotation {
   MEANING,
   MODIFIES,
   NO_ALIAS,
+  NO_COLLAPSE,
   NO_COMPILE,
   NO_SIDE_EFFECTS,
   NOT_IMPLEMENTED,
@@ -118,6 +119,7 @@ enum Annotation {
       put("meaning", Annotation.MEANING).
       put("modifies", Annotation.MODIFIES).
       put("noalias", Annotation.NO_ALIAS).
+      put("nocollapse", Annotation.NO_COLLAPSE).
       put("nocompile", Annotation.NO_COMPILE).
       put("nosideeffects", Annotation.NO_SIDE_EFFECTS).
       put("override", Annotation.OVERRIDE).

--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -658,6 +658,13 @@ public final class JsDocInfoParser {
           }
           return eatUntilEOLIfNotAnnotation();
 
+        case NO_COLLAPSE:
+          if (!jsdocBuilder.recordNoCollapse()) {
+            parser.addParserWarning("msg.jsdoc.nocollapse",
+                stream.getLineno(), stream.getCharno());
+          }
+          return eatUntilEOLIfNotAnnotation();
+
         case NOT_IMPLEMENTED:
           return eatUntilEOLIfNotAnnotation();
 

--- a/src/com/google/javascript/rhino/JSDocInfo.java
+++ b/src/com/google/javascript/rhino/JSDocInfo.java
@@ -400,6 +400,7 @@ public class JSDocInfo implements Serializable {
   private static final int MASK_DICT          = 0x00800000; // @dict
   private static final int MASK_STALBEIDGEN   = 0x01000000; // @stableIdGenerator
   private static final int MASK_MAPPEDIDGEN   = 0x02000000; // @idGenerator {mapped}
+  private static final int MASK_NOCOLLAPSE    = 0x04000000; // @nocollapse
 
   // 3 bit type field stored in the top 3 bits of the most significant
   // nibble.
@@ -570,6 +571,10 @@ public class JSDocInfo implements Serializable {
 
   void setNoCompile(boolean value) {
     setFlag(value, MASK_NOCOMPILE);
+  }
+
+  void setNoCollapse(boolean value) {
+    setFlag(value, MASK_NOCOLLAPSE);
   }
 
   private void setFlag(boolean value, int mask) {
@@ -753,6 +758,14 @@ public class JSDocInfo implements Serializable {
    */
   public boolean isNoCompile() {
     return getFlag(MASK_NOCOMPILE);
+  }
+
+  /**
+   * Returns whether the {@code @nocompile} annotation is present on this
+   * {@link JSDocInfo}.
+   */
+  public boolean isNoCollapse() {
+    return getFlag(MASK_NOCOLLAPSE);
   }
 
   /**

--- a/src/com/google/javascript/rhino/JSDocInfoBuilder.java
+++ b/src/com/google/javascript/rhino/JSDocInfoBuilder.java
@@ -758,6 +758,23 @@ final public class JSDocInfoBuilder {
 
   /**
    * Records that the {@link JSDocInfo} being built should have its
+   * {@link JSDocInfo#isNoCollapse()} flag set to {@code true}.
+   *
+   * @return {@code true} if the no collapse flag was recorded and {@code false}
+   *     if it was already recorded
+   */
+  public boolean recordNoCollapse() {
+    if (!currentInfo.isNoCollapse()) {
+      currentInfo.setNoCollapse(true);
+      populated = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Records that the {@link JSDocInfo} being built should have its
    * {@link JSDocInfo#isConstructor()} flag set to {@code true}.
    *
    * @return {@code true} if the constructor was recorded and {@code false}

--- a/src/com/google/javascript/rhino/Messages.properties
+++ b/src/com/google/javascript/rhino/Messages.properties
@@ -235,6 +235,9 @@ msg.jsdoc.externs =\
 msg.jsdoc.nocompile =\
     extra @nocompile tag
 
+msg.jsdoc.nocollapse =\
+    extra @nocollapse tag
+
 msg.jsdoc.seemissing =\
     @see tag missing description
 

--- a/test/com/google/javascript/jscomp/ProcessDefinesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessDefinesTest.java
@@ -281,21 +281,17 @@ public class ProcessDefinesTest extends CompilerTestCase {
   }
 
   public void testNamespacedDefine2b() {
-    // TODO(johnlenz): We should either reject the define as invalid
-    // or replace its value.
     overrides.put("a.B", new Node(Token.TRUE));
     test("var a = { /** @define {boolean} */ B : false };",
-         "var a = {B : false};",
-         null, ProcessDefines.UNKNOWN_DEFINE_WARNING);
+         null,
+         ProcessDefines.INVALID_DEFINE_INIT_ERROR, null);
   }
 
   public void testNamespacedDefine2c() {
-    // TODO(johnlenz): We should either reject the define as invalid
-    // or replace its value.
     overrides.put("a.B", new Node(Token.TRUE));
     test("var a = { /** @define {boolean} */ get B() { return false } };",
-      "var a = {get B() { return false } };",
-      null, ProcessDefines.UNKNOWN_DEFINE_WARNING);
+      null,
+      ProcessDefines.INVALID_DEFINE_INIT_ERROR, null);
   }
 
   public void testNamespacedDefine3() {

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -4066,6 +4066,11 @@ public class JsDocInfoParserTest extends BaseJSTypeTestCase {
         true, "Bad type annotation. type not recognized due to syntax error");
   }
 
+  public void testParseDuplicateNoCollapse() throws Exception {
+    parse("@nocollapse \n * @nocollapse \n * @type {Object}*/",
+        "extra @nocollapse tag");
+  }
+
   /**
    * Asserts that a documentation field exists on the given marker.
    *


### PR DESCRIPTION
This isn't ready to merge yet, but since this is a significant change.  Would someone be willing to test this internal to Google? 

This adds the `@nocollapse` annotation which will prevent a property from being completely collapsed. The annotation does NOT block sub-properties from being collapsed.

Example:

```JavaScript
var a = {};
/** @nocollapse */
a.b = {}; // this property will NOT be collapsed
a.b.c = {}; //this property will still be collapsed
```

There are multiple variations using the `@nocollapse` annotation. The unit tests show comprehensive examples.