### PR TITLE
Simplify jQuery externs by making the "$" symbol a true alias of the jQuery namespace

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -89,15 +89,9 @@ var jQueryAjaxSettings;
 function jQuery(arg1, arg2) {}
 
 /**
- * @constructor
- * @extends {jQuery}
- * @param {(jQuerySelector|Element|Object|Array<Element>|jQuery|string|
- *     function())=} arg1
- * @param {(Element|jQuery|Document|
- *     Object<string, (string|function(!jQuery.Event))>)=} arg2
- * @return {!jQuery}
+ * @const
  */
-function $(arg1, arg2) {}
+var $ = jQuery;
 
 /**
  * @param {(jQuerySelector|Array<Element>|string|jQuery)} arg1
@@ -135,13 +129,6 @@ jQuery.prototype.after = function(arg1, content) {};
 jQuery.ajax = function(arg1, settings) {};
 
 /**
- * @param {(string|jQueryAjaxSettings|Object<string, *>)} arg1
- * @param {(jQueryAjaxSettings|Object<string, *>)=} settings
- * @return {!jQuery.jqXHR}
- */
-$.ajax = function(arg1, settings) {};
-
-/**
  * @param {function(!jQuery.Event,XMLHttpRequest,(jQueryAjaxSettings|Object<string, *>))} handler
  * @return {!jQuery}
  */
@@ -160,12 +147,6 @@ jQuery.prototype.ajaxError = function(handler) {};
 jQuery.ajaxPrefilter = function(dataTypes, handler) {};
 
 /**
- * @param {(string|function((jQueryAjaxSettings|Object<string, *>),(jQueryAjaxSettings|Object<string, *>),jQuery.jqXHR))} dataTypes
- * @param {function((jQueryAjaxSettings|Object<string, *>),(jQueryAjaxSettings|Object<string, *>),jQuery.jqXHR)=} handler
- */
-$.ajaxPrefilter = function(dataTypes, handler) {};
-
-/**
  * @param {function(!jQuery.Event,jQuery.jqXHR,(jQueryAjaxSettings|Object<string, *>))} handler
  * @return {!jQuery}
  */
@@ -174,32 +155,17 @@ jQuery.prototype.ajaxSend = function(handler) {};
 /** @const {jQueryAjaxSettings|Object<string, *>} */
 jQuery.ajaxSettings;
 
-/** @const {jQueryAjaxSettings|Object<string, *>} */
-$.ajaxSettings = {};
-
 /** @type {Object<string, boolean>} */
 jQuery.ajaxSettings.flatOptions = {};
-
-/** @type {Object<string, boolean>} */
-$.ajaxSettings.flatOptions = {};
 
 /** @type {boolean} */
 jQuery.ajaxSettings.processData;
 
-/** @type {boolean} */
-$.ajaxSettings.processData;
-
 /** @type {Object<string, string>} */
 jQuery.ajaxSettings.responseFields = {};
 
-/** @type {Object<string, string>} */
-$.ajaxSettings.responseFields = {};
-
 /** @param {jQueryAjaxSettings|Object<string, *>} options */
 jQuery.ajaxSetup = function(options) {};
-
-/** @param {jQueryAjaxSettings|Object<string, *>} options */
-$.ajaxSetup = function(options) {};
 
 /**
  * @param {function()} handler
@@ -374,13 +340,6 @@ jQuery.prototype.closest = function(arg1, context) {};
 jQuery.contains = function(container, contained) {};
 
 /**
- * @param {Element} container
- * @param {Element} contained
- * @return {boolean}
- */
-$.contains = function(container, contained) {};
-
-/**
  * @return {!jQuery}
  * @nosideeffects
  */
@@ -399,9 +358,6 @@ jQuery.prototype.css = function(arg1, arg2) {};
 /** @type {Object<string, *>} */
 jQuery.cssHooks;
 
-/** @type {Object<string, *>} */
-$.cssHooks;
-
 /**
  * @param {Element} elem
  * @param {string=} key
@@ -416,14 +372,6 @@ jQuery.data = function(elem, key, value) {};
  * @return {*}
  */
 jQuery.prototype.data = function(arg1, value) {};
-
-/**
- * @param {Element} elem
- * @param {string=} key
- * @param {*=} value
- * @return {*}
- */
-$.data = function(elem, key, value) {};
 
 /**
  * @param {(function(!jQuery.Event)|Object<string, *>)=} arg1
@@ -447,22 +395,6 @@ jQuery.deferred = function(opt_fn) {};
  * @return {!jQuery.Deferred}
  */
 jQuery.Deferred = function(opt_fn) {};
-
-/**
- * @constructor
- * @extends {jQuery.deferred}
- * @param {function()=} opt_fn
- * @see http://api.jquery.com/category/deferred-object/
- */
-$.deferred = function(opt_fn) {};
-
-/**
- * @constructor
- * @extends {jQuery.deferred}
- * @param {function()=} opt_fn
- * @return {!jQuery.deferred}
- */
-$.Deferred = function(opt_fn) {};
 
 /**
  * @override
@@ -593,12 +525,6 @@ jQuery.dequeue = function(elem, queueName) {};
 jQuery.prototype.dequeue = function(queueName) {};
 
 /**
- * @param {Element} elem
- * @param {string=} queueName
- */
-$.dequeue = function(elem, queueName) {};
-
-/**
  * @param {jQuerySelector=} selector
  * @return {!jQuery}
  */
@@ -617,12 +543,6 @@ jQuery.each = function(collection, callback) {};
  */
 jQuery.prototype.each = function(fnc) {};
 
-/**
- * @param {Object} collection
- * @param {function((number|string),?)} callback
- * @return {Object}
- */
-$.each = function(collection, callback) {};
 
 /** @return {!jQuery} */
 jQuery.prototype.empty = function() {};
@@ -650,9 +570,6 @@ jQuery.error = function(message) {};
  */
 jQuery.prototype.error = function(arg1, handler) {};
 
-/** @param {string} message */
-$.error = function(message) {};
-
 /** @const */
 jQuery.event = {};
 
@@ -669,24 +586,6 @@ jQuery.event.special;
  * @return {!jQuery.Event}
  */
 jQuery.Event = function(eventType, properties) {};
-
-/** @const */
-$.event = {};
-
-/** @type {Array<string>} */
-$.event.props;
-
-/** @type {Object<string, Object>} */
-$.event.special;
-
-/**
- * @constructor
- * @extends {jQuery.Event}
- * @param {string} eventType
- * @param {Object=} properties
- * @return {!jQuery.Event}
- */
-$.Event = function(eventType, properties) {};
 
 /** @type {boolean} */
 jQuery.Event.prototype.altKey;
@@ -826,13 +725,6 @@ jQuery.extend = function(arg1, var_args) {};
 jQuery.prototype.extend = function(arg1, var_args) {};
 
 /**
- * @param {(Object|boolean)} arg1
- * @param {...*} var_args
- * @return {Object}
- */
-$.extend = function(arg1, var_args) {};
-
-/**
  * @param {(string|number|function())=} duration
  * @param {(function()|string)=} arg2
  * @param {function()=} callback
@@ -885,9 +777,6 @@ jQuery.prototype.first = function() {};
 /** @see http://docs.jquery.com/Plugins/Authoring */
 jQuery.fn = jQuery.prototype;
 
-/** @see http://docs.jquery.com/Plugins/Authoring */
-$.fn = $.prototype;
-
 /**
  * @param {(function(!jQuery.Event)|Object<string, *>)=} arg1
  * @param {function(!jQuery.Event)=} handler
@@ -912,20 +801,11 @@ jQuery.prototype.focusout = function(arg1, handler) {};
 /** @const */
 jQuery.fx = {};
 
-/** @const */
-$.fx = {};
-
 /** @type {number} */
 jQuery.fx.interval;
 
-/** @type {number} */
-$.fx.interval;
-
 /** @type {boolean} */
 jQuery.fx.off;
-
-/** @type {boolean} */
-$.fx.off;
 
 /**
  * @param {string} url
@@ -946,16 +826,6 @@ jQuery.prototype.get = function(index) {};
 
 /**
  * @param {string} url
- * @param {(Object<string,*>|string|
- *     function(string,string,jQuery.jqXHR))=} data
- * @param {(function(string,string,jQuery.jqXHR)|string)=} success
- * @param {string=} dataType
- * @return {!jQuery.jqXHR}
- */
-$.get = function(url, data, success, dataType) {};
-
-/**
- * @param {string} url
  * @param {(Object<string,*>|
  *     function(Object<string,*>,string,jQuery.jqXHR))=} data
  * @param {function(Object<string,*>,string,jQuery.jqXHR)=} success
@@ -966,33 +836,13 @@ jQuery.getJSON = function(url, data, success) {};
 
 /**
  * @param {string} url
- * @param {(Object<string,*>|
- *     function(Object<string,*>,string,jQuery.jqXHR))=} data
- * @param {function(Object<string,*>,string,jQuery.jqXHR)=} success
- * @return {!jQuery.jqXHR}
- * @see http://api.jquery.com/jquery.getjson/#jQuery-getJSON-url-data-success
- */
-$.getJSON = function(url, data, success) {};
-
-/**
- * @param {string} url
  * @param {function(Node,string,jQuery.jqXHR)=} success
  * @return {!jQuery.jqXHR}
  */
 jQuery.getScript = function(url, success) {};
 
-/**
- * @param {string} url
- * @param {function(Node,string,jQuery.jqXHR)=} success
- * @return {!jQuery.jqXHR}
- */
-$.getScript = function(url, success) {};
-
 /** @param {string} code */
 jQuery.globalEval = function(code) {};
-
-/** @param {string} code */
-$.globalEval = function(code) {};
 
 /**
  * @template T
@@ -1002,15 +852,6 @@ $.globalEval = function(code) {};
  * @return {!Array<T>}
  */
 jQuery.grep = function(arr, fnc, invert) {};
-
-/**
- * @template T
- * @param {!Array<T>} arr
- * @param {function(*,number)} fnc
- * @param {boolean=} invert
- * @return {!Array<T>}
- */
-$.grep = function(arr, fnc, invert) {};
 
 /**
  * @param {(string|Element)} arg1
@@ -1034,13 +875,6 @@ jQuery.prototype.hasClass = function(className) {};
 jQuery.hasData = function(elem) {};
 
 /**
- * @param {!Element} elem
- * @return {boolean}
- * @nosideeffects
- */
-$.hasData = function(elem) {};
-
-/**
  * @param {(string|number|function(number,number))=} arg1
  * @return {(number|!jQuery)}
  */
@@ -1056,9 +890,6 @@ jQuery.prototype.hide = function(duration, arg2, callback) {};
 
 /** @param {boolean} hold */
 jQuery.holdReady = function(hold) {};
-
-/** @param {boolean} hold */
-$.holdReady = function(hold) {};
 
 /**
  * @param {function(!jQuery.Event)} arg1
@@ -1081,15 +912,6 @@ jQuery.prototype.html = function(arg1) {};
  * @nosideeffects
  */
 jQuery.inArray = function(value, arr, fromIndex) {};
-
-/**
- * @param {*} value
- * @param {Array<*>} arr
- * @param {number=} fromIndex
- * @return {number}
- * @nosideeffects
- */
-$.inArray = function(value, arr, fromIndex) {};
 
 /**
  * @param {(jQuerySelector|Element|jQuery)=} arg1
@@ -1135,25 +957,11 @@ jQuery.prototype.is = function(arg1) {};
 jQuery.isArray = function(obj) {};
 
 /**
- * @param {*} obj
- * @return {boolean}
- * @nosideeffects
- */
-$.isArray = function(obj) {};
-
-/**
  * @param {Object} obj
  * @return {boolean}
  * @nosideeffects
  */
 jQuery.isEmptyObject = function(obj) {};
-
-/**
- * @param {Object} obj
- * @return {boolean}
- * @nosideeffects
- */
-$.isEmptyObject = function(obj) {};
 
 /**
  * @param {*} obj
@@ -1163,25 +971,11 @@ $.isEmptyObject = function(obj) {};
 jQuery.isFunction = function(obj) {};
 
 /**
- * @param {*} obj
- * @return {boolean}
- * @nosideeffects
- */
-$.isFunction = function(obj) {};
-
-/**
  * @param {*} value
  * @return {boolean}
  * @nosideeffects
  */
 jQuery.isNumeric = function(value) {};
-
-/**
- * @param {*} value
- * @return {boolean}
- * @nosideeffects
- */
-$.isNumeric = function(value) {};
 
 /**
  * @param {*} obj
@@ -1195,21 +989,7 @@ jQuery.isPlainObject = function(obj) {};
  * @return {boolean}
  * @nosideeffects
  */
-$.isPlainObject = function(obj) {};
-
-/**
- * @param {*} obj
- * @return {boolean}
- * @nosideeffects
- */
 jQuery.isWindow = function(obj) {};
-
-/**
- * @param {*} obj
- * @return {boolean}
- * @nosideeffects
- */
-$.isWindow = function(obj) {};
 
 /**
  * @param {Element} node
@@ -1217,13 +997,6 @@ $.isWindow = function(obj) {};
  * @nosideeffects
  */
 jQuery.isXMLDoc = function(node) {};
-
-/**
- * @param {Element} node
- * @return {boolean}
- * @nosideeffects
- */
-$.isXMLDoc = function(node) {};
 
 /** @type {string} */
 jQuery.prototype.jquery;
@@ -1352,12 +1125,6 @@ jQuery.prototype.load = function(arg1, arg2, complete) {};
 jQuery.makeArray = function(obj) {};
 
 /**
- * @param {*} obj
- * @return {Array<*>}
- */
-$.makeArray = function(obj) {};
-
-/**
  * @param {(Array<*>|Object<string, *>)} arg1
  * @param {(function(*,number)|function(*,(string|number)))} callback
  * @return {Array<*>}
@@ -1371,25 +1138,11 @@ jQuery.map = function(arg1, callback) {};
 jQuery.prototype.map = function(callback) {};
 
 /**
- * @param {(Array<*>|Object<string, *>)} arg1
- * @param {(function(*,number)|function(*,(string|number)))} callback
- * @return {Array<*>}
- */
-$.map = function(arg1, callback) {};
-
-/**
  * @param {Array<*>} first
  * @param {Array<*>} second
  * @return {Array<*>}
  */
 jQuery.merge = function(first, second) {};
-
-/**
- * @param {Array<*>} first
- * @param {Array<*>} second
- * @return {Array<*>}
- */
-$.merge = function(first, second) {};
 
 /**
  * @param {(function(!jQuery.Event)|Object<string, *>)=} arg1
@@ -1469,22 +1222,10 @@ jQuery.prototype.nextUntil = function(arg1, filter) {};
 jQuery.noConflict = function(removeAll) {};
 
 /**
- * @param {boolean=} removeAll
- * @return {Object}
- */
-$.noConflict = function(removeAll) {};
-
-/**
  * @return {function()}
  * @nosideeffects
  */
 jQuery.noop = function() {};
-
-/**
- * @return {function()}
- * @nosideeffects
- */
-$.noop = function() {};
 
 /**
  * @param {(jQuerySelector|Array<Element>|function(number)|jQuery)} arg1
@@ -1497,12 +1238,6 @@ jQuery.prototype.not = function(arg1) {};
  * @nosideeffects
  */
 jQuery.now = function() {};
-
-/**
- * @return {number}
- * @nosideeffects
- */
-$.now = function() {};
 
 /**
  * @param {(string|Object<string,*>)=} arg1
@@ -1565,13 +1300,6 @@ jQuery.prototype.outerWidth = function(includeMargin) {};
 jQuery.param = function(obj, traditional) {};
 
 /**
- * @param {(Object<string, *>|Array<Object<string, *>>)} obj
- * @param {boolean=} traditional
- * @return {string}
- */
-$.param = function(obj, traditional) {};
-
-/**
  * @param {jQuerySelector=} selector
  * @return {!jQuery}
  * @nosideeffects
@@ -1602,36 +1330,16 @@ jQuery.prototype.parentsUntil = function(arg1, filter) {};
 jQuery.parseHTML = function(data, context, keepScripts) {};
 
 /**
- * @param {string} data
- * @param {(Element|boolean)=} context
- * @param {boolean=} keepScripts
- * @return {Array<Element>}
- */
-$.parseHTML = function(data, context, keepScripts) {};
-
-/**
  * @param {string} json
  * @return {string|number|Object<string, *>|Array<?>|boolean}
  */
 jQuery.parseJSON = function(json) {};
 
 /**
- * @param {string} json
- * @return {Object<string, *>}
- */
-$.parseJSON = function(json) {};
-
-/**
  * @param {string} data
  * @return {Document}
  */
 jQuery.parseXML = function(data) {};
-
-/**
- * @param {string} data
- * @return {Document}
- */
-$.parseXML = function(data) {};
 
 /**
  * @return {{left:number,top:number}}
@@ -1648,17 +1356,6 @@ jQuery.prototype.position = function() {};
  * @return {!jQuery.jqXHR}
  */
 jQuery.post = function(url, data, success, dataType) {};
-
-/**
- * @param {string} url
- * @param {(Object<string,*>|string|
- *     function(string,string,jQuery.jqXHR))=} data
- * @param {(function(string,string,jQuery.jqXHR)|string|null)=} success
- * @param {string=} dataType
- * @return {!jQuery.jqXHR}
- */
-$.post = function(url, data, success, dataType) {};
-
 /**
  * @param {(string|Element|jQuery|function(number,string))} arg1
  * @param {(string|Element|jQuery)=} content
@@ -1760,12 +1457,6 @@ jQuery.prototype.prop = function(arg1, arg2) {};
 jQuery.proxy = function(var_args) {};
 
 /**
- * @param {...*} var_args
- * @return {function()}
- */
-$.proxy = function(var_args) {};
-
-/**
  * @param {Array<Element>} elements
  * @param {string=} name
  * @param {Array<*>=} args
@@ -1787,14 +1478,6 @@ jQuery.prototype.queue = function(queueName, arg2) {};
  * @return {(Array<Element>|!jQuery)}
  */
 jQuery.queue = function(elem, queueName, arg3) {};
-
-/**
- * @param {Element} elem
- * @param {string=} queueName
- * @param {(Array<function()>|function())=} arg3
- * @return {(Array<Element>|!jQuery)}
- */
-$.queue = function(elem, queueName, arg3) {};
 
 /**
  * @param {function()} handler
@@ -1832,13 +1515,6 @@ jQuery.prototype.removeData = function(arg1) {};
  * @return {!jQuery}
  */
 jQuery.removeData = function(elem, name) {};
-
-/**
- * @param {Element} elem
- * @param {string=} name
- * @return {!jQuery}
- */
-$.removeData = function(elem, name) {};
 
 /**
  * @param {string} propertyName
@@ -1979,88 +1655,44 @@ jQuery.prototype.submit = function(arg1, handler) {};
  */
 jQuery.support;
 
-/** @type {Object<string, *>}
- * @deprecated Please try to use feature detection instead.
- */
-$.support;
-
 /**
  * @deprecated Please try to use feature detection instead.
  * @type {boolean}
  */
 jQuery.support.boxModel;
 
-/**
- * @deprecated Please try to use feature detection instead.
- * @type {boolean}
- */
-$.support.boxModel;
-
 /** @type {boolean} */
 jQuery.support.changeBubbles;
-
-/** @type {boolean} */
-$.support.changeBubbles;
 
 /** @type {boolean} */
 jQuery.support.cors;
 
 /** @type {boolean} */
-$.support.cors;
-
-/** @type {boolean} */
 jQuery.support.cssFloat;
-
-/** @type {boolean} */
-$.support.cssFloat;
 
 /** @type {boolean} */
 jQuery.support.hrefNormalized;
 
 /** @type {boolean} */
-$.support.hrefNormalized;
-
-/** @type {boolean} */
 jQuery.support.htmlSerialize;
-
-/** @type {boolean} */
-$.support.htmlSerialize;
 
 /** @type {boolean} */
 jQuery.support.leadingWhitespace;
 
 /** @type {boolean} */
-$.support.leadingWhitespace;
-
-/** @type {boolean} */
 jQuery.support.noCloneEvent;
-
-/** @type {boolean} */
-$.support.noCloneEvent;
 
 /** @type {boolean} */
 jQuery.support.opacity;
 
 /** @type {boolean} */
-$.support.opacity;
-
-/** @type {boolean} */
 jQuery.support.style;
-
-/** @type {boolean} */
-$.support.style;
 
 /** @type {boolean} */
 jQuery.support.submitBubbles;
 
 /** @type {boolean} */
-$.support.submitBubbles;
-
-/** @type {boolean} */
 jQuery.support.tbody;
-
-/** @type {boolean} */
-$.support.tbody;
 
 /**
  * @param {(string|number|boolean|function(number,string))=} arg1
@@ -2113,25 +1745,11 @@ jQuery.prototype.triggerHandler = function(eventType, extraParameters) {};
 jQuery.trim = function(str) {};
 
 /**
- * @param {string} str
- * @return {string}
- * @nosideeffects
- */
-$.trim = function(str) {};
-
-/**
  * @param {*} obj
  * @return {string}
  * @nosideeffects
  */
 jQuery.type = function(obj) {};
-
-/**
- * @param {*} obj
- * @return {string}
- * @nosideeffects
- */
-$.type = function(obj) {};
 
 /**
  * @param {(string|function(!jQuery.Event)|jQuery.Event)=} arg1
@@ -2153,12 +1771,6 @@ jQuery.prototype.undelegate = function(arg1, arg2, handler) {};
  * @return {Array<Element>}
  */
 jQuery.unique = function(arr) {};
-
-/**
- * @param {Array<Element>} arr
- * @return {Array<Element>}
- */
-$.unique = function(arr) {};
 
 /**
  * @deprecated Please use .on( "unload", handler ) instead.
@@ -2190,14 +1802,6 @@ jQuery.prototype.val = function(arg1) {};
  * @return {!jQuery.Promise}
  */
 jQuery.when = function(deferred, deferreds) {};
-
-/**
- * Note: See jQuery.when().
- * @param {*} deferred
- * @param {...*} deferreds
- * @return {!jQuery.Promise}
- */
-$.when = function(deferred, deferreds) {};
 
 /**
  * @param {(string|number|function(number,number))=} arg1


### PR DESCRIPTION
With the changes in #1101 which were deployed in the 20150920 release, the jQuery externs can be massively simplified as we no longer need to manually recreate all static methods on the `$` alias.