### PR TITLE
Normalize the separator for file paths in source files.

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -48,6 +49,7 @@ import com.google.javascript.rhino.Token;
 import com.google.javascript.rhino.TypeIRegistry;
 import com.google.javascript.rhino.jstype.JSTypeRegistry;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.FileSystems;
@@ -236,6 +238,8 @@ public class Compiler extends AbstractCompiler {
   private String lastPassName;
 
   private Set<String> externProperties = null;
+
+  private static final Joiner pathJoiner = Joiner.on(File.separator);
 
   /**
    * Creates a Compiler that reports errors and warnings to its logger.
@@ -465,6 +469,13 @@ public class Compiler extends AbstractCompiler {
   }
 
   /**
+   * Creates an OS specific path string from parts
+   */
+  public static String joinPathParts(String... pathParts) {
+    return pathJoiner.join(pathParts);
+  }
+
+  /**
    * Fill any empty modules with a place holder file. It makes any cross module
    * motion easier.
    */
@@ -524,7 +535,8 @@ public class Compiler extends AbstractCompiler {
     return FileSystems.getDefault().getPath(base)
         .resolveSibling(relative)
         .normalize()
-        .toString();
+        .toString()
+        .replace(File.separator, "/");
   }
 
   /**

--- a/src/com/google/javascript/jscomp/SourceFile.java
+++ b/src/com/google/javascript/jscomp/SourceFile.java
@@ -83,7 +83,12 @@ public class SourceFile implements StaticSourceFile, Serializable {
     if (fileName == null || fileName.isEmpty()) {
       throw new IllegalArgumentException("a source must have a name");
     }
-    this.fileName = fileName;
+
+    if (!"/".equals(File.separator)) {
+      this.fileName = fileName.replace(File.separator, "/");
+    } else {
+      this.fileName = fileName;
+    }
   }
 
   @Override

--- a/src/com/google/javascript/jscomp/SourceMap.java
+++ b/src/com/google/javascript/jscomp/SourceMap.java
@@ -139,11 +139,6 @@ public final class SourceMap {
    * @return a remapped source file.
    */
   private String fixupSourceLocation(String sourceFile) {
-    // Replace backslashes (the file separator used on Windows systems).
-    if (File.separatorChar == '\\') {
-      sourceFile = sourceFile.replace('\\', '/');
-    }
-
     if (prefixMappings.isEmpty()) {
       return sourceFile;
     }

--- a/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
+++ b/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
@@ -678,14 +678,14 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */\n"
                 + "function Parent() {\n"
                 + "/** @package */\n"
                 + "this.prop = 'foo';\n"
                 + "}\n;"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/**"
                 + " * @constructor\n"
                 + " * @extends {Parent}\n"
@@ -705,9 +705,10 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
 
   public void testPackagePrivateAccessForProperties2() {
     testSame(ImmutableList.of(
-        SourceFile.fromCode("foo/bar.js", "/** @constructor */ function Foo() {}"),
+        SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"),
+            "/** @constructor */ function Foo() {}"),
         SourceFile.fromCode(
-            "baz/quux.js",
+            Compiler.joinPathParts("baz", "quux.js"),
             "/** @package */ Foo.prototype.bar = function() {};"
             + "Foo.prototype.baz = function() { this.bar(); }; (new Foo).bar();")));
   }
@@ -715,34 +716,36 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
   public void testPackagePrivateAccessForProperties3() {
     testSame(ImmutableList.of(
         SourceFile.fromCode(
-            "foo/bar.js",
+            Compiler.joinPathParts("foo", "bar.js"),
             "/** @constructor */ function Foo() {}"
             + "/** @package */ Foo.prototype.bar = function() {}; (new Foo).bar();"),
-        SourceFile.fromCode("foo/baz.js", "Foo.prototype.baz = function() { this.bar(); };")));
+        SourceFile.fromCode(Compiler.joinPathParts("foo", "baz.js"),
+            "Foo.prototype.baz = function() { this.bar(); };")));
   }
 
   public void testPackagePrivateAccessForProperties4() {
     testSame(ImmutableList.of(
         SourceFile.fromCode(
-            "foo/bar.js",
+            Compiler.joinPathParts("foo", "bar.js"),
             "/** @constructor */ function Foo() {}"
             + "/** @package */ Foo.prototype.bar = function() {};"),
         SourceFile.fromCode(
-            "foo/baz.js", "Foo.prototype['baz'] = function() { (new Foo()).bar(); };")));
+            Compiler.joinPathParts("foo", "baz.js"),
+            "Foo.prototype['baz'] = function() { (new Foo()).bar(); };")));
   }
 
   public void testPackagePrivateAccessForProperties5() {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */\n"
                 + "function Parent () {\n"
                 + "  /** @package */\n"
                 + "  this.prop = 'foo';\n"
                 + "};"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/**\n"
                 + " * @constructor\n"
                 + " * @extends {Parent}\n"
@@ -758,9 +761,10 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js", "/** @constructor */ function Foo() {} (new Foo).bar();"),
+                Compiler.joinPathParts("foo", "bar.js"),
+                "/** @constructor */ function Foo() {} (new Foo).bar();"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/** @package */ Foo.prototype.bar = function() {};"
                 + "Foo.prototype.baz = function() { this.bar(); };")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
@@ -770,11 +774,11 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */ function Foo() {} "
                 + "/** @package */ Foo.prototype.bar = function() {};"
                 + "Foo.prototype.baz = function() { this.bar(); };"),
-            SourceFile.fromCode("baz/quux.js", "(new Foo).bar();")),
+            SourceFile.fromCode(Compiler.joinPathParts("baz", "quux.js"), "(new Foo).bar();")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
@@ -782,11 +786,12 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */ function Foo() {} "
                 + "/** @package */ Foo.prototype.bar = function() {};"),
             SourceFile.fromCode(
-                "baz/quux.js", "/** @constructor */ function OtherFoo() { (new Foo).bar(); }")),
+                Compiler.joinPathParts("baz", "quux.js"),
+                "/** @constructor */ function OtherFoo() { (new Foo).bar(); }")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
@@ -794,11 +799,11 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */ function Foo() {} "
                 + "/** @package */ Foo.prototype.bar = function() {};"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/** @constructor \n * @extends {Foo} */ "
                 + "function SubFoo() { this.bar(); }")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
@@ -808,10 +813,10 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @const */ var foo = {};\n"
                 + "/** @package */ foo.bar = function() {};"),
-            SourceFile.fromCode("baz/quux.js", "foo.bar();")),
+            SourceFile.fromCode(Compiler.joinPathParts("baz", "quux.js"), "foo.bar();")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
@@ -819,11 +824,11 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */ function Foo() {} "
                 + "/** @package */ Foo.prototype.bar = function() {};"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/** @constructor \n * @extends {Foo} */ "
                 + "function SubFoo() {};"
                 + "SubFoo.prototype.baz = function() { this.bar(); }")),
@@ -836,11 +841,11 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */ function Foo() {} "
                 + "/** @package */ Foo.prototype.bar = function() {};"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/** @constructor \n * @extends {Foo} */ "
                 + "function SubFoo() {};"
                 + "SubFoo.prototype.bar = function() {};")),
@@ -854,14 +859,15 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/** @constructor */ function Foo() {} "
                 + "/** @package */ Foo.prototype.bar = function() {};"
                 + "/** @constructor \n * @extends {Foo} */ "
                 + "function SubFoo() {};"
                 + "SubFoo.prototype.bar = function() {};"),
             SourceFile.fromCode(
-                "baz/quux.js", "SubFoo.prototype.baz = function() { this.bar(); }")),
+                Compiler.joinPathParts("baz", "quux.js"),
+                "SubFoo.prototype.baz = function() { this.bar(); }")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
@@ -970,40 +976,40 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @public\n"
                 + " */\n"
                 + "/** @constructor @package */ function Foo() {};"),
-            SourceFile.fromCode("baz/quux.js", "new Foo();")),
+            SourceFile.fromCode(Compiler.joinPathParts("baz", "quux.js"), "new Foo();")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
   public void testPackageFileOverviewVisibilityDoesNotApplyToNameWithExplicitPublicVisibility() {
     testSame(ImmutableList.of(
         SourceFile.fromCode(
-            "foo/bar.js",
+            Compiler.joinPathParts("foo", "bar.js"),
             "/**\n"
             + " * @fileoverview\n"
             + " * @package\n"
             + " */\n"
             + "/** @constructor @public */ function Foo() {};"),
-        SourceFile.fromCode("baz/quux.js", "new Foo();")));
+        SourceFile.fromCode(Compiler.joinPathParts("baz", "quux.js"), "new Foo();")));
   }
 
   public void testPackageFileOverviewVisibilityAppliesToNameWithoutExplicitVisibility() {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @package\n"
                 + " */\n"
                 + "/** @constructor */\n"
                 + "var Foo = function() {};\n"),
-            SourceFile.fromCode("baz/quux.js", "new Foo();")),
+            SourceFile.fromCode(Compiler.joinPathParts("baz", "quux.js"), "new Foo();")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
   }
 
@@ -1011,7 +1017,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
       testPackageFileOverviewVisibilityDoesNotApplyToPropertyWithExplicitPublicVisibility() {
     testSame(ImmutableList.of(
         SourceFile.fromCode(
-            "foo/bar.js",
+            Compiler.joinPathParts("foo", "bar.js"),
             "/**\n"
             + " * @fileoverview\n"
             + " * @package\n"
@@ -1021,7 +1027,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
             + "/** @public */\n"
             + "Foo.prototype.bar = function() {};\n"),
         SourceFile.fromCode(
-            "baz/quux.js",
+            Compiler.joinPathParts("baz", "quux.js"),
             "var foo = new Foo();\n"
             + "foo.bar();")));
   }
@@ -1035,7 +1041,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
         ImmutableList.of(
             SourceFile.fromCode("foo.js", "goog.provide('foo');"),
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + "  * @fileoverview\n"
                 + "  * @package\n"
@@ -1043,7 +1049,8 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
                 + "goog.provide('foo.bar');"),
             SourceFile.fromCode("bar.js", "goog.require('foo')")),
         ImmutableList.of(SourceFile.fromCode("foo.js", "var foo={};"),
-            SourceFile.fromCode("foo/bar.js", "foo.bar={};"), SourceFile.fromCode("bar.js", "")),
+            SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"), "foo.bar={};"),
+            SourceFile.fromCode("bar.js", "")),
         null, null);
 
     compareJsDoc = true;
@@ -1057,7 +1064,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + "  * @fileoverview\n"
                 + "  * @package\n"
@@ -1068,7 +1075,8 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
                 "bar.js",
                 "goog.require('foo');\n"
                 + "var x = foo;")),
-        ImmutableList.of(SourceFile.fromCode("foo/bar.js", "var foo={};foo.bar={};"),
+        ImmutableList.of(SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"),
+                "var foo={};foo.bar={};"),
             SourceFile.fromCode("foo.js", ""), SourceFile.fromCode("bar.js", "var x=foo")),
         null, null);
 
@@ -1083,7 +1091,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @package\n"
@@ -1095,7 +1103,8 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
                 "goog.require('one.two');\n"
                 + "var x = one.two;")),
         ImmutableList.of(
-            SourceFile.fromCode("foo/bar.js", "var one={};one.two={};one.two.three=function(){};"),
+            SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"),
+                "var one={};one.two={};one.two.three=function(){};"),
             SourceFile.fromCode("baz.js", "var x=one.two")),
         null, null);
 
@@ -1106,7 +1115,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @package\n"
@@ -1125,7 +1134,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @public\n"
@@ -1135,7 +1144,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
                 + "/** @package */\n"
                 + "Foo.prototype.bar = function() {};\n"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "var foo = new Foo();\n"
                 + "foo.bar();")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
@@ -1144,7 +1153,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
   public void testPublicFileOverviewVisibilityAppliesToPropertyWithoutExplicitVisibility() {
     testSame(ImmutableList.of(
         SourceFile.fromCode(
-            "foo/bar.js",
+            Compiler.joinPathParts("foo", "bar.js"),
             "/**\n"
             + " * @fileoverview\n"
             + " * @public\n"
@@ -1153,7 +1162,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
             + "Foo = function() {};\n"
             + "Foo.prototype.bar = function() {};\n"),
         SourceFile.fromCode(
-            "baz/quux.js",
+            Compiler.joinPathParts("baz", "quux.js"),
             "var foo = new Foo();\n"
             + "foo.bar();")));
   }
@@ -1162,7 +1171,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @package\n"
@@ -1171,7 +1180,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
                 + "Foo = function() {};\n"
                 + "Foo.prototype.bar = function() {};\n"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "var foo = new Foo();\n"
                 + "foo.bar();")),
         null, BAD_PACKAGE_PROPERTY_ACCESS);
@@ -1181,7 +1190,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
     test(
         ImmutableList.of(
             SourceFile.fromCode(
-                "foo/bar.js",
+                Compiler.joinPathParts("foo", "bar.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @package\n"
@@ -1190,7 +1199,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
                 + "Foo = function() {};\n"
                 + "Foo.prototype.bar = function() {};\n"),
             SourceFile.fromCode(
-                "baz/quux.js",
+                Compiler.joinPathParts("baz", "quux.js"),
                 "/**\n"
                 + " * @fileoverview\n"
                 + " * @public\n"
@@ -1351,7 +1360,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
 
   public void testDeclarationAndConventionConflict1() {
     testError(
-        "/** @constructor */ function Foo() {}" + "/** @protected */ Foo.prototype.length_;",
+        "/** @constructor */ function Foo() {} /** @protected */ Foo.prototype.length_;",
         CONVENTION_MISMATCH);
   }
 
@@ -1364,7 +1373,7 @@ public final class CheckAccessControlsTest extends CompilerTestCase {
 
   public void testDeclarationAndConventionConflict3() {
     testError(
-        "/** @constructor */ function Foo() {" + "  /** @protected */ this.length_ = 1;\n" + "}\n",
+        "/** @constructor */ function Foo() {  /** @protected */ this.length_ = 1;\n}\n",
         CONVENTION_MISMATCH);
   }
 

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -156,7 +156,7 @@ public final class CompilerTest extends TestCase {
   }
 
   private String normalize(String path) {
-    return path.replace("/", File.separator);
+    return path.replace(File.separator, "/");
   }
 
   public void testInputSourceMaps() throws Exception {

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -75,13 +75,15 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     ProcessEs6ModulesTest.testModules(
         this,
         ImmutableList.of(
-            SourceFile.fromCode("mod/name.js", ""),
+            SourceFile.fromCode(Compiler.joinPathParts("mod", "name.js"), ""),
             SourceFile.fromCode(
-                "test/sub.js", "var name = require('mod/name');" + "(function() { name(); })();")),
-        "goog.provide('module$test$sub');"
-            + "goog.require('module$mod$name');"
-            + "var name$$module$test$sub = module$mod$name;"
-            + "(function() { name$$module$test$sub(); })();");
+                Compiler.joinPathParts("test", "sub.js"),
+                "var name = require('mod/name');"
+                + "(function() { name(); })();")),
+                "goog.provide('module$test$sub');"
+                + "goog.require('module$mod$name');"
+                + "var name$$module$test$sub = module$mod$name;"
+                + "(function() { name$$module$test$sub(); })();");
   }
 
   public void testExports() {
@@ -159,8 +161,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     ProcessEs6ModulesTest.testModules(
         this,
         ImmutableList.of(
-            SourceFile.fromCode("foo/name.js", ""),
-            SourceFile.fromCode("foo/bar.js", "var name = require('./name');")),
+            SourceFile.fromCode(Compiler.joinPathParts("foo", "name.js"), ""),
+            SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"), "var name = require('./name');")),
         "goog.provide('module$foo$bar');"
             + "goog.require('module$foo$name');"
             + "var name$$module$foo$bar = module$foo$name;");

--- a/test/com/google/javascript/jscomp/SourceMapTest.java
+++ b/test/com/google/javascript/jscomp/SourceMapTest.java
@@ -40,7 +40,8 @@ public final class SourceMapTest extends SourceMapTestCase {
   public void testPrefixReplacement1() throws IOException {
     // mapping can be used to remove a prefix
     mappings = ImmutableList.of(new SourceMap.LocationMapping("pre/", ""));
-    checkSourceMap2("alert(1);", "pre/file1", "alert(2);", "pre/file2" , "{\n" +
+    checkSourceMap2("alert(1);", Compiler.joinPathParts("pre", "file1"), "alert(2);",
+        Compiler.joinPathParts("pre", "file2") , "{\n" +
         "\"version\":3,\n" +
         "\"file\":\"testcode\",\n" +
         "\"lineCount\":1,\n" +
@@ -52,8 +53,10 @@ public final class SourceMapTest extends SourceMapTestCase {
 
   public void testPrefixReplacement2() throws IOException {
     // mapping can be used to replace a prefix
-    mappings = ImmutableList.of(new SourceMap.LocationMapping("pre/file", "src"));
-    checkSourceMap2("alert(1);", "pre/file1", "alert(2);", "pre/file2" , "{\n" +
+    mappings = ImmutableList.of(
+        new SourceMap.LocationMapping("pre/file", "src"));
+    checkSourceMap2("alert(1);", Compiler.joinPathParts("pre", "file1"), "alert(2);",
+        "pre/file2" , "{\n" +
         "\"version\":3,\n" +
         "\"file\":\"testcode\",\n" +
         "\"lineCount\":1,\n" +


### PR DESCRIPTION
Allows most passes to assume a separator of "/".

Fixes #1070 