### PR TITLE
Fix maven tests

### DIFF
--- a/externs/pom.xml
+++ b/externs/pom.xml
@@ -48,7 +48,8 @@
             <phase>generate-sources</phase>
             <configuration>
               <tasks>
-                <zip destfile="target/generated-resources/externs.zip" basedir="." includes="*.js"/>
+                <zip destfile="../target/classes/externs.zip" basedir="." includes="**/*.js"/>
+                <zip destfile="target/classes/externs.zip" basedir="." includes="**/*.js"/>
               </tasks>
             </configuration>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
       <name>Paul Lindner</name>
       <email>lindner@inuus.com</email>
     </developer>
+
+    <developer>
+      <id>ckillingsworth</id>
+      <name>Chad Killingsworth</name>
+      <email>chadkillingsworth@gmail.com</email>
+    </developer>
   </developers>
 
   <properties>


### PR DESCRIPTION
Travis is currently failing because the externs.zip folder is not copied into the target/classes folder to be available for tests. I made that change for the ant build, but I forgot about Maven.

This may not be the most efficient way to do this. I barely use maven so I'm more or less hacking at the configuration to get it working.