### PR TITLE
Supporting @suppress annotation on class nodes

### DIFF
--- a/src/com/google/javascript/jscomp/SuppressDocWarningsGuard.java
+++ b/src/com/google/javascript/jscomp/SuppressDocWarningsGuard.java
@@ -68,6 +68,9 @@ class SuppressDocWarningsGuard extends WarningsGuard {
         if (type == Token.FUNCTION) {
           info = NodeUtil.getBestJSDocInfo(current);
           visitedFunction = true;
+        } else if (current.isClass()) {
+          // for example: /** @suppress {missingRequire} */ class X extends Y
+          info = current.getJSDocInfo();
         } else if (type == Token.SCRIPT) {
           info = current.getJSDocInfo();
         } else if (current.isVar() || current.isAssign()) {


### PR DESCRIPTION
SuppressDocWarningsGuard wasn't observing class nodes when looking for
@suppress, as needed for missingRequire on class X extends Y:

``` javascript
/** @suppress {missingRequire} */
class X extends Y.Z { // where Y.Z is in externs
}
```

Without this:
```
WARNING - 'Y.Z' used but not goog.require'd
```

See https://github.com/google/closure-compiler/issues/1143
and https://github.com/google/closure-compiler/issues/1145