### PR TITLE
Adding missing methods to angular 1.4 '$animate' externs

### DIFF
--- a/contrib/externs/angular-1.4.js
+++ b/contrib/externs/angular-1.4.js
@@ -1010,6 +1010,27 @@ angular.$animate.prototype.animate = function(
     element, from, to, opt_className, opt_options) {};
 
 /**
+ * @param {string} event
+ * @param {JQLiteSelector} container
+ * @param {function(JQLiteSelector, string)} callback
+ */
+angular.$animate.prototype.on = function(event, container, callback) {};
+
+/**
+ * @param {string} event
+ * @param {JQLiteSelector=} opt_container
+ * @param {function(JQLiteSelector, string)=} opt_callback
+ */
+angular.$animate.prototype.off = function(event, opt_container, opt_callback) {
+};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {JQLiteSelector} parentElement
+ */
+angular.$animate.prototype.pin = function(element, parentElement) {};
+
+/**
  * @param {JQLiteSelector} element
  * @param {JQLiteSelector} parentElement
  * @param {JQLiteSelector} afterElement


### PR DESCRIPTION
With this pull request I added `on`, `off` and `pin` method to angular 1.4 externs. See https://code.angularjs.org/1.4.1/docs/api/ng/service/$animate.
Please review.