### PR TITLE
ES6: Accept IdentiferName (including Keyword) in ExportSpecifier and ImportSpecifier.

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/IRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/IRFactory.java
@@ -2033,10 +2033,13 @@ class IRFactory {
     }
 
     Node processExportSpec(ExportSpecifierTree tree) {
-      Node exportSpec = newNode(Token.EXPORT_SPEC,
-          processName(tree.importedName));
+      Node importedName = processName(tree.importedName, true);
+      importedName.setType(Token.NAME);
+      Node exportSpec = newNode(Token.EXPORT_SPEC, importedName);
       if (tree.destinationName != null) {
-        exportSpec.addChildToBack(processName(tree.destinationName));
+        Node destinationName = processName(tree.destinationName, true);
+        destinationName.setType(Token.NAME);
+        exportSpec.addChildToBack(destinationName);
       }
       return exportSpec;
     }
@@ -2054,8 +2057,9 @@ class IRFactory {
     }
 
     Node processImportSpec(ImportSpecifierTree tree) {
-      Node importSpec = newNode(Token.IMPORT_SPEC,
-          processName(tree.importedName));
+      Node importedName = processName(tree.importedName, true);
+      importedName.setType(Token.NAME);
+      Node importSpec = newNode(Token.IMPORT_SPEC, importedName);
       if (tree.destinationName != null) {
         importSpec.addChildToBack(processName(tree.destinationName));
       }

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -3426,11 +3426,7 @@ public class Parser {
   }
 
   private boolean peekIdOrKeyword() {
-    return peekIdOrKeyword(0);
-  }
-
-  private boolean peekIdOrKeyword(int index) {
-    TokenType type = peekType(index);
+    TokenType type = peekType();
     return TokenType.IDENTIFIER == type || Keywords.isKeyword(type);
   }
 

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -374,6 +374,9 @@ public class Parser {
       } else {
         parseExplicitNames = false;
       }
+    } else if (Keywords.isKeyword(peekType())) {
+        Token keyword = nextToken();
+        reportError(keyword, "cannot use keyword '%s' here.", keyword);
     }
 
     if (parseExplicitNames) {
@@ -415,12 +418,13 @@ public class Parser {
   //  ImportSpecifier ::= Identifier ('as' Identifier)?
   private ParseTree parseImportSpecifier() {
     SourcePosition start = getTreeStartLocation();
-    boolean isKeyword = Keywords.isKeyword(peekType());
     IdentifierToken importedName = eatIdOrKeywordAsId();
     IdentifierToken destinationName = null;
-    if (isKeyword || peekPredefinedString(PredefinedName.AS)) {
+    if (peekPredefinedString(PredefinedName.AS)) {
       eatPredefinedString(PredefinedName.AS);
       destinationName = eatId();
+    } else if (Keywords.isKeyword(importedName.value)) {
+      reportExpectedError(null, PredefinedName.AS);
     }
     return new ImportSpecifierTree(
         getTreeLocation(start), importedName, destinationName);

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -522,6 +522,13 @@ public class Parser {
         (isExportSpecifier && peekPredefinedString(PredefinedName.FROM))) {
       eatPredefinedString(PredefinedName.FROM);
       moduleSpecifier = eat(TokenType.STRING).asLiteral();
+    } else if (isExportSpecifier) {
+      for (ParseTree tree : exportSpecifierList) {
+        IdentifierToken importedName = tree.asExportSpecifier().importedName;
+        if (Keywords.isKeyword(importedName.value)) {
+          reportError(importedName, "cannot use keyword '%s' here.", importedName.value);
+        }
+      }
     }
 
     if (needsSemiColon || peekImplicitSemiColon()) {

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -101,17 +101,21 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testImport() {
     testModules(
         "import name from 'other'; use(name);",
-        LINE_JOINER.join("goog.require('module$other');", "use(module$other.default);"));
+        "goog.require('module$other'); use(module$other.default);");
 
     testModules("import {n as name} from 'other';", "goog.require('module$other');");
 
     testModules(
         "import x, {f as foo, b as bar} from 'other'; use(x);",
-        LINE_JOINER.join("goog.require('module$other');", "use(module$other.default);"));
+        "goog.require('module$other'); use(module$other.default);");
 
     testModules(
         "import {default as name} from 'other'; use(name);",
-        LINE_JOINER.join("goog.require('module$other');", "use(module$other.default);"));
+        "goog.require('module$other'); use(module$other.default);");
+
+    testModules(
+        "import {class as name} from 'other'; use(name);",
+        "goog.require('module$other'); use(module$other.class);");
   }
 
   public void testImport_missing() {
@@ -190,6 +194,13 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "goog.provide('module$testcode');",
             "var f$$module$testcode = 1;",
             "module$testcode.default = f$$module$testcode;"));
+
+    testModules(
+        "var f = 1; export {f as class};",
+        LINE_JOINER.join(
+            "goog.provide('module$testcode');",
+            "var f$$module$testcode = 1;",
+            "module$testcode.class = f$$module$testcode;"));
   }
 
   public void testExportWithJsDoc() {
@@ -238,11 +249,16 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
   public void testExportFrom() {
     testModules(
-        "export {name} from 'other';",
+        LINE_JOINER.join(
+            "export {name} from 'other';",
+            "export {default} from 'other';",
+            "export {class} from 'other';"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
-            "module$testcode.name = module$other.name;"));
+            "module$testcode.name = module$other.name;",
+            "module$testcode.default = module$other.default;",
+            "module$testcode.class = module$other.class;"));
 
     testModules(
         "export {a, b as c, d} from 'other';",
@@ -254,15 +270,25 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "module$testcode.d = module$other.d;"));
 
     testModules(
+        "export {a as b, b as a} from 'other';",
+        LINE_JOINER.join(
+            "goog.provide('module$testcode');",
+            "goog.require('module$other');",
+            "module$testcode.b = module$other.a;",
+            "module$testcode.a = module$other.b;"));
+
+    testModules(
         LINE_JOINER.join(
             "export {default as a} from 'other';",
-            "export {a as a2, default as b} from 'other';"),
+            "export {a as a2, default as b} from 'other';",
+            "export {class as switch} from 'other';"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
             "module$testcode.a = module$other.default;",
             "module$testcode.a2 = module$other.a;",
-            "module$testcode.b = module$other.default;"));
+            "module$testcode.b = module$other.default;",
+            "module$testcode.switch = module$other.class;"));
   }
 
   public void testExportDefault() {

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -108,6 +108,10 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
     testModules(
         "import x, {f as foo, b as bar} from 'other'; use(x);",
         LINE_JOINER.join("goog.require('module$other');", "use(module$other.default);"));
+
+    testModules(
+        "import {default as name} from 'other'; use(name);",
+        LINE_JOINER.join("goog.require('module$other');", "use(module$other.default);"));
   }
 
   public void testImport_missing() {
@@ -179,6 +183,13 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "var b$$module$testcode = 2;",
             "module$testcode.foo = f$$module$testcode;",
             "module$testcode.bar = b$$module$testcode;"));
+
+    testModules(
+        "var f = 1; export {f as default};",
+        LINE_JOINER.join(
+            "goog.provide('module$testcode');",
+            "var f$$module$testcode = 1;",
+            "module$testcode.default = f$$module$testcode;"));
   }
 
   public void testExportWithJsDoc() {
@@ -241,6 +252,17 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "module$testcode.a = module$other.a;",
             "module$testcode.c = module$other.b;",
             "module$testcode.d = module$other.d;"));
+
+    testModules(
+        LINE_JOINER.join(
+            "export {default as a} from 'other';",
+            "export {a as a2, default as b} from 'other';"),
+        LINE_JOINER.join(
+            "goog.provide('module$testcode');",
+            "goog.require('module$other');",
+            "module$testcode.a = module$other.default;",
+            "module$testcode.a2 = module$other.a;",
+            "module$testcode.b = module$other.default;"));
   }
 
   public void testExportDefault() {

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -2660,6 +2660,15 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("import {default as d} from './someModule'");
     parse("import d, {x as x1, y as y1} from './someModule'");
     parse("import * as sm from './someModule'");
+
+    parseError("import class from './someModule'",
+            "cannot use keyword 'class' here.");
+    parseError("import * as class from './someModule'",
+            "'identifier' expected");
+    parseError("import {a as class} from './someModule'",
+            "'identifier' expected");
+    parseError("import {class} from './someModule'",
+            "'as' expected");
   }
 
   public void testExport() {
@@ -2672,9 +2681,12 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("export {x, y}");
     parse("export {x as x1}");
     parse("export {x as default, y as y1}");
+
     parseError("export {default as x}",
         "cannot use keyword 'default' here.");
     parseError("export {package as x}",
+        "cannot use keyword 'package' here.");
+    parseError("export {package}",
         "cannot use keyword 'package' here.");
 
     parse("export {x as x1, y as y1} from './someModule'");

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -2657,7 +2657,7 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("import {x, y} from './someModule'");
     parse("import {x as x1, y as y1} from './someModule'");
     parse("import {x as x1, y as y1, } from './someModule'");
-    parse("import {default as d} from './someModule'");
+    parse("import {default as d, class as c} from './someModule'");
     parse("import d, {x as x1, y as y1} from './someModule'");
     parse("import * as sm from './someModule'");
 
@@ -2680,7 +2680,8 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("export class c {}");
     parse("export {x, y}");
     parse("export {x as x1}");
-    parse("export {x as default, y as y1}");
+    parse("export {x as x1, y as x2}");
+    parse("export {x as default, y as class}");
 
     parseError("export {default as x}",
         "cannot use keyword 'default' here.");
@@ -2692,8 +2693,9 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("export {x as x1, y as y1} from './someModule'");
     parse("export {x as x1, y as y1, } from './someModule'");
     parse("export {default as d} from './someModule'");
-    parse("export {x as default, y as y1} from './someModule'");
-    parse("export {default as default, y as y1} from './someModule'");
+    parse("export {d as default, c as class} from './someModule'");
+    parse("export {default as default, class as class} from './someModule'");
+    parse("export {class} from './someModule'");
     parse("export * from './someModule'");
   }
 

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -2657,7 +2657,28 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("import {x, y} from './someModule'");
     parse("import {x as x1, y as y1} from './someModule'");
     parse("import {x as x1, y as y1, } from './someModule'");
+    parse("import {default as d} from './someModule'");
+    parse("import d, {x as x1, y as y1} from './someModule'");
     parse("import * as sm from './someModule'");
+  }
+
+  public void testExport() {
+    mode = LanguageMode.ECMASCRIPT6;
+
+    parse("export const x = 1");
+    parse("export var x = 1");
+    parse("export function f() {}");
+    parse("export class c {}");
+    parse("export {x, y}");
+    parse("export {x as x1}");
+    parse("export {x as default, y as y1}");
+
+    parse("export {x as x1, y as y1} from './someModule'");
+    parse("export {x as x1, y as y1, } from './someModule'");
+    parse("export {default as d} from './someModule'");
+    parse("export {x as default, y as y1} from './someModule'");
+    parse("export {default as default, y as y1} from './someModule'");
+    parse("export * from './someModule'");
   }
 
   public void testShebang() {

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -2672,6 +2672,10 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     parse("export {x, y}");
     parse("export {x as x1}");
     parse("export {x as default, y as y1}");
+    parseError("export {default as x}",
+        "cannot use keyword 'default' here.");
+    parseError("export {package as x}",
+        "cannot use keyword 'package' here.");
 
     parse("export {x as x1, y as y1} from './someModule'");
     parse("export {x as x1, y as y1, } from './someModule'");


### PR DESCRIPTION
 see:
    http://www.ecma-international.org/ecma-262/6.0/index.html#sec-imports
    http://www.ecma-international.org/ecma-262/6.0/index.html#sec-exports

This fix is necessary for  implementing "package index" module. e.g.:

```javascript
// index.js: 

export {default as AClass} from "./AClass" // AClass.js: export default class AClass { ...}
export {default as BClass} from "./BClass" // BClass.js: export default class BClass { ...}
```
