### PR TITLE
Fix angular.bind jsdoc to return the actual function type

### DIFF
--- a/contrib/externs/angular-1.3.js
+++ b/contrib/externs/angular-1.3.js
@@ -58,10 +58,14 @@ var JQLiteSelector;
 var angular = {};
 
 /**
- * @param {Object} self
- * @param {Function} fn
- * @param {...*} args
- * @return {Function}
+ * @param {T} self Specifies the object which this should point to when the
+ *     function is run.
+ * @param {?function(this:T, ...)} fn A function to partially apply.
+ * @return {!Function} A partially-applied form of the function bind() was
+ *     invoked as a method of.
+ * @param {...*} args Additional arguments that are partially applied to the
+ *     function.
+ * @template T
  */
 angular.bind = function(self, fn, args) {};
 


### PR DESCRIPTION
Angular.bind was not returning the actual type of the passed function but
'Function'. This issue was addressed by using the jsdoc from goog.bind.