### PR TITLE
Add Navigator.prototype.msMaxTouchPoints property in IE extern

### DIFF
--- a/externs/ie_dom.js
+++ b/externs/ie_dom.js
@@ -1371,6 +1371,12 @@ XDomainRequest.prototype.contentType;
 Navigator.prototype.browserLanguage;
 
 /**
+ * @type {number}
+ * @see https://msdn.microsoft.com/en-us/library/ie/hh772144(v=vs.85).aspx
+ */
+Navigator.prototype.msMaxTouchPoints;
+
+/**
  * @type {boolean}
  * @see http://blogs.msdn.com/b/ie/archive/2011/09/20/touch-input-for-ie10-and-metro-style-apps.aspx
  */


### PR DESCRIPTION
Note: as of Internet Explorer 11, this property is deprecated and
Navigator.prototype.maxTouchPoints should be used instead (defined in
contrib/externs/w3c_pointer_events.js).