### PR TITLE
Enable the use_types_for_optmization flag by default

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -359,12 +359,12 @@ public class CommandLineRunner extends
     private String compilationLevel = "SIMPLE";
     private CompilationLevel compilationLevelParsed = null;
 
-    @Option(name = "--use_types_for_optimization",
+    @Option(name = "--disable_type_optimizations",
         hidden = true,
-        usage = "Experimental: perform additional optimizations " +
-        "based on available information. Inaccurate type annotations " +
+        usage = "Disable the optimizations " +
+        "based on available type information. Inaccurate type annotations " +
         "may result in incorrect results.")
-    private boolean useTypesForOptimization = false;
+    private boolean disableTypeOptimizations = false;
 
     @Option(name = "--warning_level",
         aliases = {"-W"},
@@ -1122,7 +1122,7 @@ public class CommandLineRunner extends
       level.setDebugOptionsForCompilationLevel(options);
     }
 
-    if (flags.useTypesForOptimization) {
+    if (!flags.disableTypeOptimizations) {
       level.setTypeBasedOptimizationOptions(options);
     }
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -359,12 +359,13 @@ public class CommandLineRunner extends
     private String compilationLevel = "SIMPLE";
     private CompilationLevel compilationLevelParsed = null;
 
-    @Option(name = "--disable_type_optimizations",
+    @Option(name = "--use_types_for_optimization",
         hidden = true,
-        usage = "Disable the optimizations " +
+        handler = BooleanOptionHandler.class,
+        usage = "Enable or disable the optimizations " +
         "based on available type information. Inaccurate type annotations " +
         "may result in incorrect results.")
-    private boolean disableTypeOptimizations = false;
+    private boolean useTypesForOptimization = true;
 
     @Option(name = "--warning_level",
         aliases = {"-W"},
@@ -1122,7 +1123,7 @@ public class CommandLineRunner extends
       level.setDebugOptionsForCompilationLevel(options);
     }
 
-    if (!flags.disableTypeOptimizations) {
+    if (flags.useTypesForOptimization) {
       level.setTypeBasedOptimizationOptions(options);
     }
 

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -247,7 +247,6 @@ public class CommandLineRunnerTest extends TestCase {
 
   public void testTypedAdvanced() {
     args.add("--compilation_level=ADVANCED_OPTIMIZATIONS");
-    args.add("--use_types_for_optimization");
     test(
         "/** @constructor */\n" +
         "function Foo() {}\n" +
@@ -258,6 +257,26 @@ public class CommandLineRunnerTest extends TestCase {
         "new Foo().handle1(1, 2);\n" +
         "new Bar().handle1(1, 2);\n",
         "alert(2)");
+  }
+
+  public void testTypedDisabledAdvanced() {
+    args.add("--compilation_level=ADVANCED_OPTIMIZATIONS");
+    args.add("--disable_type_optimizations");
+    test(
+        "/** @constructor */\n" +
+            "function Foo() {}\n" +
+            "Foo.prototype.handle1 = function(x, y) { alert(y); };\n" +
+            "/** @constructor */\n" +
+            "function Bar() {}\n" +
+            "Bar.prototype.handle1 = function(x, y) {};\n" +
+            "new Foo().handle1(1, 2);\n" +
+            "new Bar().handle1(1, 2);\n",
+        "function a() {}\n" +
+            "a.prototype.a = function(d, c) { alert(c); };\n" +
+            "function b() {}\n" +
+            "b.prototype.a = function() {};\n" +
+            "(new a).a(1, 2);\n" +
+            "(new b).a(1, 2);");
   }
 
   public void testTypeCheckingOnWithVerbose() {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -261,7 +261,7 @@ public class CommandLineRunnerTest extends TestCase {
 
   public void testTypedDisabledAdvanced() {
     args.add("--compilation_level=ADVANCED_OPTIMIZATIONS");
-    args.add("--disable_type_optimizations");
+    args.add("--use_types_for_optimization=false");
     test(
         "/** @constructor */\n"
         + "function Foo() {}\n"

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -263,20 +263,20 @@ public class CommandLineRunnerTest extends TestCase {
     args.add("--compilation_level=ADVANCED_OPTIMIZATIONS");
     args.add("--disable_type_optimizations");
     test(
-        "/** @constructor */\n" +
-            "function Foo() {}\n" +
-            "Foo.prototype.handle1 = function(x, y) { alert(y); };\n" +
-            "/** @constructor */\n" +
-            "function Bar() {}\n" +
-            "Bar.prototype.handle1 = function(x, y) {};\n" +
-            "new Foo().handle1(1, 2);\n" +
-            "new Bar().handle1(1, 2);\n",
-        "function a() {}\n" +
-            "a.prototype.a = function(d, c) { alert(c); };\n" +
-            "function b() {}\n" +
-            "b.prototype.a = function() {};\n" +
-            "(new a).a(1, 2);\n" +
-            "(new b).a(1, 2);");
+        "/** @constructor */\n"
+        + "function Foo() {}\n"
+        +"Foo.prototype.handle1 = function(x, y) { alert(y); };\n"
+        + "/** @constructor */\n"
+        + "function Bar() {}\n"
+        + "Bar.prototype.handle1 = function(x, y) {};\n"
+        + "new Foo().handle1(1, 2);\n"
+        + "new Bar().handle1(1, 2);\n",
+        "function a() {}\n"
+        + "a.prototype.a = function(d, c) { alert(c); };\n"
+        + "function b() {}\n"
+        + "b.prototype.a = function() {};\n"
+        + "(new a).a(1, 2);\n"
+        + "(new b).a(1, 2);");
   }
 
   public void testTypeCheckingOnWithVerbose() {


### PR DESCRIPTION
Enables type optimizations by default. Fixes #812.

Based off of the discussion at https://groups.google.com/forum/#!topic/closure-compiler-discuss/JPzrMiD_6dk

Question: Should we have a temporary warning or banner for the compiler when this would take effect?

I plan to update the FAQ and any other documentation pieces about this. There are also a few stackoverflow posts I'll edit. Someone should probably change the web service options to match as well (after release).