### PR TITLE
Fix externs for FontFace constructor

### DIFF
--- a/externs/w3c_css.js
+++ b/externs/w3c_css.js
@@ -2363,7 +2363,7 @@ var FontFaceDescriptors;
 /**
  * @constructor
  * @param {string} fontFamily
- * @param {string} source
+ * @param {(string|ArrayBuffer|ArrayBufferView)} source
  * @param {!FontFaceDescriptors} descriptors
  * @see http://dev.w3.org/csswg/css-font-loading/#font-face-constructor
  */


### PR DESCRIPTION
According to the W3C CSS font loading specification (http://dev.w3.org/csswg/css-font-loading/#font-face-constructor) the FontFace constructor takes three types: `string`, `ArrayBuffer`, and `ArrayBufferView`. The current version of the w3c_css externs file only lists `string`. This pull request adds `ArrayBuffer` and `ArrayBufferView` so it follows the specification.