### PR TITLE
Make ProcessCommonJSModules, ProcessEs6Modules and ES6ModuleLoader public

### DIFF
--- a/src/com/google/javascript/jscomp/ES6ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/ES6ModuleLoader.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * @see Section 26.3.3.18.2 of the ES6 spec
  * @see http://wiki.commonjs.org/wiki/Modules/1.1
  */
-class ES6ModuleLoader {
+public final class ES6ModuleLoader {
   /**
    * According to the spec, the forward slash should be the delimiter on all
    * platforms.
@@ -57,7 +57,14 @@ class ES6ModuleLoader {
   private final URI moduleRootURI;
   private final AbstractCompiler compiler;
 
-  ES6ModuleLoader(AbstractCompiler compiler, String moduleRoot) {
+  /**
+   * Creates an instance of the module loader which can be used to locate
+   * ES6 and CommonJS modules.
+   *
+   * @param compiler The compiler
+   * @param moduleRoot Path to a directory which can be used to locate modules
+   */
+  public ES6ModuleLoader(AbstractCompiler compiler, String moduleRoot) {
     this.moduleRoot = moduleRoot;
     this.moduleRootURI = createUri(moduleRoot);
     this.compiler = compiler;

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -49,11 +49,30 @@ public final class ProcessCommonJSModules implements CompilerPass {
   private final ES6ModuleLoader loader;
   private final boolean reportDependencies;
 
-  ProcessCommonJSModules(Compiler compiler, ES6ModuleLoader loader) {
+  /**
+   * Creates a new ProcessCommonJSModules instance which can be used to
+   * rewrite CommonJS modules to a concatenable form.
+   *
+   * @param compiler The compiler
+   * @param loader The module loader which is used to locate CommonJS modules
+   */
+  public ProcessCommonJSModules(Compiler compiler, ES6ModuleLoader loader) {
     this(compiler, loader, true);
   }
 
-  ProcessCommonJSModules(Compiler compiler, ES6ModuleLoader loader,
+  /**
+   * Creates a new ProcessCommonJSModules instance which can be used to
+   * rewrite CommonJS modules to a concatenable form.
+   *
+   * @param compiler The compiler
+   * @param loader The module loader which is used to locate CommonJS modules
+   * @param reportDependencies Whether the rewriter should report dependency
+   *     information to the Closure dependency manager. This needs to be true
+   *     if we want to sort CommonJS module inputs correctly. Note that goog.provide
+   *     and goog.require calls will still be generated if this argument is
+   *     false.
+   */
+  public ProcessCommonJSModules(Compiler compiler, ES6ModuleLoader loader,
       boolean reportDependencies) {
     this.compiler = compiler;
     this.loader = loader;

--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -79,13 +79,18 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
   private boolean reportDependencies;
 
   /**
+   * Creates a new ProcessEs6Modules instance which can be used to rewrite
+   * ES6 modules to a concatenable form.
+   *
+   * @param compiler The compiler
+   * @param loader The module loader which is used to locate ES6 modules
    * @param reportDependencies Whether the rewriter should report dependency
    *     information to the Closure dependency manager. This needs to be true
    *     if we want to sort ES6 module inputs correctly. Note that goog.provide
    *     and goog.require calls will still be generated if this argument is
    *     false.
    */
-  ProcessEs6Modules(Compiler compiler, ES6ModuleLoader loader,
+  public ProcessEs6Modules(Compiler compiler, ES6ModuleLoader loader,
       boolean reportDependencies) {
     this.compiler = compiler;
     this.loader = loader;


### PR DESCRIPTION
For this year's GSoC project, we are planning to add CommonJS, ECMAScript 6 and AMD module support to ClojureScript and would like to use functionality that is already provided by the Google Closure Compiler. Instead of using this functionality indirectly through the Compiler class we would like to use the ProcessCommonJSModules, ProcessEs6Modules and ES6ModuleLoader classes directly to make it easier for us to support incremental compilation.

I have signed the CLA and David Nolen, who is my mentor for this project, asked about this change on the mailing list [1].

[1] https://groups.google.com/forum/#!topic/closure-compiler-discuss/C8yfc6ImDkI