### PR TITLE
Deprecate the @expose annotation

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -82,19 +82,18 @@ public class DiagnosticGroups {
   // If a group is suppressible on a per-file basis, it should be added
   // to parser/ParserConfig.properties
   static final String DIAGNOSTIC_GROUP_NAMES =
-      "accessControls, ambiguousFunctionDecl, checkEventfulObjectDisposal, " +
-      "checkRegExp, checkStructDictInheritance, checkTypes, checkVars, " +
-      "conformanceViolations, " +
-      "const, constantProperty, deprecated, duplicateMessage, es3, " +
-      "es5Strict, externsValidation, fileoverviewTags, globalThis, " +
-      "inferredConstCheck, " +
-      "internetExplorerChecks, invalidCasts, misplacedTypeAnnotation, " +
-      "missingGetCssName, missingProperties, " +
-      "missingProvide, missingRequire, missingReturn," +
-      "newCheckTypes, nonStandardJsDocs, reportUnknownTypes, suspiciousCode, " +
-      "strictModuleDepCheck, typeInvalidation, " +
-      "undefinedNames, undefinedVars, unknownDefines, uselessCode, " +
-      "useOfGoogBase, visibility";
+      "accessControls, ambiguousFunctionDecl, checkEventfulObjectDisposal, "
+      + "checkRegExp, checkStructDictInheritance, checkTypes, checkVars, "
+      + "conformanceViolations, const, constantProperty, deprecated, "
+      + "deprecatedAnnotations, duplicateMessage, es3, "
+      + "es5Strict, externsValidation, fileoverviewTags, globalThis, "
+      + "inferredConstCheck, internetExplorerChecks, invalidCasts, "
+      + "misplacedTypeAnnotation, missingGetCssName, missingProperties, "
+      + "missingProvide, missingRequire, missingReturn,"
+      + "newCheckTypes, nonStandardJsDocs, reportUnknownTypes, suspiciousCode, "
+      + "strictModuleDepCheck, typeInvalidation, "
+      + "undefinedNames, undefinedVars, unknownDefines, uselessCode, "
+      + "useOfGoogBase, visibility";
 
   public static final DiagnosticGroup GLOBAL_THIS =
       DiagnosticGroups.registerGroup("globalThis",
@@ -407,6 +406,10 @@ public class DiagnosticGroups {
           CheckSuspiciousCode.SUSPICIOUS_COMPARISON_WITH_NAN,
           CheckSuspiciousCode.SUSPICIOUS_IN_OPERATOR,
           CheckSuspiciousCode.SUSPICIOUS_INSTANCEOF_LEFT_OPERAND);
+
+  public static final DiagnosticGroup DEPRECATED_ANNOTATIONS =
+      DiagnosticGroups.registerGroup("deprecatedAnnotations",
+          RhinoErrorReporter.ANNOTATION_DEPRECATED);
 
   // These checks are not intended to be enabled as errors. It is
   // recommended that you think of them as "linter" warnings that

--- a/src/com/google/javascript/jscomp/RhinoErrorReporter.java
+++ b/src/com/google/javascript/jscomp/RhinoErrorReporter.java
@@ -90,6 +90,9 @@ class RhinoErrorReporter {
           "{0}. Use --language_in=ECMASCRIPT6 or ECMASCRIPT6_STRICT " +
           "to enable ES6 features.");
 
+  static final DiagnosticType ANNOTATION_DEPRECATED =
+      DiagnosticType.warning("JSC_ANNOTATION_DEPRECATED", "{0}");
+
   // A map of Rhino messages to their DiagnosticType.
   private final Map<Pattern, DiagnosticType> typeMap;
 
@@ -161,6 +164,10 @@ class RhinoErrorReporter {
 
         .put(Pattern.compile("^this language feature is only supported in es6 mode.*"),
             ES6_FEATURE)
+
+        // Deprecated annotations
+        .put(Pattern.compile("^The @[a-z]+ annotation is deprecated\\..*"),
+            ANNOTATION_DEPRECATED)
 
         .build();
   }

--- a/src/com/google/javascript/jscomp/parsing/IRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/IRFactory.java
@@ -196,6 +196,9 @@ class IRFactory {
 
   static final String UNDEFINED_LABEL = "undefined label \"%s\"";
 
+  static final String ANNOTATION_DEPRECATED =
+      "The %s annotation is deprecated.%s";
+
   private final String sourceString;
   private final List<Integer> newlines;
   private final StaticSourceFile sourceFile;
@@ -470,6 +473,24 @@ class IRFactory {
     validateTypeAnnotations(n);
     validateFunctionJsDoc(n);
     validateMsgJsDoc(n);
+    validateDeprecatedJsDoc(n);
+  }
+
+  /**
+   * Checks that deprecated annotations such as @expose are not present
+   */
+  private void validateDeprecatedJsDoc(Node n) {
+    JSDocInfo info = n.getJSDocInfo();
+    if (info == null) {
+      return;
+    }
+    if (info.isExpose()) {
+      errorReporter.warning(
+          String.format(ANNOTATION_DEPRECATED, "@expose",
+              " Use @nocollapse or @export instead."),
+          sourceName,
+          n.getLineno(), n.getCharno());
+    }
   }
 
   /**

--- a/test/com/google/javascript/jscomp/CheckConformanceTest.java
+++ b/test/com/google/javascript/jscomp/CheckConformanceTest.java
@@ -831,6 +831,7 @@ public final class CheckConformanceTest extends CompilerTestCase {
         "  error_message: 'BanExpose Message'\n" +
         "}";
 
+    setExpectParseWarningsThisTest();
     testSame(
         EXTERNS,
         "/** @expose */ var x;",

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -376,22 +376,26 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilationLevel.ADVANCED_OPTIMIZATIONS
         .setOptionsForCompilationLevel(options);
     test(options,
-         "var x = {eeny: 1, /** @expose */ meeny: 2};" +
-         "/** @constructor */ var Foo = function() {};" +
-         "/** @expose */  Foo.prototype.miny = 3;" +
-         "Foo.prototype.moe = 4;" +
-         "/** @expose */  Foo.prototype.tiger;" +
-         "function moe(a, b) { return a.meeny + b.miny + a.tiger; }" +
-         "window['x'] = x;" +
-         "window['Foo'] = Foo;" +
-         "window['moe'] = moe;",
-         "function a(){}" +
-         "a.prototype.miny=3;" +
-         "window.x={a:1,meeny:2};" +
-         "window.Foo=a;" +
-         "window.moe=function(b,c){" +
-         "  return b.meeny+c.miny+b.tiger" +
-         "}");
+        new String[] {"var x = {eeny: 1, /** @expose */ meeny: 2};" +
+            "/** @constructor */ var Foo = function() {};" +
+            "/** @expose */  Foo.prototype.miny = 3;" +
+            "Foo.prototype.moe = 4;" +
+            "/** @expose */  Foo.prototype.tiger;" +
+            "function moe(a, b) { return a.meeny + b.miny + a.tiger; }" +
+            "window['x'] = x;" +
+            "window['Foo'] = Foo;" +
+            "window['moe'] = moe;"},
+        new String[] {"function a(){}" +
+            "a.prototype.miny=3;" +
+            "window.x={a:1,meeny:2};" +
+            "window.Foo=a;" +
+            "window.moe=function(b,c){" +
+            "  return b.meeny+c.miny+b.tiger" +
+            "}"},
+        new DiagnosticType[]{
+            RhinoErrorReporter.PARSE_ERROR,
+            RhinoErrorReporter.PARSE_ERROR,
+            RhinoErrorReporter.PARSE_ERROR});
   }
 
   public void testCheckSymbolsOff() {

--- a/test/com/google/javascript/jscomp/NormalizeTest.java
+++ b/test/com/google/javascript/jscomp/NormalizeTest.java
@@ -461,11 +461,13 @@ public final class NormalizeTest extends CompilerTestCase {
   }
 
   public void testExposeSimple() {
+    setExpectParseWarningsThisTest();
     test("var x = {}; /** @expose */ x.y = 3; x.y = 5;",
          "var x = {}; x['y'] = 3; x['y'] = 5;");
   }
 
   public void testExposeComplex() {
+    setExpectParseWarningsThisTest();
     test(
         "var x = {/** @expose */ a: 1, b: 2};"
         + "x.a = 3; /** @expose */ x.b = 5;",

--- a/test/com/google/javascript/jscomp/RhinoErrorReporterTest.java
+++ b/test/com/google/javascript/jscomp/RhinoErrorReporterTest.java
@@ -100,6 +100,19 @@ public final class RhinoErrorReporterTest extends TestCase {
     assertEquals(10, error.getCharno());
   }
 
+  public void testAnnotationDeprecated() throws Exception {
+    String message =
+        "The @expose annotation is deprecated. Use @nocollapse or @export "
+        + "instead.";
+    JSError error = assertWarning(
+        "/** @expose */ var x = 1;",
+        RhinoErrorReporter.ANNOTATION_DEPRECATED,
+        message);
+
+    assertEquals(1, error.getLineNumber());
+    assertEquals(15, error.getCharno());
+  }
+
   /**
    * Verifies that the compiler emits an error for the given code.
    */

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -65,6 +65,9 @@ public final class NewParserTest extends BaseJSTypeTestCase {
       "for legacy reasons. Removing this from your code is " +
       "safe for all browsers currently in use.";
 
+  private static final String ANNOTATION_DEPRECATED_WARNING =
+      "The %s annotation is deprecated.%s";
+
   private Config.LanguageMode mode;
   private boolean isIdeMode = false;
 
@@ -2561,6 +2564,12 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     long stop = System.currentTimeMillis();
 
     assertThat(stop - start).named("runtime").isLessThan(5000L);
+  }
+
+  public void testExposeDeprecated() {
+    parseWarning("/** @expose */ var x = 0;",
+        String.format(ANNOTATION_DEPRECATED_WARNING, "@expose",
+            " Use @nocollapse or @export instead."));
   }
 
   private Node script(Node stmt) {


### PR DESCRIPTION
With `@nocollapse` now supported, `@expose` can be deprecated. The compiler will only warn on the first occurrence of `@expose`.

I currently have this as part of the `nonStandardJsDocs` diagnostic group. I'm not completely convinced that's the correct place for it.