### PR TITLE
Allow FormData::append to accept optional filename parameter

### DIFF
--- a/externs/w3c_xml.js
+++ b/externs/w3c_xml.js
@@ -413,5 +413,6 @@ function FormData(opt_form) {}
 /**
  * @param {string} name
  * @param {Blob|string} value
+ * @param {string=} opt_filename
  */
-FormData.prototype.append = function(name, value) {};
+FormData.prototype.append = function(name, value, opt_filename) {};


### PR DESCRIPTION
Align FormData::append with the updated FormData interface, as implemented in modern browsers. See: https://dvcs.w3.org/hg/xhr/raw-file/default/xhr-1/Overview.html#interface-formdata