### PR TITLE
Speed Travis CI execution up + have it run protobuf-gen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,15 @@ sudo: false
 
 notifications:
   email: false
+
+cache:
+  directories:
+    # Cache Maven repository.
+    - $HOME/.m2
+    # Cache prebuilt protoc binaries.
+    - $HOME/.protobuf
+
+# By default, install runs `mvn install -DskipTests=true` and test runs `mvn test`.
+# In our case though, it would be very inefficient as we re-do lots of work.
+install: ./get-protoc.sh
+test: mvn install -Pprotobuf-gen -Dprotoc.executable=`./get-protoc.sh`

--- a/get-protoc.sh
+++ b/get-protoc.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# 
+# Gets the version of protoc needed to build Closure, and prints its path.
+# Downloads sources and builds them if needed, and caches the binary in ~/.protobuf.
+#
+# Note: the version of protobuf-compiler available through
+# Travis CI's addons.apt.packages mechanism is 2.4.1, and protoc's version really
+# needs to match that of the protobuf-java dependency.
+#
+set -eu
+
+PROTOBUF_VERSION=$( \
+  cat pom-main.xml | \
+  grep "<protobuf.version>" | \
+  sed -E 's/.*>(.*)<.*/\1/' \
+)
+
+# Where we'll install protoc (on Travis CI, will be cached).
+PROTOBUF_DIR=$HOME/.protobuf/$PROTOBUF_VERSION
+PROTOC=$PROTOBUF_DIR/bin/protoc
+
+function getAndBuildProtoc() {
+  local name=protobuf-$PROTOBUF_VERSION
+
+  rm -fR $name*
+  wget https://protobuf.googlecode.com/files/$name.tar.gz
+  tar -xzvf $name.tar.gz
+  cd $name
+
+  ./configure --prefix=$PROTOBUF_DIR
+  make
+  make install
+
+  cd ..
+  rm -fR $name*
+}
+
+if [[ ! -x $PROTOC ]]; then
+  getAndBuildProtoc >&2
+fi
+
+# Print the path to protoc.
+echo $PROTOC

--- a/pom-main.xml
+++ b/pom-main.xml
@@ -38,6 +38,9 @@
   <inceptionYear>2009</inceptionYear>
 
   <properties>
+    <protobuf.version>2.5.0</protobuf.version>
+    <protoc.executable>protoc</protoc.executable>
+    <protoc.generatedSources>${project.basedir}/gen</protoc.generatedSources>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <jdk.version>1.7</jdk.version>
@@ -76,7 +79,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.5.0</version>
+      <version>${protobuf.version}</version>
     </dependency>
 
     <dependency>
@@ -143,7 +146,7 @@
             <goals><goal>add-source</goal></goals>
             <configuration>
               <sources>
-                <source>gen</source>
+                <source>${protoc.generatedSources}</source>
               </sources>
             </configuration>
           </execution>
@@ -240,7 +243,6 @@
           </execution>
         </executions>
       </plugin>
-
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
@@ -265,6 +267,43 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>protobuf-gen</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>protobuf-gen</id>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <tasks>
+                    <mkdir dir="${protoc.generatedSources}" />
+                    <fileset dir="${project.basedir}/src" id="proto.classpath">
+                      <include name="**/*.proto"/>
+                    </fileset>
+                    <pathconvert property="protofiles" pathsep=" " refid="proto.classpath"/>
+                    <echo message="${protoc.executable} -I ${src.dir} --java_out=${gen.dir} ${protofiles}"/>
+                    <exec executable="${protoc.executable}" searchpath="true">
+                      <arg line="-I ${project.basedir}/src"/>
+                      <arg line="--java_out=${protoc.generatedSources}"/>
+                      <arg line="${protofiles}"/>
+                    </exec>
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <!-- reporting -->
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,9 @@
 
   <profiles>
     <profile>
+      <id>protobuf-gen</id>
+    </profile>
+    <profile>
       <id>parallel-test</id>
       <build>
         <plugins>


### PR DESCRIPTION
This downloads & caches the right version of protoc, and cuts nearly a minute of execution in Travis CI (thanks to single mvn build & caching of local repo).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1132)
<!-- Reviewable:end -->
