### PR TITLE
Fix spurious parse error on TypeScript keywords

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/parser/Keywords.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Keywords.java
@@ -120,6 +120,18 @@ public enum Keywords {
   public static boolean isKeyword(TokenType token) {
     return get(token) != null;
   }
+  
+  public static boolean isTypeScriptSpecificKeyword(String value) {
+    switch (value) {
+      case "declare":
+      case "type":
+      case "module":
+      case "namespace":
+        return true;
+      default:
+        return false;
+    }
+  }
 
   /**
    * Returns true if {@code token} is a "future reserved word" which can

--- a/src/com/google/javascript/jscomp/parsing/parser/Keywords.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Keywords.java
@@ -120,7 +120,7 @@ public enum Keywords {
   public static boolean isKeyword(TokenType token) {
     return get(token) != null;
   }
-  
+
   public static boolean isTypeScriptSpecificKeyword(String value) {
     switch (value) {
       case "declare":

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -2431,7 +2431,8 @@ public class Parser {
     if (colon == null) {
       if (name.type != TokenType.IDENTIFIER) {
         reportExpectedError(peekToken(), TokenType.COLON);
-      } else if (Keywords.isKeyword(name.asIdentifier().value)) {
+      } else if (Keywords.isKeyword(name.asIdentifier().value)
+          && !Keywords.isTypeScriptSpecificKeyword(name.asIdentifier().value)) {
         reportError(name, "Cannot use keyword in short object literal");
       }
     }
@@ -3239,7 +3240,8 @@ public class Parser {
       name = eatIdOrKeywordAsId();
       if (!peek(TokenType.COLON)) {
         IdentifierToken idToken = (IdentifierToken) name;
-        if (Keywords.isKeyword(idToken.value)) {
+        if (Keywords.isKeyword(idToken.value)
+            && !Keywords.isTypeScriptSpecificKeyword(idToken.value)) {
           reportError("cannot use keyword '" + name + "' here.");
         }
         if (peek(TokenType.EQUAL)) {

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -1006,7 +1006,7 @@ public final class NewParserTest extends BaseJSTypeTestCase {
   public void testMethodInObjectLiteral() {
     testMethodInObjectLiteral("var a = {b() {}};");
     testMethodInObjectLiteral("var a = {b() { alert('b'); }};");
-    
+
     // Static methods not allowed in object literals.
     parseError("var a = {static b() { alert('b'); }};",
         "Cannot use keyword in short object literal");
@@ -1029,7 +1029,7 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     testExtendedObjectLiteral("var a = {declare};");
     testExtendedObjectLiteral("var a = {namespace};");
     testExtendedObjectLiteral("var a = {module};");
-    
+
     parseError("var a = { '!@#$%' };", "':' expected");
     parseError("var a = { 123 };", "':' expected");
     parseError("var a = { let };", "Cannot use keyword in short object literal");

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -1006,7 +1006,7 @@ public final class NewParserTest extends BaseJSTypeTestCase {
   public void testMethodInObjectLiteral() {
     testMethodInObjectLiteral("var a = {b() {}};");
     testMethodInObjectLiteral("var a = {b() { alert('b'); }};");
-
+    
     // Static methods not allowed in object literals.
     parseError("var a = {static b() { alert('b'); }};",
         "Cannot use keyword in short object literal");
@@ -1025,7 +1025,11 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     testExtendedObjectLiteral("var a = {b};");
     testExtendedObjectLiteral("var a = {b, c};");
     testExtendedObjectLiteral("var a = {b, c: d, e};");
-
+    testExtendedObjectLiteral("var a = {type};");
+    testExtendedObjectLiteral("var a = {declare};");
+    testExtendedObjectLiteral("var a = {namespace};");
+    testExtendedObjectLiteral("var a = {module};");
+    
     parseError("var a = { '!@#$%' };", "':' expected");
     parseError("var a = { 123 };", "':' expected");
     parseError("var a = { let };", "Cannot use keyword in short object literal");
@@ -1368,6 +1372,11 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     mode = LanguageMode.ECMASCRIPT6;
     parse("var {if: x, else: y} = foo();");
     parse("var {while: x=1, for: y} = foo();");
+    parse("var {type} = foo();");
+    parse("var {declare} = foo();");
+    parse("var {module} = foo();");
+    parse("var {namespace} = foo();");
+
     parseError("var {while} = foo();", "cannot use keyword 'while' here.");
     parseError("var {implements} = foo();", "cannot use keyword 'implements' here.");
   }


### PR DESCRIPTION
TypeScript specific keywords should be allowed as object literal field names. Fixed the parser to not report errors on them.

Fixes #1135 and #1136