### PR TITLE
Fixed several issues in the Web Sockets API in the html5.js extern file.

### DIFF
--- a/externs/html5.js
+++ b/externs/html5.js
@@ -2230,10 +2230,10 @@ WebSocket.prototype.send = function(data) {};
 
 /**
  * Closes the Web Socket connection or connection attempt, if any.
- * @param {number=} code
- * @param {string=} reason
+ * @param {number=} opt_code
+ * @param {string=} opt_reason
  */
-WebSocket.prototype.close = function(code, reason) {};
+WebSocket.prototype.close = function(opt_code, opt_reason) {};
 
 /**
  * @type {string} Sets the type of data (blob or arraybuffer) for binary data.

--- a/externs/html5.js
+++ b/externs/html5.js
@@ -2144,6 +2144,30 @@ TimeRanges.prototype.end = function(index) { return 0; };
 function WebSocket(url, opt_protocol) {}
 
 /**
+ * The connection has not yet been established.
+ * @type {number}
+ */
+WebSocket.CONNECTING = 0;
+
+/**
+ * The WebSocket connection is established and communication is possible.
+ * @type {number}
+ */
+WebSocket.OPEN = 1;
+
+/**
+ * The connection is going through the closing handshake, or the close() method has been invoked.
+ * @type {number}
+ */
+WebSocket.CLOSING = 2;
+
+/**
+ * The connection has been closed or could not be opened.
+ * @type {number}
+ */
+WebSocket.CLOSED = 3;
+
+/**
  * @param {boolean=} opt_useCapture
  * @override
  */
@@ -2164,25 +2188,7 @@ WebSocket.prototype.dispatchEvent = function(evt) {};
  * Returns the URL value that was passed to the constructor.
  * @type {string}
  */
-WebSocket.prototype.URL;
-
-/**
- * The connection has not yet been established.
- * @type {number}
- */
-WebSocket.prototype.CONNECTING = 0;
-
-/**
- * The Web Socket connection is established and communication is possible.
- * @type {number}
- */
-WebSocket.prototype.OPEN = 1;
-
-/**
- * The connection has been closed or could not be opened.
- * @type {number}
- */
-WebSocket.prototype.CLOSED = 2;
+WebSocket.prototype.url;
 
 /**
  * Represents the state of the connection.
@@ -2224,8 +2230,10 @@ WebSocket.prototype.send = function(data) {};
 
 /**
  * Closes the Web Socket connection or connection attempt, if any.
+ * @param {number=} code
+ * @param {string=} reason
  */
-WebSocket.prototype.close = function() {};
+WebSocket.prototype.close = function(code, reason) {};
 
 /**
  * @type {string} Sets the type of data (blob or arraybuffer) for binary data.


### PR DESCRIPTION
Fixed a few issues in the WebSockets externs. The changes all align the extern with the spec here:

http://www.w3.org/TR/websockets/#websocket

1. The OPEN, CONNECTING, and CLOSED constants were moved from the prototype to the class.
2. The missing WebSocket.CLOSING constant was added and set to 2.
3. The missing WebSocket.CLOSED constant was changed from 2 (incorrect) to 3 (correct).
4. The WebSocket.prototype.URL property was changed to The WebSocket.prototype.url.
5. The WebSocket.prototype.close method was updated to add the two optional parameters (code, and reason).

This PR addresses the discussion here:

https://groups.google.com/forum/#!topic/closure-compiler-discuss/FYK7rx04U4M

As well as a few other issues, I was seeing.