### PR TITLE
Update links to migrated off of Google Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ options/arguments in your CUI application.</td>
 
   <tr>
     <td>URL</td>
-    <td>http://code.google.com/p/protobuf/</td>
+    <td>https://github.com/google/protobuf</td>
   </tr>
 
   <tr>
@@ -448,7 +448,7 @@ without make's wrinkles and with the full portability of pure java code.</td>
 
   <tr>
     <td>URL</td>
-    <td>https://code.google.com/p/google-gson/</td>
+    <td>https://github.com/google/gson</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
With Google Code ([code.google.com](https://code.google.com)) turning down early next year, active
projects are migrating elsewhere. This change updates the links to the
GSON and protobuf projects, which have since migrated to GitHub.

There still is a link to [https://code.google.com/p/jsr-305/](https://code.google.com/archive/p/jsr-305/), which has
not migrated. That URL will continue to work until after Google Code
gets shut down, but it will show users an archived version of the project.
(You can see a demo at [https://code.google.com/archive/p/jsr-305/](https://code.google.com/archive/p/jsr-305/).)