### PR TITLE
Update DiagnosticGroups.java

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -295,7 +295,7 @@ public class DiagnosticGroups {
 //           NewTypeInference.POSSIBLY_INEXISTENT_PROPERTY,
 //           NewTypeInference.PROPERTY_ACCESS_ON_NONOBJECT,
 //           NewTypeInference.RETURN_NONDECLARED_TYPE,
-//           NewTypeInference.WRONG_ARGUMENT_COUNT,
+          NewTypeInference.WRONG_ARGUMENT_COUNT,
           NewTypeInference.UNKNOWN_ASSERTION_TYPE,
           NewTypeInference.UNKNOWN_TYPEOF_VALUE);
   }


### PR DESCRIPTION
I'd like to be able to suppress these compiler warnings. Here is the scenario I've encountered.
Function $jscomp.scope.Graph.prototype.setEdge: called with 2 argument(s). Function requires at least 0 argument(s) and no more than 0 argument(s).

I encountered this when trying to use the graphlib library with a closure compiled project. I downloaded the graphlib library and modified it to use goog.require and goog.provide statements.
https://github.com/cpettitt/graphlib

They use a function (Graph.prototype.setEdge) without defined parameters in graph.js but it uses the 'arguments' reference to pull down the arguments. This code does this because it is overloaded and has multiple ways of calling it. You can see it here.
https://github.com/cpettitt/graphlib/blob/master/lib/graph.js#L353

Normally, if you've written code like this then you're doing something wrong and should just fix up the function. But its desirable to leave the third party library unmodified as much as possible in your own project. So in this case it is desirable to suppress the warning.