### PR TITLE
Apply pull request #768 by @kayahr.

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -2170,6 +2170,7 @@ public class Compiler extends AbstractCompiler {
   protected Config createConfig(Config.LanguageMode mode) {
     return ParserRunner.createConfig(
         isIdeMode(),
+        options.isParseJsDocDocumentation(),
         mode,
         acceptConstKeyword(),
         options.extraAnnotationNames);

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -152,6 +152,8 @@ public class CompilerOptions implements Serializable, Cloneable {
    */
   public boolean ideMode;
 
+  private boolean parseJsDocDocumentation = false;
+
   /**
    * Even if checkTypes is disabled, clients might want to still infer types.
    * This is mostly used when ideMode is enabled.
@@ -1799,6 +1801,26 @@ public class CompilerOptions implements Serializable, Cloneable {
 
   public void setIdeMode(boolean ideMode) {
     this.ideMode = ideMode;
+  }
+
+  /**
+   * Enables or disables the parsing of JSDoc documentation. When IDE mode is
+   * enabled then documentation is always parsed.
+   *
+   * @param parseJsDocDocumentation
+   *           True to enable JSDoc documentation parsing, false to disable it.
+   */
+  public void setParseJsDocDocumentation(boolean parseJsDocDocumentation) {
+    this.parseJsDocDocumentation = parseJsDocDocumentation;
+  }
+
+  /**
+   * Checks JSDoc documentation will be parsed.
+   *
+   * @return True when JSDoc documentation will be parsed, false if not.
+   */
+  public boolean isParseJsDocDocumentation() {
+    return this.ideMode || this.parseJsDocDocumentation;
   }
 
   public void setSkipAllPasses(boolean skipAllPasses) {

--- a/src/com/google/javascript/jscomp/parsing/Config.java
+++ b/src/com/google/javascript/jscomp/parsing/Config.java
@@ -73,8 +73,14 @@ public final class Config {
   Config(Set<String> annotationWhitelist, Set<String> suppressionNames,
       boolean isIdeMode, LanguageMode languageMode,
       boolean acceptConstKeyword) {
+    this(annotationWhitelist, suppressionNames, isIdeMode, isIdeMode, languageMode, acceptConstKeyword);
+  }
+
+  Config(Set<String> annotationWhitelist, Set<String> suppressionNames,
+      boolean isIdeMode, boolean parseJsDocDocumentation, LanguageMode languageMode,
+      boolean acceptConstKeyword) {
     this.annotationNames = buildAnnotationNames(annotationWhitelist);
-    this.parseJsDocDocumentation = isIdeMode;
+    this.parseJsDocDocumentation = parseJsDocDocumentation;
     this.suppressionNames = suppressionNames;
     this.isIdeMode = isIdeMode;
     this.languageMode = languageMode;

--- a/src/com/google/javascript/jscomp/parsing/ParserRunner.java
+++ b/src/com/google/javascript/jscomp/parsing/ParserRunner.java
@@ -53,6 +53,14 @@ public final class ParserRunner {
                                     LanguageMode languageMode,
                                     boolean acceptConstKeyword,
                                     Set<String> extraAnnotationNames) {
+    return createConfig(isIdeMode, isIdeMode, languageMode, acceptConstKeyword, extraAnnotationNames);
+  }
+
+  public static Config createConfig(boolean isIdeMode,
+                                    boolean parseJsDocDocumentation,
+                                    LanguageMode languageMode,
+                                    boolean acceptConstKeyword,
+                                    Set<String> extraAnnotationNames) {
     initResourceConfig();
     Set<String> effectiveAnnotationNames;
     if (extraAnnotationNames == null) {
@@ -62,7 +70,7 @@ public final class ParserRunner {
       effectiveAnnotationNames.addAll(extraAnnotationNames);
     }
     return new Config(effectiveAnnotationNames, suppressionNames,
-        isIdeMode, languageMode, acceptConstKeyword);
+        isIdeMode, parseJsDocDocumentation, languageMode, acceptConstKeyword);
   }
 
   public static Set<String> getReservedVars() {


### PR DESCRIPTION
Decouple jsdoc documentation parsing from IDE mode.

Currently the parsing of JSDoc documentation is coupled to the IDE mode
option so normally JSDoc documentation strings are not parsed.  This
prevents the implementation of custom compiler passes like API Documentation
generation.  This patch introduces a new compiler option
(parseJsDocDocumentation) which can be used to enable the documentation
parsing even when not in IDE mode.  The functionality is backward
compatible, when IDE mode is enabled then documentation parsing is always
enabled)