### PR TITLE
Allow simple alias assignments in externs for type inference.

### DIFF
--- a/src/com/google/javascript/jscomp/VarCheck.java
+++ b/src/com/google/javascript/jscomp/VarCheck.java
@@ -17,7 +17,6 @@
 package com.google.javascript.jscomp;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.SyntacticScopeCreator.RedeclarationHandler;
 import com.google.javascript.rhino.IR;
@@ -102,9 +101,6 @@ class VarCheck extends AbstractPostOrderCallback implements
 
   // Whether extern checks emit error.
   private final boolean strictExternCheck;
-
-  private final Set allowedExternAssignmentTypes = ImmutableSet.of(
-      Token.VAR, Token.CONST, Token.LET);
 
   VarCheck(AbstractCompiler compiler) {
     this(compiler, false);
@@ -310,7 +306,7 @@ class VarCheck extends AbstractPostOrderCallback implements
             // Don't warn for simple var assignments "/** @const */ var foo = bar;"
             // They are used to infer the types of namespace aliases.
             if (parent.getType() != Token.NAME || parent.getParent() == null ||
-                !allowedExternAssignmentTypes.contains(parent.getParent().getType())) {
+                !NodeUtil.isNameDeclaration(parent.getParent())) {
               t.report(n, NAME_REFERENCE_IN_EXTERNS_ERROR, n.getString());
             }
 

--- a/src/com/google/javascript/jscomp/VarCheck.java
+++ b/src/com/google/javascript/jscomp/VarCheck.java
@@ -17,6 +17,7 @@
 package com.google.javascript.jscomp;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.SyntacticScopeCreator.RedeclarationHandler;
 import com.google.javascript.rhino.IR;
@@ -101,6 +102,9 @@ class VarCheck extends AbstractPostOrderCallback implements
 
   // Whether extern checks emit error.
   private final boolean strictExternCheck;
+
+  private final Set allowedExternAssignmentTypes = ImmutableSet.of(
+      Token.VAR, Token.CONST, Token.LET);
 
   VarCheck(AbstractCompiler compiler) {
     this(compiler, false);
@@ -306,7 +310,7 @@ class VarCheck extends AbstractPostOrderCallback implements
             // Don't warn for simple var assignments "/** @const */ var foo = bar;"
             // They are used to infer the types of namespace aliases.
             if (parent.getType() != Token.NAME || parent.getParent() == null ||
-                parent.getParent().getType() != Token.VAR) {
+                !allowedExternAssignmentTypes.contains(parent.getParent().getType())) {
               t.report(n, NAME_REFERENCE_IN_EXTERNS_ERROR, n.getString());
             }
 

--- a/src/com/google/javascript/jscomp/VarCheck.java
+++ b/src/com/google/javascript/jscomp/VarCheck.java
@@ -303,7 +303,12 @@ class VarCheck extends AbstractPostOrderCallback implements
             }
             // fall through
           default:
-            t.report(n, NAME_REFERENCE_IN_EXTERNS_ERROR, n.getString());
+            // Don't warn for simple var assignments "/** @const */ var foo = bar;"
+            // They are used to infer the types of namespace aliases.
+            if (parent.getType() != Token.NAME || parent.getParent() == null ||
+                parent.getParent().getType() != Token.VAR) {
+              t.report(n, NAME_REFERENCE_IN_EXTERNS_ERROR, n.getString());
+            }
 
             Scope scope = t.getScope();
             Var var = scope.getVar(n.getString());

--- a/test/com/google/javascript/jscomp/VarCheckTest.java
+++ b/test/com/google/javascript/jscomp/VarCheckTest.java
@@ -180,6 +180,10 @@ public final class VarCheckTest extends Es6CompilerTestCase {
     testSame("var asdf;", "asdf;", null);
   }
 
+  public void testVarAssignmentInExterns() {
+    testSame("/** @type{{foo:string}} */ var foo; var asdf = foo;", "asdf.foo;", null);
+  }
+
   public void testLetDeclarationInExterns() {
     testSameEs6("let asdf;", "asdf;", null);
   }


### PR DESCRIPTION
The compiler can correctly infer the types of aliases in externs when they are assigned and we should allow this pattern.

This removes the spurious warning that is generated for such simple assignments.

I can remove 400 lines from the jQuery externs with this change.