### PR TITLE
Support shorthand field in exported object literal in ClosureRewriteModule

### DIFF
--- a/src/com/google/javascript/jscomp/ClosureRewriteModule.java
+++ b/src/com/google/javascript/jscomp/ClosureRewriteModule.java
@@ -83,6 +83,11 @@ final class ClosureRewriteModule implements NodeTraversal.Callback, HotSwapCompi
           "JSC_GOOG_MODULE_INVALID_GET_ALIAS",
           "goog.module.get should not be aliased.");
 
+  static final DiagnosticType INVALID_EXPORT_COMPUTED_PROPERTY =
+      DiagnosticType.error(
+          "JSC_GOOG_MODULE_INVALID_EXPORT_COMPUTED_PROPERTY",
+          "Computed properties are not yet supported in goog.module exports.");
+
   private final AbstractCompiler compiler;
 
   private class ModuleDescription {
@@ -348,7 +353,9 @@ final class ClosureRewriteModule implements NodeTraversal.Callback, HotSwapCompi
 
     if (rhs.isObjectLit()) {
       for (Node c = rhs.getFirstChild(); c != null; c = c.getNext()) {
-        if (c.isStringKey()) {
+        if (c.isComputedProp()) {
+          t.report(c, INVALID_EXPORT_COMPUTED_PROPERTY);
+        } else if (c.isStringKey()) {
           Node value = c.hasChildren() ? c.getFirstChild() : IR.name(c.getString());
           maybeUpdateExportDeclToNode(t, c, value);
         }

--- a/src/com/google/javascript/jscomp/ClosureRewriteModule.java
+++ b/src/com/google/javascript/jscomp/ClosureRewriteModule.java
@@ -349,7 +349,7 @@ final class ClosureRewriteModule implements NodeTraversal.Callback, HotSwapCompi
     if (rhs.isObjectLit()) {
       for (Node c = rhs.getFirstChild(); c != null; c = c.getNext()) {
         if (c.isStringKey()) {
-          Node value = c.getFirstChild();
+          Node value = c.hasChildren() ? c.getFirstChild() : IR.name(c.getString());
           maybeUpdateExportDeclToNode(t, c, value);
         }
       }

--- a/test/com/google/javascript/jscomp/ClosureRewriteModuleTest.java
+++ b/test/com/google/javascript/jscomp/ClosureRewriteModuleTest.java
@@ -396,6 +396,17 @@ public final class ClosureRewriteModuleTest extends Es6CompilerTestCase {
         + "});");
   }
 
+  public void testExportEnhancedObjectLiteral() {
+    testEs6(
+        "goog.module('ns.a');" +
+        "exports = { something };",
+
+        "goog.provide('ns.a');" +
+        "goog.scope(function(){" +
+        "  /** @const */ ns.a = { /** @const */ something };" +
+        "});");
+  }
+
   public void testRequiresRetainOrder() {
     test(
         "goog.module('ns.a');" +

--- a/test/com/google/javascript/jscomp/ClosureRewriteModuleTest.java
+++ b/test/com/google/javascript/jscomp/ClosureRewriteModuleTest.java
@@ -405,6 +405,11 @@ public final class ClosureRewriteModuleTest extends Es6CompilerTestCase {
         "goog.scope(function(){" +
         "  /** @const */ ns.a = { /** @const */ something };" +
         "});");
+
+    testErrorEs6(
+        "goog.module('ns.a');" +
+        "exports = { [something]: 3 };",
+        ClosureRewriteModule.INVALID_EXPORT_COMPUTED_PROPERTY);
   }
 
   public void testRequiresRetainOrder() {


### PR DESCRIPTION
Fixed it so that "exports = {x}" is treated as "exports = {x: x}".

Report an error if goog.module exports contain computed properties.

Fixes #1142 