### PR TITLE
[WIP] Improved @export support

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -388,11 +388,12 @@ public class CommandLineRunner extends
         usage = "Enable debugging options")
     private boolean debug = false;
 
-    @Option(name = "--generate_exports",
+    @Option(name = "--exports_mode",
         hidden = true,
-        handler = BooleanOptionHandler.class,
-        usage = "Generates export code for those marked with @export")
-    private boolean generateExports = false;
+        usage = "Specifies the method to generates export code for those "
+            + "marked with @export. Options: OFF, SHADOW, NO_RENAME")
+    private CompilerOptions.ExportsMode exportsMode =
+        CompilerOptions.ExportsMode.OFF;
 
     @Option(name = "--export_local_property_definitions",
         hidden = true,
@@ -1138,9 +1139,7 @@ public class CommandLineRunner extends
       level.setTypeBasedOptimizationOptions(options);
     }
 
-    if (flags.generateExports) {
-      options.setGenerateExports(flags.generateExports);
-    }
+    options.setExportsMode(flags.exportsMode);
 
     if (flags.exportLocalPropertyDefinitions) {
       options.setExportLocalPropertyDefinitions(true);

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -760,7 +760,7 @@ public class CompilerOptions implements Serializable, Cloneable {
 
   public boolean checksOnly;
 
-  public boolean generateExports;
+  public ExportsMode exportsMode;
 
   boolean exportLocalPropertyDefinitions;
 
@@ -1098,7 +1098,7 @@ public class CompilerOptions implements Serializable, Cloneable {
     appNameStr = "";
     recordFunctionInformation = false;
     checksOnly = false;
-    generateExports = false;
+    exportsMode = ExportsMode.OFF;
     exportLocalPropertyDefinitions = false;
     cssRenamingMap = null;
     cssRenamingWhitelist = null;
@@ -1534,8 +1534,8 @@ public class CompilerOptions implements Serializable, Cloneable {
     this.checksOnly = checksOnly;
   }
 
-  public void setGenerateExports(boolean generateExports) {
-    this.generateExports = generateExports;
+  public void setExportsMode(ExportsMode exportsMode) {
+    this.exportsMode = exportsMode;
   }
 
   public void setExportLocalPropertyDefinitions(boolean export) {
@@ -2467,6 +2467,22 @@ public class CompilerOptions implements Serializable, Cloneable {
 
     public boolean shouldStrip() {
       return this == STRIP;
+    }
+  }
+
+  public static enum ExportsMode {
+    // Do not generate exports
+    OFF,
+
+    // Generate exports by shadowing properties and variables
+    SHADOW,
+
+    // Export by blocking renaming and creating sink values to prevent
+    // dead code elimination
+    NO_RENAME;
+
+    public boolean isOn() {
+      return this != OFF;
     }
   }
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -288,8 +288,8 @@ public final class DefaultPassConfig extends PassConfig {
     // The following passes are more like "preprocessor" passes.
     // It's important that they run before most checking passes.
     // Perhaps this method should be renamed?
-    if (options.generateExports) {
-      checks.add(generateExports);
+    if (options.exportsMode == CompilerOptions.ExportsMode.SHADOW) {
+      checks.add(shadowExports);
     }
 
     if (options.exportTestFunctions) {
@@ -930,14 +930,14 @@ public final class DefaultPassConfig extends PassConfig {
     }
   };
 
-  private static final DiagnosticType GENERATE_EXPORTS_ERROR =
+  private static final DiagnosticType SHADOW_EXPORTS_ERROR =
       DiagnosticType.error(
-          "JSC_GENERATE_EXPORTS_ERROR",
-          "Exports can only be generated if export symbol/property " +
+          "JSC_SHADOW_EXPORTS_ERROR",
+          "Shadowed exports can only be generated if export symbol/property " +
           "functions are set.");
 
   /** Generates exports for @export annotations. */
-  private final PassFactory generateExports = new PassFactory("generateExports", true) {
+  private final PassFactory shadowExports = new PassFactory("shadowExports", true) {
     @Override
     protected CompilerPass create(AbstractCompiler compiler) {
       if (options.removeUnusedPrototypePropertiesInExterns
@@ -949,12 +949,12 @@ public final class DefaultPassConfig extends PassConfig {
       CodingConvention convention = compiler.getCodingConvention();
       if (convention.getExportSymbolFunction() != null &&
           convention.getExportPropertyFunction() != null) {
-        return new GenerateExports(compiler,
+        return new ShadowExports(compiler,
             options.exportLocalPropertyDefinitions,
             convention.getExportSymbolFunction(),
             convention.getExportPropertyFunction());
       } else {
-        return new ErrorPass(compiler, GENERATE_EXPORTS_ERROR);
+        return new ErrorPass(compiler, SHADOW_EXPORTS_ERROR);
       }
     }
   };
@@ -970,7 +970,7 @@ public final class DefaultPassConfig extends PassConfig {
             convention.getExportSymbolFunction(),
             convention.getExportPropertyFunction());
       } else {
-        return new ErrorPass(compiler, GENERATE_EXPORTS_ERROR);
+        return new ErrorPass(compiler, SHADOW_EXPORTS_ERROR);
       }
     }
   };

--- a/src/com/google/javascript/jscomp/ShadowExports.java
+++ b/src/com/google/javascript/jscomp/ShadowExports.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * Generates goog.exportSymbol/goog.exportProperty for the @export annotation.
  *
  */
-class GenerateExports implements CompilerPass {
+class ShadowExports implements CompilerPass {
 
   private static final String PROTOTYPE_PROPERTY = "prototype";
 
@@ -46,7 +46,7 @@ class GenerateExports implements CompilerPass {
    * @param exportSymbolFunction function used for exporting symbols.
    * @param exportPropertyFunction function used for exporting property names.
    */
-  GenerateExports(
+  ShadowExports(
       AbstractCompiler compiler,
       boolean allowNonGlobalExports,
       String exportSymbolFunction,

--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -80,7 +80,7 @@ public final class CompileTask
   private boolean manageDependencies;
   private boolean prettyPrint;
   private boolean printInputDelimiter;
-  private boolean generateExports;
+  private CompilerOptions.ExportsMode exportsMode;
   private boolean replaceProperties;
   private boolean forceRecompile;
   private String replacePropertiesPrefix;
@@ -106,7 +106,7 @@ public final class CompileTask
     this.manageDependencies = false;
     this.prettyPrint = false;
     this.printInputDelimiter = false;
-    this.generateExports = false;
+    this.exportsMode = CompilerOptions.ExportsMode.OFF;
     this.replaceProperties = false;
     this.forceRecompile = false;
     this.replacePropertiesPrefix = "closure.define.";
@@ -278,8 +278,8 @@ public final class CompileTask
   /**
    * Set generateExports option
    */
-  public void setGenerateExports(boolean generateExports) {
-   this.generateExports = generateExports;
+  public void setExportsMode(CompilerOptions.ExportsMode exportsMode) {
+   this.exportsMode = exportsMode;
   }
 
   /**
@@ -406,7 +406,7 @@ public final class CompileTask
 
     options.setPrettyPrint(this.prettyPrint);
     options.setPrintInputDelimiter(this.printInputDelimiter);
-    options.setGenerateExports(this.generateExports);
+    options.setExportsMode(this.exportsMode);
 
     options.setLanguageIn(this.languageIn);
     options.setOutputCharset(this.outputEncoding);

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1194,8 +1194,8 @@ public final class CommandLineRunnerTest extends TestCase {
       CheckAccessControls.DEPRECATED_NAME);
   }
 
-  public void testGenerateExports() {
-    args.add("--generate_exports=true");
+  public void testExportsModeShadow() {
+    args.add("--exports_mode=SHADOW");
     test("/** @export */ foo.prototype.x = function() {};",
         "foo.prototype.x=function(){};" +
         "goog.exportSymbol(\"foo.prototype.x\",foo.prototype.x);");

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -671,7 +671,7 @@ public final class CompilerTest extends TestCase {
     CompilerOptions options = new CompilerOptions();
     options.setClosurePass(true);
     options.setVariableRenaming(VariableRenamingPolicy.ALL);
-    options.setGenerateExports(true);
+    options.setExportsMode(CompilerOptions.ExportsMode.SHADOW);
 
     String js = "var goog; /** @export */ var a={};";
     List<SourceFile> inputs = ImmutableList.of(

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -104,7 +104,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setCollapseProperties(true);
     options.setInlineVariables(true);
-    options.setGenerateExports(true);
+    options.setExportsMode(CompilerOptions.ExportsMode.SHADOW);
     test(
         options,
         CLOSURE_BOILERPLATE + "/** @export */ goog.CONSTANT = 1;"
@@ -114,7 +114,7 @@ public final class IntegrationTest extends IntegrationTestCase {
 
   public void testBug2410122() {
     CompilerOptions options = createCompilerOptions();
-    options.setGenerateExports(true);
+    options.setExportsMode(CompilerOptions.ExportsMode.SHADOW);
     options.setClosurePass(true);
     test(
         options,
@@ -842,7 +842,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setCheckSuspiciousCode(true);
     options.setCheckProvides(CheckLevel.ERROR);
-    options.setGenerateExports(true);
+    options.setExportsMode(CompilerOptions.ExportsMode.SHADOW);
     options.exportTestFunctions = true;
     options.setClosurePass(true);
     options.setCheckMissingGetCssNameLevel(CheckLevel.ERROR);
@@ -3084,7 +3084,7 @@ public final class IntegrationTest extends IntegrationTestCase {
         "alert((new function(){this.a = 1}).a + " +
             "(new function(){this.a = 1}).a);");
 
-    options.setGenerateExports(true);
+    options.setExportsMode(CompilerOptions.ExportsMode.SHADOW);
 
     // exports enabled, but not local exports
     test(options,

--- a/test/com/google/javascript/jscomp/ShadowExportsTest.java
+++ b/test/com/google/javascript/jscomp/ShadowExportsTest.java
@@ -21,7 +21,7 @@ package com.google.javascript.jscomp;
  * Generate exports unit test.
  *
  */
-public final class GenerateExportsTest extends CompilerTestCase {
+public final class ShadowExportsTest extends CompilerTestCase {
 
   private static final String EXTERNS =
       "function google_exportSymbol(a, b) {}; " +
@@ -29,14 +29,14 @@ public final class GenerateExportsTest extends CompilerTestCase {
 
   private boolean allowNonGlobalExports = true;
 
-  public GenerateExportsTest() {
+  public ShadowExportsTest() {
     super(EXTERNS);
     compareJsDoc = false;
   }
 
   @Override
   protected CompilerPass getProcessor(Compiler compiler) {
-    return new GenerateExports(compiler, allowNonGlobalExports,
+    return new ShadowExports(compiler, allowNonGlobalExports,
         "google_exportSymbol", "goog.exportProperty");
   }
 


### PR DESCRIPTION
The only method for exporting code using `@export` is through shadowing. Ideally, we would also have a method to export that simply doesn't rename.

Past discussions related to this:

 * https://code.google.com/p/closure-compiler/issues/detail?id=50
 * https://github.com/google/closure-compiler/issues/636 - See the end of the discussion