### PR TITLE
Fixing Eclipse classpath to exclude GWT (trivial)

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry including="**/*.java|**/*.properties" kind="src" path="src"/>
+	<classpathentry excluding="**/gwt/**" including="**/*.java|**/*.properties" kind="src" path="src"/>
 	<classpathentry including="**/*.java" kind="src" path="gen"/>
 	<classpathentry including="**/*.java" kind="src" output="build/test-classes" path="test"/>
 	<classpathentry kind="lib" path="lib/ant.jar"/>


### PR DESCRIPTION
As per Ant build.xml rules