### PR TITLE
Adding BEFORE_ALWAYS custom pass execution time

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -669,6 +669,8 @@ public class Compiler extends AbstractCompiler {
       return;
     }
 
+    runCustomPasses(CustomPassExecutionTime.BEFORE_ALWAYS);
+    
     if (!options.skipNonTranspilationPasses || options.lowerFromEs6()) {
       check();
       if (hasErrors()) {

--- a/src/com/google/javascript/jscomp/CustomPassExecutionTime.java
+++ b/src/com/google/javascript/jscomp/CustomPassExecutionTime.java
@@ -21,6 +21,8 @@ package com.google.javascript.jscomp;
  * custom pass executes.
  */
 public enum CustomPassExecutionTime {
+  /** Unlike other passes, this is always included, even in whitespace only mode */
+  BEFORE_ALWAYS,
   BEFORE_CHECKS,
   BEFORE_OPTIMIZATIONS,
   BEFORE_OPTIMIZATION_LOOP,


### PR DESCRIPTION
Necessary to allow custom passes in WHITESPACE_ONLY mode, such as to
process goog.module.

See #611.

Unless you are transpiling from ES6, WHITESPACE_ONLY mode disables all custom passes; this allows 3rd party use of Compiler in Java to add custom passes that apply to WHITESPACE_ONLY mode.