### PR TITLE
Mark the second argument to document.registerElement as optional

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2976,7 +2976,10 @@ Document.prototype.msHidden;
  * @see http://www.w3.org/TR/components-intro/
  * @see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register
  * @param {string} type
- * @param {{extends: (string|undefined), prototype: (Object|undefined)}} options
+ * @param {{extends: (string|undefined), prototype: (Object|undefined)}=} options
+ * @return {!Function} a constructor for the new tag. A generic function is the best we
+ *     can do here as it allows the return value to be annotated properly
+ *     at the call site.
  */
 Document.prototype.registerElement;
 


### PR DESCRIPTION
This fixes #1174.

The second argument for document.registerElement should be optional. Also, we are intentionally returning the unknown type from the method so that it can be properly annotated at the call site.