### PR TITLE
Source map in flag

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -578,6 +578,7 @@ public class CommandLineRunner extends
 
     @Argument
     private List<String> arguments = new ArrayList<>();
+    private CmdLineParser parser;
 
     private static final Map<String, CompilationLevel> COMPILATION_LEVEL_MAP =
         ImmutableMap.of(
@@ -592,11 +593,14 @@ public class CommandLineRunner extends
             "ADVANCED_OPTIMIZATIONS",
             CompilationLevel.ADVANCED_OPTIMIZATIONS);
 
+    Flags() {
+      parser = new CmdLineParser(this);
+    }
+
     /**
      * Parse the given args list.
      */
     private void parse(List<String> args) throws CmdLineException {
-      CmdLineParser parser = new CmdLineParser(this);
       parser.parseArgument(args.toArray(new String[] {}));
 
       compilationLevelParsed =
@@ -609,14 +613,13 @@ public class CommandLineRunner extends
     }
 
     private void printUsage(PrintStream ps) {
-      CmdLineParser p = new CmdLineParser(this);
-      p.printUsage(new OutputStreamWriter(ps, UTF_8), null, OptionHandlerFilter.ALL);
+      parser.printUsage(new OutputStreamWriter(ps, UTF_8), null, OptionHandlerFilter.ALL);
       ps.flush();
     }
 
     private void printShortUsageAfterErrors(PrintStream ps) {
       ps.print("Sample usage: ");
-      ps.println((new CmdLineParser(this)).printExample(OptionHandlerFilter.PUBLIC, null));
+      ps.println(parser.printExample(OptionHandlerFilter.PUBLIC, null));
       ps.println("Run with --help for all options and details");
       ps.flush();
     }
@@ -646,12 +649,11 @@ public class CommandLineRunner extends
       patterns.addAll(arguments);
       List<String> allJsInputs = findJsFiles(patterns);
       if (!patterns.isEmpty() && allJsInputs.isEmpty()) {
-        throw new CmdLineException(new CmdLineParser(this), "No inputs matched");
+        throw new CmdLineException(parser, "No inputs matched");
       }
       return allJsInputs;
     }
 
-    @SuppressWarnings("deprecation")
     List<SourceMap.LocationMapping> getSourceMapLocationMappings() throws CmdLineException {
       ImmutableList.Builder<LocationMapping> locationMappings = ImmutableList.builder();
 
@@ -659,7 +661,7 @@ public class CommandLineRunner extends
       for (String locationMapping : sourceMapLocationMapping) {
         List<String> parts = splitter.splitToList(locationMapping);
         if (parts.size() != 2) {
-          throw new CmdLineException(
+          throw new CmdLineException(parser,
             "Bad value for --source_map_location_mapping: " +
             ImmutableList.of(sourceMapLocationMapping));
         }

--- a/src/com/google/javascript/jscomp/SourceMapInput.java
+++ b/src/com/google/javascript/jscomp/SourceMapInput.java
@@ -32,7 +32,7 @@ public class SourceMapInput {
       Logger.getLogger(SourceMapInput.class.getName());
 
   private SourceFile sourceFile;
-  private SourceMapConsumerV3 parsedSourceMap = null;
+  private volatile SourceMapConsumerV3 parsedSourceMap = null;
 
   public SourceMapInput(SourceFile sourceFile) {
     this.sourceFile = sourceFile;

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -32,6 +32,7 @@ import com.google.javascript.jscomp.AbstractCommandLineRunner.FlagUsageException
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.SourceMap.LocationMapping;
 import com.google.javascript.rhino.Node;
+
 import junit.framework.TestCase;
 
 import java.io.ByteArrayOutputStream;
@@ -974,7 +975,7 @@ public class CommandLineRunnerTest extends TestCase {
                 .toString());
   }
 
-  public void testSourceMapLocationsTranslations3() throws IOException {
+  public void testSourceMapLocationsTranslations3() {
     // Prevents this from trying to load externs.zip
     args.add("--use_only_custom_externs=true");
 
@@ -987,6 +988,22 @@ public class CommandLineRunnerTest extends TestCase {
     assertThat(runner.shouldRunCompiler()).isFalse();
     assertThat(new String(errReader.toByteArray(), UTF_8))
         .contains("Bad value for --source_map_location_mapping");
+  }
+
+  public void testSourceMapInputs() throws Exception {
+    args.add("--js_output_file");
+    args.add("/path/to/out.js");
+    args.add("--source_map_input=input1|input1.sourcemap");
+    args.add("--source_map_input=input2|input2.sourcemap");
+    testSame("var x = 3;");
+
+    Map<String, SourceMapInput> inputMaps = lastCompiler.getOptions()
+        .inputSourceMaps;
+    assertThat(inputMaps).hasSize(2);
+    assertThat(inputMaps.get("input1").getOriginalPath())
+        .isEqualTo("input1.sourcemap");
+    assertThat(inputMaps.get("input2").getOriginalPath())
+        .isEqualTo("input2.sourcemap");
   }
 
   public void testModuleWrapperBaseNameExpansion() throws Exception {


### PR DESCRIPTION
This allows specifying a pipe separated source map
mapping, e.g. `myinput.js|mysourcemap.sourcemap`.

Fixes #115.