### PR TITLE
Fix handling of function declarations in loops with let/consts

### DIFF
--- a/src/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclaration.java
+++ b/src/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclaration.java
@@ -16,14 +16,6 @@
 
 package com.google.javascript.jscomp;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
@@ -34,6 +26,14 @@ import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.JSDocInfoBuilder;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Rewrite "let"s and "const"s as "var"s.

--- a/src/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclaration.java
+++ b/src/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclaration.java
@@ -342,11 +342,11 @@ public final class Es6RewriteBlockScopedDeclaration extends AbstractPostOrderCal
                 }
               }
 
-              // Change reference to GETPROP.
               if (reference.getParent().isCall()
                   && reference.getParent().getFirstChild() == reference) {
                 reference.getParent().putBooleanProp(Node.FREE_CALL, false);
               }
+              // Change reference to GETPROP.
               reference.getParent().replaceChild(
                   reference,
                   IR.getprop(IR.name(object.name), IR.string(var.name))

--- a/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
+++ b/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
@@ -746,6 +746,25 @@ public final class Es6RewriteBlockScopedDeclarationTest extends CompilerTestCase
         "  }($jscomp$loop$0);",
         "  $jscomp$loop$0 = {x:$jscomp$loop$0.x};",
         "}"));
+
+    test(LINE_JOINER.join(
+        "while (true) {",
+        "  let x = null;",
+        "  (function() {",
+        "    x();",
+        "  })();",
+        "}"),
+        LINE_JOINER.join(
+        "var $jscomp$loop$0 = {x:undefined};",
+        "while (true) {",
+        "  $jscomp$loop$0.x = null;",
+        "  (function($jscomp$loop$0) {",
+        "    return function () {",
+        "      ($jscomp$loop$0.x)();",
+        "    };",
+        "  })($jscomp$loop$0)();",
+        "  $jscomp$loop$0 = {x:$jscomp$loop$0.x};",
+        "}"));
   }
 
   public void testDoWhileForOfCapturedLetAnnotated() {

--- a/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
+++ b/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
@@ -708,6 +708,46 @@ public final class Es6RewriteBlockScopedDeclarationTest extends CompilerTestCase
             "} while (false);"));
   }
 
+  public void testIssue1124() {
+    test(LINE_JOINER.join(
+        "while (true) {",
+        "  let x = null;",
+        "  var f = function() {",
+        "    x();",
+        "  }",
+        "}"),
+        LINE_JOINER.join(
+        "var $jscomp$loop$0 = {x:undefined};",
+        "while (true) {",
+        "  $jscomp$loop$0.x = null;",
+        "  var f = function($jscomp$loop$0) {",
+        "    return function() {",
+        "      ($jscomp$loop$0.x)();",
+        "    };",
+        "  }($jscomp$loop$0);",
+        "  $jscomp$loop$0 = {x:$jscomp$loop$0.x};",
+        "}"));
+
+    test(LINE_JOINER.join(
+        "while (true) {",
+        "  let x = null;",
+        "  function f() {",
+        "    x();",
+        "  }",
+        "}"),
+        LINE_JOINER.join(
+        "var $jscomp$loop$0 = {x:undefined};",
+        "while (true) {",
+        "  $jscomp$loop$0.x = null;",
+        "  var f = function($jscomp$loop$0) {",
+        "    return function f() {",
+        "      ($jscomp$loop$0.x)();",
+        "    };",
+        "  }($jscomp$loop$0);",
+        "  $jscomp$loop$0 = {x:$jscomp$loop$0.x};",
+        "}"));
+  }
+
   public void testDoWhileForOfCapturedLetAnnotated() {
     enableTypeCheck(CheckLevel.WARNING);
 

--- a/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
+++ b/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
@@ -708,7 +708,8 @@ public final class Es6RewriteBlockScopedDeclarationTest extends CompilerTestCase
             "} while (false);"));
   }
 
-  public void testIssue1124() {
+  // https://github.com/google/closure-compiler/issues/1124
+  public void testGithubIssue1124() {
     test(LINE_JOINER.join(
         "while (true) {",
         "  let x = null;",


### PR DESCRIPTION
Convert function declaration to variable declaration so that the IIFE can still be applied.

Unmark calls to captured functions like $jscomp$loop.x() as FREE_CALL.

Fixes #1124 