### PR TITLE
Add interface for google.visualization.events.addOneTimeListener

### DIFF
--- a/contrib/externs/google_visualization_api.js
+++ b/contrib/externs/google_visualization_api.js
@@ -577,6 +577,16 @@ google.visualization.events.addListener =
 
 
 /**
+ * @param {!Object} eventSource
+ * @param {string} eventName
+ * @param {!Function} eventHandler
+ * @return {!Object}
+ */
+google.visualization.events.addOneTimeListener =
+    function(eventSource, eventName, eventHandler) {};
+
+
+/**
  * @param {Object} listener
  * @return {undefined}
  */


### PR DESCRIPTION
Filling in missing API call for google.visualization.events.addOneTimeListener in the google_visualization_api.js externs file.