### PR TITLE
Fix compile error caused by merge 924393a

### DIFF
--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -276,10 +276,6 @@ public final class CompileTask
   public void setForceRecompile(boolean forceRecompile) {
     this.forceRecompile = forceRecompile;
   }
-  
-  public void setAngularPass(boolean angularPass) {
-    this.angularPass = angularPass;
-  }
 
   public void setAngularPass(boolean angularPass) {
     this.angularPass = angularPass;


### PR DESCRIPTION
I haven't figured out exactly how, but the 924393aae863a15661a21c3d62f966cae60b4792 merge duplicated a method thus causing build errors: https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/ant/CompileTask.java#L284.

The previous commit in the tree for the tree does not have that error so I am at a loss as to how this occurred.

Regardless, this needs merged ASAP.