### PR TITLE
make HTMLOptionsCollection non-nullable

### DIFF
--- a/externs/w3c_dom2.js
+++ b/externs/w3c_dom2.js
@@ -728,7 +728,7 @@ HTMLSelectElement.prototype.length;
 HTMLSelectElement.prototype.form;
 
 /**
- * @type {HTMLOptionsCollection}
+ * @type {!HTMLOptionsCollection}
  * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-30606413
  */
 HTMLSelectElement.prototype.options;


### PR DESCRIPTION
[Issue #840] Make HTMLOptionsCollection non-nullable in externs for HTMLSelectElement.options.