### PR TITLE
Add Document.prototype.readyState to the HTML5 externs

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -735,6 +735,13 @@ Document.prototype.postMessage = function(message) {};
 Document.prototype.head;
 
 /**
+ * Describes the loading state of the document.
+ * @see https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+ * @type {string}
+ */
+Document.prototype.readyState;
+
+/**
  * @see https://developer.apple.com/webapps/docs/documentation/AppleApplications/Reference/SafariJSRef/DOMApplicationCache/DOMApplicationCache.html
  * @constructor
  * @implements {EventTarget}

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -834,12 +834,6 @@ Document.prototype.parentWindow;
 Document.prototype.protocol;
 
 /**
- * @type {string}
- * @see http://msdn.microsoft.com/en-us/library/ms534359(VS.85).aspx
- */
-HTMLDocument.prototype.readyState;
-
-/**
  * @type {Selection}
  * @see http://msdn.microsoft.com/en-us/library/ms535869(VS.85).aspx
  */


### PR DESCRIPTION
This eliminates a new type inference warning in Closure Library's base.js