### PR TITLE
Obfuscation exclusions

### DIFF
--- a/src/com/google/javascript/jscomp/RenameProperties.java
+++ b/src/com/google/javascript/jscomp/RenameProperties.java
@@ -289,7 +289,9 @@ class RenameProperties implements CompilerPass {
       String prevName = prevUsedPropertyMap.lookupNewName(prop.oldName);
       if (!generatePseudoNames && prevName != null) {
         // We can reuse prevName if it's not reserved.
-        if (reservedNames.contains(prevName)) {
+      	// HOWEVER, if prevName is an "exclude obfuscation" mapping (matches oldName),
+      	// retain it, to ensure the exclusion remains:
+        if (reservedNames.contains(prevName) && !prevName.equals(prop.oldName)) {
           continue;
         }
 


### PR DESCRIPTION
Allowing exclusion of properties from obfuscation using "old:old"
mapping. Wasn't working when the same property existed elsewhere as a
quoted string.

We use input renaming maps to preserve names of a large number of 'schema' objects which are exchanged elsewhere.  We supply e.g. "manifest:manifest" to ensure that particular object member is never renamed.

However in rare cases it ignores this, and you see "manifest:xyz" in the output. This fixes it.