### PR TITLE
Fix Regression: source location of node of type Token.NAME should actually refer to variable name.

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/IRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/IRFactory.java
@@ -1811,7 +1811,7 @@ class IRFactory {
       if (decl.initializer != null) {
         Node initializer = transform(decl.initializer);
         node.addChildToBack(initializer);
-        maybeSetLength(node, decl.location.start, decl.location.end);
+        maybeSetLength(node, decl.lvalue.location.start, decl.lvalue.location.end);
       }
       maybeProcessType(node, decl.declaredType);
       return node;

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -162,18 +162,19 @@ public final class NewParserTest extends BaseJSTypeTestCase {
   public void testVarSourceLocations() {
     isIdeMode = true;
 
-    Node n = parse("var x, y = 1;");
+    Node n = parse("var x, yy = 1;");
     Node var = n.getFirstChild();
     assertNode(var).hasType(Token.VAR);
 
     Node x = var.getFirstChild();
     assertNode(x).hasType(Token.NAME);
     assertNode(x).hasCharno("var ".length());
+    assertNode(x).hasLength("x".length());
 
     Node y = x.getNext();
     assertNode(y).hasType(Token.NAME);
     assertNode(y).hasCharno("var x, ".length());
-    assertNode(y).hasLength("y = 1".length());
+    assertNode(y).hasLength("yy".length());
   }
 
   public void testReturn() {


### PR DESCRIPTION
Currently, source location of nodes of type Token.NAME refer to the full variable declaration.
This patch fixes this to refer to the variable name only.

This is a regression caused by 544de7369955ba21cbab4217d7f0799d81c957a0.

Please, take a look. 