### PR TITLE
Better control over what gets renamed

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2377,22 +2377,12 @@ public final class DefaultPassConfig extends PassConfig {
     char[] reservedChars = options.anonymousFunctionNaming.getReservedCharacters();
     switch (options.propertyRenaming) {
       case HEURISTIC:
+      case AGGRESSIVE_HEURISTIC:
+      case PRIVATE:
         RenamePrototypes rproto =
             new RenamePrototypes(compiler, options.propertyRenaming, reservedChars, prevPropertyMap);
         rproto.process(externs, root);
         return rproto.getPropertyMap();
-
-      case AGGRESSIVE_HEURISTIC:
-        RenamePrototypes rproto2 =
-            new RenamePrototypes(compiler, options.propertyRenaming, reservedChars, prevPropertyMap);
-        rproto2.process(externs, root);
-        return rproto2.getPropertyMap();
-
-      case PRIVATE:
-          RenamePrototypes rproto3 =
-              new RenamePrototypes(compiler, options.propertyRenaming, reservedChars, prevPropertyMap);
-          rproto3.process(externs, root);
-          return rproto3.getPropertyMap();
 
       case ALL_UNQUOTED:
         RenameProperties rprop =

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2378,15 +2378,21 @@ public final class DefaultPassConfig extends PassConfig {
     switch (options.propertyRenaming) {
       case HEURISTIC:
         RenamePrototypes rproto =
-            new RenamePrototypes(compiler, false, reservedChars, prevPropertyMap);
+            new RenamePrototypes(compiler, options.propertyRenaming, reservedChars, prevPropertyMap);
         rproto.process(externs, root);
         return rproto.getPropertyMap();
 
       case AGGRESSIVE_HEURISTIC:
         RenamePrototypes rproto2 =
-            new RenamePrototypes(compiler, true, reservedChars, prevPropertyMap);
+            new RenamePrototypes(compiler, options.propertyRenaming, reservedChars, prevPropertyMap);
         rproto2.process(externs, root);
         return rproto2.getPropertyMap();
+
+      case PRIVATE:
+          RenamePrototypes rproto3 =
+              new RenamePrototypes(compiler, options.propertyRenaming, reservedChars, prevPropertyMap);
+          rproto3.process(externs, root);
+          return rproto3.getPropertyMap();
 
       case ALL_UNQUOTED:
         RenameProperties rprop =
@@ -2533,12 +2539,13 @@ public final class DefaultPassConfig extends PassConfig {
   }
 
   /**
-   * All inlining is forbidden in heuristic renaming mode, because inlining
-   * will ruin the invariants that it depends on.
+   * All inlining is forbidden in heuristic and private renaming modes,
+   * because inlining will ruin the invariants that it depends on.
    */
   private boolean isInliningForbidden() {
     return options.propertyRenaming == PropertyRenamingPolicy.HEURISTIC
-        || options.propertyRenaming == PropertyRenamingPolicy.AGGRESSIVE_HEURISTIC;
+        || options.propertyRenaming == PropertyRenamingPolicy.AGGRESSIVE_HEURISTIC
+        || options.propertyRenaming == PropertyRenamingPolicy.PRIVATE;
   }
 
   /** Create a compiler pass that runs the given passes in serial. */

--- a/src/com/google/javascript/jscomp/PropertyRenamingPolicy.java
+++ b/src/com/google/javascript/jscomp/PropertyRenamingPolicy.java
@@ -42,6 +42,14 @@ public enum PropertyRenamingPolicy {
   AGGRESSIVE_HEURISTIC,
 
   /**
+   * Rename all private properties (as defined by the coding conventions),
+   * provided they aren't externally defined (i.e. declared in an
+   * externs file).
+   * @see RenamePrototypes
+   */
+  PRIVATE,
+
+  /**
    * Rename all properties that aren't explicitly quoted and aren't
    * externally defined (i.e. declared in an externs file). This policy
    * achieves better compaction than the others.

--- a/src/com/google/javascript/jscomp/PropertyRenamingPolicy.java
+++ b/src/com/google/javascript/jscomp/PropertyRenamingPolicy.java
@@ -26,13 +26,17 @@ public enum PropertyRenamingPolicy {
   OFF,
 
   /**
-   * Rename properties heuristically.
+   * Rename properties that contain any non lower-case characters
+   * or that are private (as defined by the coding conventions),
+   * provided they aren't externally defined (i.e. declared in an
+   * externs file).
    * @see RenamePrototypes
    */
   HEURISTIC,
 
   /**
-   * Rename properties more heuristically.
+   * Rename all properties that would be considered for renaming when
+   * using the HEURISTIC mode.
    * @see RenamePrototypes
    */
   AGGRESSIVE_HEURISTIC,

--- a/src/com/google/javascript/jscomp/RenamePrototypes.java
+++ b/src/com/google/javascript/jscomp/RenamePrototypes.java
@@ -60,7 +60,7 @@ import javax.annotation.Nullable;
 class RenamePrototypes implements CompilerPass {
 
   private final AbstractCompiler compiler;
-  private final boolean aggressiveRenaming;
+  private final PropertyRenamingPolicy propertyRenamingPolicy;
   private final char[] reservedCharacters;
 
   /** Previously used prototype renaming map. */
@@ -114,11 +114,11 @@ class RenamePrototypes implements CompilerPass {
         return true;
       }
 
-      if (aggressiveRenaming) {
+      if (propertyRenamingPolicy == PropertyRenamingPolicy.AGGRESSIVE_HEURISTIC) {
         return true;
       }
 
-      if(matchesHeuristic(oldName)) {
+      if ((propertyRenamingPolicy == PropertyRenamingPolicy.HEURISTIC) && matchesHeuristic(oldName)) {
         return true;
       }
 
@@ -188,18 +188,18 @@ class RenamePrototypes implements CompilerPass {
    * Creates an instance.
    *
    * @param compiler The JSCompiler
-   * @param aggressiveRenaming Whether to rename aggressively
+   * @param propertyRenamingPolicy Whether to rename aggressively
    * @param reservedCharacters If specified these characters won't be used in
    *   generated names
    * @param prevUsedRenameMap The rename map used in the previous compilation
    */
   RenamePrototypes(
       AbstractCompiler compiler,
-      boolean aggressiveRenaming,
+      PropertyRenamingPolicy propertyRenamingPolicy,
       @Nullable char[] reservedCharacters,
       @Nullable VariableMap prevUsedRenameMap) {
     this.compiler = compiler;
-    this.aggressiveRenaming = aggressiveRenaming;
+    this.propertyRenamingPolicy = propertyRenamingPolicy;
     this.reservedCharacters = reservedCharacters;
     this.prevUsedRenameMap = prevUsedRenameMap;
   }

--- a/src/com/google/javascript/jscomp/RenamePrototypes.java
+++ b/src/com/google/javascript/jscomp/RenamePrototypes.java
@@ -118,13 +118,22 @@ class RenamePrototypes implements CompilerPass {
         return true;
       }
 
-      for (int i = 0, n = oldName.length(); i < n; i++) {
-        char ch = oldName.charAt(i);
+      if(matchesHeuristic(oldName)) {
+        return true;
+      }
+
+      return false;
+    }
+
+    private boolean matchesHeuristic(String name) {
+      for (int i = 0, n = name.length(); i < n; i++) {
+        char ch = name.charAt(i);
 
         if (Character.isUpperCase(ch) || !Character.isLetter(ch)) {
           return true;
         }
       }
+
       return false;
     }
 

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -1614,10 +1614,10 @@ public final class IntegrationTest extends IntegrationTestCase {
     String heuristic =
         "function f() { return this.foo + this['bar'] + this.a; }"
             + "f.prototype.bar = 3; f.prototype.a = 3;";
-    String aggHeuristic =
+    String all =
         "function f() { return this.foo + this['b'] + this.a; } "
             + "f.prototype.b = 3; f.prototype.a = 3;";
-    String all =
+    String allUnquoted =
         "function f() { return this.c + this['bar'] + this.a; }"
             + "f.prototype.b = 3; f.prototype.a = 3;";
     testSame(options, code);
@@ -1626,10 +1626,10 @@ public final class IntegrationTest extends IntegrationTestCase {
     test(options, code, heuristic);
 
     options.setPropertyRenaming(PropertyRenamingPolicy.AGGRESSIVE_HEURISTIC);
-    test(options, code, aggHeuristic);
+    test(options, code, all);
 
     options.setPropertyRenaming(PropertyRenamingPolicy.ALL_UNQUOTED);
-    test(options, code, all);
+    test(options, code, allUnquoted);
   }
 
   public void testConvertToDottedProperties() {

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -1610,23 +1610,29 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     String code =
         "function f() { return this.foo + this['bar'] + this.Baz; }" +
-        "f.prototype.bar = 3; f.prototype.Baz = 3;";
+        "f.prototype.bar = 3; f.prototype.bar_ = 3; f.prototype.Baz = 3;";
     String heuristic =
         "function f() { return this.foo + this['bar'] + this.a; }"
-            + "f.prototype.bar = 3; f.prototype.a = 3;";
-    String all =
+            + "f.prototype.bar = 3; f.prototype.b = 3; f.prototype.a = 3;";
+    String aggressiveHeuristic =
         "function f() { return this.foo + this['b'] + this.a; } "
-            + "f.prototype.b = 3; f.prototype.a = 3;";
+            + "f.prototype.b = 3; f.prototype.c = 3; f.prototype.a = 3;";
+    String privateOnly =
+         "function f() { return this.foo + this['bar'] + this.Baz; }"
+            + "f.prototype.bar = 3; f.prototype.a = 3; f.prototype.Baz = 3;";
     String allUnquoted =
-        "function f() { return this.c + this['bar'] + this.a; }"
-            + "f.prototype.b = 3; f.prototype.a = 3;";
+        "function f() { return this.d + this['bar'] + this.a; }"
+            + "f.prototype.b = 3; f.prototype.c = 3; f.prototype.a = 3;";
     testSame(options, code);
 
     options.setPropertyRenaming(PropertyRenamingPolicy.HEURISTIC);
     test(options, code, heuristic);
 
     options.setPropertyRenaming(PropertyRenamingPolicy.AGGRESSIVE_HEURISTIC);
-    test(options, code, all);
+    test(options, code, aggressiveHeuristic);
+
+    options.setPropertyRenaming(PropertyRenamingPolicy.PRIVATE);
+    test(options, code, privateOnly);
 
     options.setPropertyRenaming(PropertyRenamingPolicy.ALL_UNQUOTED);
     test(options, code, allUnquoted);

--- a/test/com/google/javascript/jscomp/RenamePrototypesTest.java
+++ b/test/com/google/javascript/jscomp/RenamePrototypesTest.java
@@ -29,7 +29,7 @@ public final class RenamePrototypesTest extends CompilerTestCase {
 
   @Override
   public CompilerPass getProcessor(Compiler compiler) {
-    return renamePrototypes = new RenamePrototypes(compiler, true, null, prevUsedRenameMap);
+    return renamePrototypes = new RenamePrototypes(compiler, PropertyRenamingPolicy.AGGRESSIVE_HEURISTIC, null, prevUsedRenameMap);
   }
 
   @Override


### PR DESCRIPTION
The heuristic used to determine whether member properties can be renamed is very liberal (it accepts any names containing symbols or non lower-case characters) which reduces the effectiveness of the `CodeConventions.isPrivate()` method for determining whether properties can be renamed. By providing a `PropertyRenamingPolicy.PRIVATE` flag, it becomes possible to let the `CodeConventions` instance better drive which properties get renamed or not.

I've also taken the opportunity to update the documentation so it better represents what actually happens in code, and to make the code easier to follow.
