### PR TITLE
Remove @nosideeffects from DataTransferItem.prototype.getAsString()

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2014,7 +2014,6 @@ DataTransferItem.prototype.type;
 
 /**
  * @param {function(string)} callback
- * @nosideeffects
  */
 DataTransferItem.prototype.getAsString = function(callback) {};
 


### PR DESCRIPTION
The following code incorrectly compiles to nothing:

```javascript
var test = /** @type {!DataTransferItem} */(window['item']);
test.getAsString(alert);
```

[`DataTransferItem.prototype.getAsString`](http://www.w3.org/TR/2011/WD-html5-20110113/dnd.html#the-datatransferitem-interface) was incorrect labeled as not having side effects.

More generally, it may be a good idea to warning about externs with `@nosideeffects` that are missing `@return`.