### PR TITLE
Signature for the ImageData constructor

### DIFF
--- a/externs/html5.js
+++ b/externs/html5.js
@@ -512,9 +512,16 @@ function TextMetrics() {}
 TextMetrics.prototype.width;
 
 /**
+ * @param {Uint8ClampedArray|number} dataOrWidth In the first form, this is the
+ *     array of pixel data.  In the second form, this is the image width.
+ * @param {number} widthOrHeight In the first form, this is the image width.  In
+ *     the second form, this is the image height.
+ * @param {number=} opt_height In the first form, this is the optional image
+ *     height.  The second form omits this argument.
+ * @see https://html.spec.whatwg.org/multipage/scripting.html#imagedata
  * @constructor
  */
-function ImageData() {}
+function ImageData(dataOrWidth, widthOrHeight, opt_height) {}
 
 /** @type {Uint8ClampedArray} */
 ImageData.prototype.data;


### PR DESCRIPTION
This adds arguments to the `ImageData` constructor to follow the proposed spec and implementations in Chrome, Firefox, and Opera.

From [the spec](https://html.spec.whatwg.org/multipage/scripting.html#imagedata):
```
[Constructor(unsigned long sw, unsigned long sh),
 Constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh),
 Exposed=(Window,Worker)]
interface ImageData {
  readonly attribute unsigned long width;
  readonly attribute unsigned long height;
  readonly attribute Uint8ClampedArray data;
};
```