### PR TITLE
CommonJS processing: Consider "module" scope

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -44,6 +44,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
   private static final String MODULE_NAME_PREFIX = "module$";
 
   private static final String EXPORTS = "exports";
+  private static final String MODULE = "module";
 
   private final Compiler compiler;
   private final ES6ModuleLoader loader;
@@ -168,7 +169,13 @@ public final class ProcessCommonJSModules implements CompilerPass {
 
       if (n.isGetProp() &&
           "module.exports".equals(n.getQualifiedName())) {
-        moduleExportRefs.add(n);
+        Var v = t.getScope().getVar(MODULE);
+        // only rewrite "module.exports" if "module" is a free variable,
+        // meaning it is not defined in the current scope as a local
+        // variable or function parameter
+        if (v == null) {
+          moduleExportRefs.add(n);
+        }
       }
 
       if (n.isName() && EXPORTS.equals(n.getString())) {

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -157,6 +157,30 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "var name$$module$foo$bar = module$foo$name;");
   }
 
+  public void testModuleExportsScope() {
+    setFilename("test");
+    test(
+        "var foo = function (module) {module.exports = {};};" +
+        "module.exports = foo;",
+        "goog.provide('module$test');" +
+        "var foo$$module$test=function(module){module.exports={}};" +
+        "var module$test=foo$$module$test");
+    test(
+        "var foo = function () {var module = {};module.exports = {};};" +
+        "module.exports = foo;",
+        "goog.provide('module$test');" +
+        "var foo$$module$test=function(){var module={};module.exports={}};" +
+        "var module$test=foo$$module$test");
+    test(
+        "var foo = function () {if (true) var module = {};" +
+        "module.exports = {};};" +
+        "module.exports = foo;",
+        "goog.provide('module$test');" +
+        "var foo$$module$test=function(){if(true)var module={};" +
+        "module.exports={}};" +
+        "var module$test=foo$$module$test");
+  }
+
   public void testSortInputs() throws Exception {
     SourceFile a = SourceFile.fromCode("a.js",
             "require('b');require('c')");


### PR DESCRIPTION
When rewriting a CommonJS module, only process `module.exports` when
`module` is not defined in current scope.

For example, if a function has a parameter `module`, references to `module.exports` should not be replaced with the new module name (e.g. `module$foobar`)

```
var foo = function (module) {
    module.exports = "foo";
};
module.exports = "bar";
```

https://groups.google.com/forum/#!topic/closure-compiler-discuss/AklSy5PNQ_I