### PR TITLE
Account for windows path separators when checking package name.

### DIFF
--- a/src/com/google/javascript/jscomp/GoogleCodingConvention.java
+++ b/src/com/google/javascript/jscomp/GoogleCodingConvention.java
@@ -22,6 +22,7 @@ package com.google.javascript.jscomp;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.StaticSourceFile;
 
+import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -159,6 +160,9 @@ public class GoogleCodingConvention extends CodingConventions.Proxy {
   @Override
   public String getPackageName(StaticSourceFile source) {
     String name = source.getName();
+    if (File.separatorChar == '\\') {
+      name = name.replace('\\', '/');
+    }
     Matcher m = PACKAGE_WITH_TEST_DIR.matcher(name);
     if (m.find()) {
       return m.group(1);

--- a/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
+++ b/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
@@ -698,26 +698,25 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
   }
 
   public void testPackagePrivateAccessForNamesWithWindowsFilePaths() {
-    test(
-        ImmutableList.of(
-            SourceFile.fromCode(
-                "foo\\bar.js",
-                "/** @constructor */\n"
-                    + "function Parent() {\n"
-                    + "/** @package */\n"
-                    + "this.prop = 'foo';\n"
-                    + "}\n;"),
-            SourceFile.fromCode(
-                "baz\\quux.js",
-                "/**"
-                    + " * @constructor\n"
-                    + " * @extends {Parent}\n"
-                    + " */\n"
-                    + "function Child() {\n"
-                    + "  this.prop = 'asdf';\n"
-                    + "}\n"
-                    + "Child.prototype = new Parent();")),
-        null, BAD_PACKAGE_PROPERTY_ACCESS);
+    ImmutableList<SourceFile> js = ImmutableList.of(
+        SourceFile.fromCode(
+            "foo\\bar.js",
+            "/** @constructor */\n"
+            + "function Parent() {\n"
+            + "/** @package */\n"
+            + "this.prop = 'foo';\n"
+            + "}\n;"),
+        SourceFile.fromCode(
+            "baz\\quux.js",
+            "/**"
+            + " * @constructor\n"
+            + " * @extends {Parent}\n"
+            + " */\n"
+            + "function Child() {\n"
+            + "  this.prop = 'asdf';\n"
+            + "}\n"
+            + "Child.prototype = new Parent();"));
+      test(js, null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
   public void testPackagePrivateAccessForProperties1() {

--- a/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
+++ b/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
@@ -697,28 +697,6 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
-  public void testPackagePrivateAccessForNamesWithWindowsFilePaths() {
-    ImmutableList<SourceFile> js = ImmutableList.of(
-        SourceFile.fromCode(
-            "foo\\bar.js",
-            "/** @constructor */\n"
-            + "function Parent() {\n"
-            + "/** @package */\n"
-            + "this.prop = 'foo';\n"
-            + "}\n;"),
-        SourceFile.fromCode(
-            "baz\\quux.js",
-            "/**"
-            + " * @constructor\n"
-            + " * @extends {Parent}\n"
-            + " */\n"
-            + "function Child() {\n"
-            + "  this.prop = 'asdf';\n"
-            + "}\n"
-            + "Child.prototype = new Parent();"));
-      test(js, null, BAD_PACKAGE_PROPERTY_ACCESS);
-  }
-
   public void testPackagePrivateAccessForProperties1() {
     testSame("/** @constructor */ function Foo() {}"
         + "/** @package */ Foo.prototype.bar = function() {};"

--- a/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
+++ b/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
@@ -697,6 +697,29 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
+  public void testPackagePrivateAccessForNamesWithWindowsFilePaths() {
+    test(
+        ImmutableList.of(
+            SourceFile.fromCode(
+                "foo\\bar.js",
+                "/** @constructor */\n"
+                    + "function Parent() {\n"
+                    + "/** @package */\n"
+                    + "this.prop = 'foo';\n"
+                    + "}\n;"),
+            SourceFile.fromCode(
+                "baz\\quux.js",
+                "/**"
+                    + " * @constructor\n"
+                    + " * @extends {Parent}\n"
+                    + " */\n"
+                    + "function Child() {\n"
+                    + "  this.prop = 'asdf';\n"
+                    + "}\n"
+                    + "Child.prototype = new Parent();")),
+        null, BAD_PACKAGE_PROPERTY_ACCESS);
+  }
+
   public void testPackagePrivateAccessForProperties1() {
     testSame("/** @constructor */ function Foo() {}"
         + "/** @package */ Foo.prototype.bar = function() {};"


### PR DESCRIPTION
Fixes #1070 