### PR TITLE
Transpile ES6 super getprop & getelem calls (fixes #1089)

### DIFF
--- a/src/com/google/javascript/jscomp/Es6ConvertSuper.java
+++ b/src/com/google/javascript/jscomp/Es6ConvertSuper.java
@@ -62,7 +62,7 @@ public final class Es6ConvertSuper implements NodeTraversal.Callback, HotSwapCom
       }
       checkClassSuperReferences(n);
     } else if (isSuperGet(n)) {
-      if (isInsideStaticMember(n)) {
+      if (NodeUtil.isEnclosedByStaticMember(n)) {
         compiler.report(JSError.make(n, CANNOT_CONVERT_YET,
             "Super calls in static members are not allowed."));
       }
@@ -77,16 +77,6 @@ public final class Es6ConvertSuper implements NodeTraversal.Callback, HotSwapCom
     if (n.isSuper()) {
       visitSuper(n, parent);
     }
-  }
-
-  private boolean isInsideStaticMember(Node n) {
-    while (n != null) {
-      if (n.isMemberFunctionDef() && n.isStaticMember()) {
-        return true;
-      }
-      n = n.getParent();
-    }
-    return false;
   }
 
   private boolean isSuperGet(Node n) {

--- a/src/com/google/javascript/jscomp/Es6ConvertSuper.java
+++ b/src/com/google/javascript/jscomp/Es6ConvertSuper.java
@@ -15,6 +15,7 @@
  */
 package com.google.javascript.jscomp;
 
+import static com.google.javascript.jscomp.Es6ToEs3Converter.CALL_SUPER_GETTER;
 import static com.google.javascript.jscomp.Es6ToEs3Converter.CANNOT_CONVERT_YET;
 
 import com.google.common.base.Joiner;
@@ -60,6 +61,13 @@ public final class Es6ConvertSuper implements NodeTraversal.Callback, HotSwapCom
         addSyntheticConstructor(n);
       }
       checkClassSuperReferences(n);
+    } else if (isSuperGet(n)) {
+      if (isInsideStaticMember(n)) {
+        compiler.report(JSError.make(n, CANNOT_CONVERT_YET,
+            "Super calls in static members are not allowed."));
+      }
+      visitSuperGet(n);
+      return false; // Don't visit the super we've just removed.
     }
     return true;
   }
@@ -69,6 +77,37 @@ public final class Es6ConvertSuper implements NodeTraversal.Callback, HotSwapCom
     if (n.isSuper()) {
       visitSuper(n, parent);
     }
+  }
+
+  private boolean isInsideStaticMember(Node n) {
+    while (n != null) {
+      if (n.isMemberFunctionDef() && n.isStaticMember()) {
+        return true;
+      }
+      n = n.getParent();
+    }
+    return false;
+  }
+
+  private boolean isSuperGet(Node n) {
+    return (n.isGetProp() || n.isGetElem())
+        && !n.getParent().isCall()
+        && n.getFirstChild().isSuper();
+  }
+
+  private void visitSuperGet(Node n) {
+    Preconditions.checkArgument(isSuperGet(n));
+
+    Node name = n.getLastChild().cloneTree();
+    Node callSuperGetter = IR.call(
+        NodeUtil.newQName(compiler, CALL_SUPER_GETTER),
+        IR.thisNode(),
+        n.isGetProp() ? NodeUtil.renameProperty(name) : name).srcrefTree(n);
+
+    n.getParent().replaceChild(n, callSuperGetter);
+
+    compiler.needsEs6Runtime = true;
+    compiler.reportCodeChange();
   }
 
   private void addSyntheticConstructor(Node classNode) {
@@ -110,7 +149,7 @@ public final class Es6ConvertSuper implements NodeTraversal.Callback, HotSwapCom
     }
     if (!enclosingCall.isCall() || enclosingCall.getFirstChild() != potentialCallee) {
       compiler.report(JSError.make(node, CANNOT_CONVERT_YET,
-          "Only calls to super or to a method of super are supported."));
+          "Only calls to super or to a method/getter of super are supported."));
       return;
     }
     Node clazz = NodeUtil.getEnclosingClass(node);

--- a/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
+++ b/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
@@ -89,6 +89,7 @@ public final class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapC
   // These functions are defined in js/es6_runtime.js
   static final String INHERITS = "$jscomp.inherits";
   static final String MAKE_ITER = "$jscomp.makeIterator";
+  static final String CALL_SUPER_GETTER = "$jscomp.callSuperGetter";
 
   public Es6ToEs3Converter(AbstractCompiler compiler) {
     this.compiler = compiler;

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -895,6 +895,18 @@ public final class NodeUtil {
   }
 
   /**
+   * Wraps a property string in a JSCompiler_renameProperty call.
+   *
+   * <p>Should only be called in phases running before {@link RenameProperties}.
+   */
+  static Node renameProperty(Node name) {
+    Preconditions.checkArgument(name.isString());
+    Node call = IR.call(IR.name(JSC_PROPERTY_NAME_FN), name).srcrefTree(name);
+    call.putBooleanProp(Node.FREE_CALL, true);
+    return call;
+  }
+
+  /**
    * Returns true if the node may create new mutable state, or change existing
    * state.
    *

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -907,6 +907,24 @@ public final class NodeUtil {
   }
 
   /**
+   * Returns true if this node is or is enclosed by a static member definition (static method,
+   * getter or setter).
+   */
+  static boolean isEnclosedByStaticMember(Node n) {
+    while (n != null) {
+      if (n.isMemberFunctionDef() && n.isStaticMember()) {
+        return true;
+      }
+      if (n.isClass()) {
+        // Stop at the first enclosing class.
+        return false;
+      }
+      n = n.getParent();
+    }
+    return false;
+  }
+
+  /**
    * Returns true if the node may create new mutable state, or change existing
    * state.
    *

--- a/src/com/google/javascript/jscomp/js/es6_runtime.js
+++ b/src/com/google/javascript/jscomp/js/es6_runtime.js
@@ -161,3 +161,40 @@ $jscomp.inherits = function(childCtor, parentCtor) {
     }
   }
 };
+
+/**
+ * Gets a property descriptor for a target instance, skipping its class
+ * and walking up the super-classes hierarchy.
+ *
+ * @param {*} target
+ * @param {!string} propertyName
+ */
+$jscomp.getSuperPropertyDescriptor = function(target, propertyName) {
+  var getPrototypeOf = $jscomp.global.Object.getPrototypeOf;
+  var cls = getPrototypeOf(target);
+  while (cls != null) {
+    cls = getPrototypeOf(cls);
+    var desc = $jscomp.global.Object.getOwnPropertyDescriptor(cls, propertyName);
+    if (desc != null) {
+      return desc;
+    }
+  }
+  throw new Error('No property ' + propertyName + ' defined in super class(es)');
+};
+
+/**
+ * Calls a property getter from the target instance's super class.
+ *
+ * Note that callers may want to use JSCompiler_renameProperty to
+ * play nicely with property renaming.
+ *
+ * TODO(ochafik): Do the same for setters.
+ *
+ * @param {*} target
+ * @param {!string} propertyName
+ */
+$jscomp.callSuperGetter = function(target, propertyName) {
+  var desc = $jscomp.getSuperPropertyDescriptor(target, propertyName);
+  var getter = desc['get'];
+  return getter != null ? getter.call(target) : desc['value'];
+};

--- a/src/com/google/javascript/jscomp/js/es6_runtime.js
+++ b/src/com/google/javascript/jscomp/js/es6_runtime.js
@@ -166,20 +166,22 @@ $jscomp.inherits = function(childCtor, parentCtor) {
  * Gets a property descriptor for a target instance, skipping its class
  * and walking up the super-classes hierarchy.
  *
- * @param {*} target
- * @param {!string} propertyName
+ * @param {!Object} target
+ * @param {!string} name
+ * @return {!Object.<ObjectPropertyDescriptor>}
+ * @throws If there is no such a property on the super class.
  */
-$jscomp.getSuperPropertyDescriptor = function(target, propertyName) {
+$jscomp.getSuperPropertyDescriptor = function(target, name) {
   var getPrototypeOf = $jscomp.global.Object.getPrototypeOf;
   var cls = getPrototypeOf(target);
   while (cls != null) {
     cls = getPrototypeOf(cls);
-    var desc = $jscomp.global.Object.getOwnPropertyDescriptor(cls, propertyName);
+    var desc = $jscomp.global.Object.getOwnPropertyDescriptor(cls, name);
     if (desc != null) {
       return desc;
     }
   }
-  throw new Error('No property ' + propertyName + ' defined in super class(es)');
+  throw new Error('No property ' + name + ' in super class(es)');
 };
 
 /**
@@ -190,11 +192,11 @@ $jscomp.getSuperPropertyDescriptor = function(target, propertyName) {
  *
  * TODO(ochafik): Do the same for setters.
  *
- * @param {*} target
- * @param {!string} propertyName
+ * @param {!Object} target
+ * @param {!string} name
+ * @return {*}
  */
-$jscomp.callSuperGetter = function(target, propertyName) {
-  var desc = $jscomp.getSuperPropertyDescriptor(target, propertyName);
-  var getter = desc['get'];
-  return getter != null ? getter.call(target) : desc['value'];
+$jscomp.callSuperGetter = function(target, name) {
+  var desc = $jscomp.getSuperPropertyDescriptor(target, name);
+  return desc.get != null ? desc.get.call(target) : desc.value;
 };

--- a/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
@@ -542,24 +542,30 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
   }
 
   public void testSuperGet() {
-    testError("class D {} class C extends D { f() {var i = super.c;} }",
-              Es6ToEs3Converter.CANNOT_CONVERT_YET);
+    test("class D {} class C extends D { f() { var i = super.c; i = super.foo.bar(); } }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */",
+            "var D = function() {};",
+            "/** @constructor @struct @extends {D} */",
+            "var C = function(var_args) { D.apply(this, arguments); };",
+            "$jscomp.inherits(C, D);",
+            "C.prototype.f = function() {",
+            "  var i = $jscomp.callSuperGetter(this, JSCompiler_renameProperty('c'));",
+            "  i = $jscomp.callSuperGetter(this, JSCompiler_renameProperty('foo')).bar();",
+            "};"));
+    test("class D {} class C extends D { f() { var i = super['s']; } }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */",
+            "var D = function() {};",
+            "/** @constructor @struct @extends {D} */",
+            "var C = function(var_args) { D.apply(this, arguments); };",
+            "$jscomp.inherits(C, D);",
+            "C.prototype.f = function() {",
+            "  var i = $jscomp.callSuperGetter(this, 's');",
+            "};"));
 
     testError("class D {} class C extends D { static f() {var i = super.c;} }",
               Es6ToEs3Converter.CANNOT_CONVERT_YET);
-
-    testError("class D {} class C extends D { f() {var i; i = super[s];} }",
-              Es6ToEs3Converter.CANNOT_CONVERT_YET);
-
-    testError("class D {} class C extends D { f() {return super.s;} }",
-              Es6ToEs3Converter.CANNOT_CONVERT_YET);
-
-    testError("class D {} class C extends D { f() {m(super.s);} }",
-              Es6ToEs3Converter.CANNOT_CONVERT_YET);
-
-    testError(
-        "class D {} class C extends D { foo() { return super.m.foo(); } }",
-        Es6ToEs3Converter.CANNOT_CONVERT_YET);
 
     testError(
         "class D {} class C extends D { static foo() { return super.m.foo(); } }",


### PR DESCRIPTION
(fixes https://github.com/google/closure-compiler/issues/1089, which is blocking https://github.com/dart-lang/dev_compiler/issues/312)