### PR TITLE
Remove UMD pattern when processing CommonJS.

### DIFF
--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -190,6 +190,41 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "module$test=foo$$module$test");
   }
 
+  public void testUMDPatternConversion() {
+    setFilename("test");
+    testModules(
+        "var foobar = {foo: 'bar'};" +
+        "if (typeof module === 'object' && module.exports) {" +
+        "  module.exports = foobar;" +
+        "} else if (typeof define === 'function' && define.amd) {" +
+        "  define([], function() {return foobar;});" +
+        "} else {" +
+        "  this.foobar = foobar;}",
+        "goog.provide('module$test');" +
+        "var foobar$$module$test = {foo: 'bar'};" +
+        "module$test = foobar$$module$test;");
+    testModules(
+        "var foobar = {foo: 'bar'};" +
+        "if (typeof define === 'function' && define.amd) {" +
+        "  define([], function() {return foobar;});" +
+        "} else if (typeof module === 'object' && module.exports) {" +
+        "  module.exports = foobar;" +
+        "} else {" +
+        "  this.foobar = foobar;}",
+        "goog.provide('module$test');" +
+        "var foobar$$module$test = {foo: 'bar'};" +
+        "module$test = foobar$$module$test;");
+    testModules(
+        "var foobar = {foo: 'bar'};" +
+        "if (typeof module === 'object' && module.exports) {" +
+        "  module.exports = foobar;}" +
+        "if (typeof define === 'function' && define.amd) {" +
+        "  define([], function () {return foobar;});}",
+        "goog.provide('module$test');" +
+        "var foobar$$module$test = {foo: 'bar'};" +
+        "module$test = foobar$$module$test;");
+}
+
   public void testSortInputs() throws Exception {
     SourceFile a = SourceFile.fromCode("a.js", "require('b');require('c')");
     SourceFile b = SourceFile.fromCode("b.js", "require('d')");


### PR DESCRIPTION
To remove the UMD pattern from a JavaScript library and pull out the
`module.exports` or `exports`, check the condition of an if-statement
for an occurrence of either `module.exports`/`exports` for CommonJS or
`define.amd` for AMD. For an if-statement that is checking for CommonJS,
we pull out the then-branch and remove the rest. For an if-statement
that is checking for AMD, we pull out the else-branch (since it could be
checking for CommonJS) and remove the rest.

For example:

```javascript
var foobar = {
    foo: "bar"
};

if (typeof define === "function" && define.amd) {
    define([], function() {
        return foobar;
    });
} else if (typeof exports === "object") {
    if (true) {
        module.exports = foobar;
    }
} else {
    this.foobar = foobar;
}
```

will be translated to:

```javascript
var module$umd_standard = {},
    foobar$$module$umd_standard = {foo:"bar"},
    module$umd_standard = foobar$$module$umd_standard;
```

Thread on the mailing list:
https://groups.google.com/forum/#!topic/closure-compiler-discuss/-M1HBUn35fs