### PR TITLE
Fixes crash on assignment to 'arguments' with SIMPLE_OPTIMIZATIONS.

### DIFF
--- a/src/com/google/javascript/jscomp/CollapseVariableDeclarations.java
+++ b/src/com/google/javascript/jscomp/CollapseVariableDeclarations.java
@@ -215,7 +215,7 @@ class CollapseVariableDeclarations implements CompilerPass {
   }
 
   private static boolean isNamedParameter(Var v) {
-    return v.getParentNode().isParamList();
+    return v.isParam();
   }
 
   private void applyCollapses() {

--- a/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java
+++ b/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java
@@ -87,6 +87,10 @@ public final class CollapseVariableDeclarationsTest extends CompilerTestCase {
          "var a = 1, x, y = 3; x = 5;");
   }
 
+  public void testArgumentsAssignment() {
+    testSame("function f() {arguments = 1;}");
+  }
+
   @Override
   protected CompilerPass getProcessor(Compiler compiler) {
     return new CollapseVariableDeclarations(compiler);


### PR DESCRIPTION
http://closure-compiler-debugger.appspot.com/#input0%3Dfunction%2520f()%2520%257B%2520arguments%2520%253D%25201%253B%257D%250A%26input1%26conformanceConfig%26externs%26refasterjs-template%26includeDefaultExterns%3D1%26CHECK_SYMBOLS%3D1%26CHECK_TYPES%3D1%26COLLAPSE_VARIABLE_DECLARATIONS%3D1

The issue appeared in 8ca04f2ec725e0905a21521954546dc064707e77 (103199949).