### PR TITLE
Suppress missing require from externs

### DIFF
--- a/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
+++ b/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
@@ -52,14 +52,6 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
   private final AbstractCompiler compiler;
   private final CodingConvention codingConvention;
 
-  public static enum Mode {
-    // Looking at a single file. Externs are not present.
-    SINGLE_FILE,
-    // Used during a normal compilation. The entire program + externs are available.
-    FULL_COMPILE
-  };
-  private final Mode mode;
-
   private final Set<String> constructors = new HashSet<>();
   private final Map<String, Node> requires = new HashMap<>();
 
@@ -70,9 +62,6 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
   // require a goog.require, such as in a @type annotation. If the only usages of a name are
   // in weakUsages, don't give a missingRequire warning, nor an extraRequire warning.
   private final Map<String, Node> weakUsages = new HashMap<>();
-
-  // Whether the current file is an ES6 module.
-  private boolean isModule = false;
 
   // Warnings
   static final DiagnosticType MISSING_REQUIRE_WARNING =
@@ -90,9 +79,8 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
   private static final Set<String> DEFAULT_EXTRA_NAMESPACES = ImmutableSet.of(
     "goog.testing.asserts", "goog.testing.jsunit");
 
-  CheckRequiresForConstructors(AbstractCompiler compiler, Mode mode) {
+  CheckRequiresForConstructors(AbstractCompiler compiler) {
     this.compiler = compiler;
-    this.mode = mode;
     this.codingConvention = compiler.getCodingConvention();
   }
 
@@ -102,7 +90,7 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
    */
   @Override
   public void process(Node externs, Node root) {
-    NodeTraversal.traverseRootsEs6(compiler, this, externs, root);
+    NodeTraversal.traverseRoots(compiler, this, externs, root);
   }
 
   @Override
@@ -131,339 +119,311 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
     return null;
   }
 
-  @Override
-  public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
-    return parent == null || !parent.isScript() || !t.getInput().isExtern();
-  }
+    @Override
+    public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
+      return parent == null || !parent.isScript() || !t.getInput().isExtern();
+    }
 
-  @Override
-  public void visit(NodeTraversal t, Node n, Node parent) {
-    maybeAddJsDocUsages(t, n);
-    switch (n.getType()) {
-      case Token.ASSIGN:
-      case Token.VAR:
-      case Token.LET:
-      case Token.CONST:
-        maybeAddConstructor(n);
-        break;
-      case Token.FUNCTION:
-        // Exclude function expressions.
-        if (NodeUtil.isStatement(n)) {
+    @Override
+    public void visit(NodeTraversal t, Node n, Node parent) {
+      maybeAddJsDocUsages(t, n);
+      switch (n.getType()) {
+        case Token.ASSIGN:
+        case Token.VAR:
+        case Token.LET:
+        case Token.CONST:
           maybeAddConstructor(n);
-        }
-        break;
-      case Token.GETPROP:
-        visitGetProp(n);
-        break;
-      case Token.CALL:
-        visitCallNode(n, parent);
-        break;
-      case Token.SCRIPT:
-        visitScriptNode(t);
-        reset();
-        break;
-      case Token.NEW:
-        visitNewNode(t, n);
-        break;
-      case Token.CLASS:
-        visitClassNode(n);
-        break;
-      case Token.IMPORT:
-      case Token.EXPORT:
-        isModule = true;
-        break;
-    }
-  }
-
-  private void reset() {
-    this.usages.clear();
-    this.weakUsages.clear();
-    this.requires.clear();
-    this.constructors.clear();
-    this.isModule = false;
-  }
-
-  private void visitScriptNode(NodeTraversal t) {
-    if (isModule) {
-      return;
-    }
-
-    Set<String> classNames = new HashSet<>();
-
-    // For every usage, check that there is a goog.require, and warn if not.
-    for (Map.Entry<String, Node> entry : usages.entrySet()) {
-      String className = entry.getKey();
-      Node node = entry.getValue();
-
-      String outermostClassName = getOutermostClassName(className);
-      // The parent namespace is also checked as part of the requires so that classes
-      // used by goog.module are still checked properly. This may cause missing requires
-      // to be missed but in practice that should happen rarely.
-      String nonNullClassName = outermostClassName != null ? outermostClassName : className;
-      String parentNamespace = null;
-      int separatorIndex = nonNullClassName.lastIndexOf('.');
-      if (separatorIndex > 0) {
-        parentNamespace = nonNullClassName.substring(0, separatorIndex);
-      }
-      boolean notProvidedByConstructors =
-          (constructors == null
-              || (!constructors.contains(className) && !constructors.contains(outermostClassName)));
-      boolean notProvidedByRequires =
-          (requires == null
-              || (!requires.containsKey(className)
-                  && !requires.containsKey(outermostClassName)
-                  && !requires.containsKey(parentNamespace)));
-      if (notProvidedByConstructors && notProvidedByRequires && !classNames.contains(className)) {
-        // TODO(mknichel): If the symbol is not explicitly provided, find the next best
-        // symbol from the provides in the same file.
-        compiler.report(t.makeError(node, MISSING_REQUIRE_WARNING, className));
-        classNames.add(className);
-      }
-    }
-
-    // For every goog.require, check that there is a usage (in either usages or weakUsages)
-    // and warn if there is not.
-    for (Map.Entry<String, Node> entry : requires.entrySet()) {
-      String require = entry.getKey();
-      Node call = entry.getValue();
-      Node parent = call.getParent();
-      if (parent.isAssign()) {
-        // var baz = goog.require('foo.bar.baz');
-        // Assume that the var 'baz' is used somewhere, and don't warn.
-        continue;
-      }
-      if (!usages.containsKey(require) && !weakUsages.containsKey(require)) {
-        reportExtraRequireWarning(call, require);
-      }
-    }
-  }
-
-  private void reportExtraRequireWarning(Node call, String require) {
-    if (DEFAULT_EXTRA_NAMESPACES.contains(require)) {
-      return;
-    }
-    JSDocInfo jsDoc = call.getJSDocInfo();
-    if (jsDoc != null && jsDoc.getSuppressions().contains("extraRequire")) {
-      // There is a @suppress {extraRequire} on the call node. Even though the compiler generally
-      // doesn't understand @suppress in that position, respect it in this case,
-      // since lots of people put it there to suppress the closure-linter's extraRequire check.
-      return;
-    }
-    compiler.report(JSError.make(call, EXTRA_REQUIRE_WARNING, require));
-  }
-
-  private void reportDuplicateRequireWarning(Node call, String require) {
-    compiler.report(JSError.make(call, DUPLICATE_REQUIRE_WARNING, require));
-  }
-
-  private void visitCallNode(Node call, Node parent) {
-    String required = codingConvention.extractClassNameIfRequire(call, parent);
-    if (required != null) {
-      if (requires.containsKey(required)) {
-        reportDuplicateRequireWarning(call, required);
-      } else {
-        requires.put(required, call);
-      }
-    }
-
-    Node callee = call.getFirstChild();
-    if (callee.isName()) {
-      weakUsages.put(callee.getString(), callee);
-    }
-  }
-
-  private void visitGetProp(Node getprop) {
-    // For "foo.bar.baz.qux" add weak usages for "foo.bar.baz.qux", foo.bar.baz",
-    // "foo.bar", and "foo" because those might all be goog.provide'd in different files,
-    // so it doesn't make sense to require the user to goog.require all of them.
-    for (; getprop != null; getprop = getprop.getFirstChild()) {
-      weakUsages.put(getprop.getQualifiedName(), getprop);
-    }
-  }
-
-  private void visitNewNode(NodeTraversal t, Node newNode) {
-    Node qNameNode = newNode.getFirstChild();
-
-    // Single names are likely external, but if this is running in single-file mode, they
-    // will not be in the externs, so add a weak usage.
-    if (mode == Mode.SINGLE_FILE && qNameNode.isName()) {
-      weakUsages.put(qNameNode.getString(), qNameNode);
-      return;
-    }
-
-    // If the ctor is something other than a qualified name, ignore it.
-    if (!qNameNode.isQualifiedName()) {
-      return;
-    }
-
-    // Grab the root ctor namespace.
-    Node root = NodeUtil.getRootOfQualifiedName(qNameNode);
-
-    // We only consider programmer-defined constructors that are
-    // global variables, or are defined on global variables.
-    if (!root.isName()) {
-      return;
-    }
-
-    String name = root.getString();
-    Var var = t.getScope().getVar(name);
-    if (var != null && (var.isLocal() || var.isExtern())) {
-      return;
-    }
-    usages.put(qNameNode.getQualifiedName(), newNode);
-
-    // for "new foo.bar.Baz.Qux" add weak usages for "foo.bar.Baz", "foo.bar", and "foo"
-    // because those might be goog.provide'd from a different file than foo.bar.Baz.Qux,
-    // so it doesn't make sense to require the user to goog.require all of them.
-    for (; qNameNode != null; qNameNode = qNameNode.getFirstChild()) {
-      weakUsages.put(qNameNode.getQualifiedName(), qNameNode);
-    }
-  }
-
-  private void visitClassNode(Node classNode) {
-    String name = NodeUtil.getClassName(classNode);
-    if (name != null) {
-      constructors.add(name);
-    }
-    Node extendClass = classNode.getSecondChild();
-    if (extendClass.isQualifiedName()) {
-      usages.put(extendClass.getQualifiedName(), extendClass);
-    }
-  }
-
-  private void maybeAddConstructor(Node n) {
-    JSDocInfo info = n.getJSDocInfo();
-    if (info != null) {
-      String ctorName = n.getFirstChild().getQualifiedName();
-      if (info.isConstructorOrInterface()) {
-        constructors.add(ctorName);
-      } else {
-        JSTypeExpression typeExpr = info.getType();
-        if (typeExpr != null) {
-          Node typeExprRoot = typeExpr.getRoot();
-          if (typeExprRoot.isFunction() && typeExprRoot.getFirstChild().isNew()) {
-            constructors.add(ctorName);
+          break;
+        case Token.FUNCTION:
+          // Exclude function expressions.
+          if (NodeUtil.isStatement(n)) {
+            maybeAddConstructor(n);
           }
+          break;
+        case Token.GETPROP:
+          visitGetProp(n);
+          break;
+        case Token.CALL:
+          visitCallNode(n, parent);
+          break;
+        case Token.SCRIPT:
+          visitScriptNode(t);
+          break;
+        case Token.NEW:
+          visitNewNode(t, n);
+          break;
+        case Token.CLASS:
+          visitClassNode(n);
+      }
+    }
+
+    private void visitScriptNode(NodeTraversal t) {
+      Set<String> classNames = new HashSet<>();
+
+      // For every usage, check that there is a goog.require, and warn if not.
+      for (Map.Entry<String, Node> entry : usages.entrySet()) {
+        String className = entry.getKey();
+        Node node = entry.getValue();
+
+        String outermostClassName = getOutermostClassName(className);
+        // The parent namespace is also checked as part of the requires so that classes
+        // used by goog.module are still checked properly. This may cause missing requires
+        // to be missed but in practice that should happen rarely.
+        String nonNullClassName = outermostClassName != null ? outermostClassName : className;
+        String parentNamespace = null;
+        int separatorIndex = nonNullClassName.lastIndexOf('.');
+        if (separatorIndex > 0) {
+          parentNamespace = nonNullClassName.substring(0, separatorIndex);
+        }
+        Var scopeVar = t.getScope().getVar(nonNullClassName);
+        boolean notProvidedByConstructors =
+            (constructors == null
+            || (!constructors.contains(className) && !constructors.contains(outermostClassName)));
+        boolean notProvidedByRequires =
+            (requires == null || (!requires.containsKey(className)
+                                  && !requires.containsKey(outermostClassName)
+                                  && !requires.containsKey(parentNamespace)));
+        boolean notProvidedByExterns = scopeVar==null || !scopeVar.isExtern();
+        if (notProvidedByConstructors && notProvidedByRequires && notProvidedByExterns
+            && !classNames.contains(className)) {
+          // TODO(mknichel): If the symbol is not explicitly provided, find the next best
+          // symbol from the provides in the same file.
+          compiler.report(t.makeError(node, MISSING_REQUIRE_WARNING, className));
+          classNames.add(className);
         }
       }
-    }
-  }
 
-  /**
-   * If this returns true, check for @extends and @implements annotations on this node.
-   * Otherwise, it's probably an alias for an existing class, so skip those annotations.
-   *
-   * @return Whether the given node declares a function. True for the following forms:
-   *      <li><pre>function foo() {}</pre>
-   *      <li><pre>var foo = function() {};</pre>
-   *      <li><pre>foo.bar = function() {};</pre>
-   */
-  private boolean declaresFunction(Node n) {
-    if (n.isFunction()) {
-      return true;
-    }
-
-    if (n.isAssign() && n.getLastChild().isFunction()) {
-      return true;
-    }
-
-    if (NodeUtil.isNameDeclaration(n)
-        && n.getFirstChild().hasChildren()
-        && n.getFirstChild().getFirstChild().isFunction()) {
-      return true;
-    }
-
-    return false;
-  }
-
-  private void maybeAddJsDocUsages(NodeTraversal t, Node n) {
-    JSDocInfo info = n.getJSDocInfo();
-    if (info == null) {
-      return;
-    }
-
-    if (declaresFunction(n)) {
-      for (JSTypeExpression expr : info.getImplementedInterfaces()) {
-        maybeAddUsage(t, n, expr);
+      // For every goog.require, check that there is a usage (in either usages or weakUsages)
+      // and warn if there is not.
+      for (Map.Entry<String, Node> entry : requires.entrySet()) {
+        String require = entry.getKey();
+        Node call = entry.getValue();
+        Node parent = call.getParent();
+        if (parent.isAssign()) {
+          // var baz = goog.require('foo.bar.baz');
+          // Assume that the var 'baz' is used somewhere, and don't warn.
+          continue;
+        }
+        if (!usages.containsKey(require) && !weakUsages.containsKey(require)) {
+          reportExtraRequireWarning(call, require);
+        }
       }
-      if (info.getBaseType() != null) {
-        maybeAddUsage(t, n, info.getBaseType());
+
+      // for the next script, if there is one, we don't want the new, ctor, and
+      // require nodes to spill over.
+      this.usages.clear();
+      this.weakUsages.clear();
+      this.requires.clear();
+      this.constructors.clear();
+    }
+
+    private void reportExtraRequireWarning(Node call, String require) {
+      if (DEFAULT_EXTRA_NAMESPACES.contains(require)) {
+        return;
       }
-      for (JSTypeExpression extendedInterface : info.getExtendedInterfaces()) {
-        maybeAddUsage(t, n, extendedInterface);
+      JSDocInfo jsDoc = call.getJSDocInfo();
+      if (jsDoc != null && jsDoc.getSuppressions().contains("extraRequire")) {
+        // There is a @suppress {extraRequire} on the call node. Even though the compiler generally
+        // doesn't understand @suppress in that position, respect it in this case,
+        // since lots of people put it there to suppress the closure-linter's extraRequire check.
+        return;
+      }
+      compiler.report(JSError.make(call, EXTRA_REQUIRE_WARNING, require));
+    }
+
+    private void reportDuplicateRequireWarning(Node call, String require) {
+      compiler.report(JSError.make(call, DUPLICATE_REQUIRE_WARNING, require));
+    }
+
+    private void visitCallNode(Node call, Node parent) {
+      String required = codingConvention.extractClassNameIfRequire(call, parent);
+      if (required != null) {
+        if (requires.containsKey(required)) {
+          reportDuplicateRequireWarning(call, required);
+        } else {
+          requires.put(required, call);
+        }
+      }
+
+      Node callee = call.getFirstChild();
+      if (callee.isName()) {
+        weakUsages.put(callee.getString(), callee);
       }
     }
 
-    for (Node typeNode : info.getTypeNodes()) {
-      maybeAddWeakUsage(t, n, typeNode);
+    private void visitGetProp(Node getprop) {
+      // For "foo.bar.baz.qux" add weak usages for "foo.bar.baz.qux", foo.bar.baz",
+      // "foo.bar", and "foo" because those might all be goog.provide'd in different files,
+      // so it doesn't make sense to require the user to goog.require all of them.
+      for (; getprop != null; getprop = getprop.getFirstChild()) {
+        weakUsages.put(getprop.getQualifiedName(), getprop);
+      }
     }
-  }
 
-  /**
-   * Adds a weak usage for the given type expression (unless it references a variable that is
-   * defined in the externs, in which case no goog.require() is needed). When a "weak usage"
-   * is added, it means that a goog.require for that type is optional: No
-   * warning is given whether the require is there or not.
-   */
-  private void maybeAddWeakUsage(NodeTraversal t, Node n, Node typeNode) {
-    maybeAddUsage(t, n, typeNode, this.weakUsages, Predicates.<Node>alwaysTrue());
-  }
+    private void visitNewNode(NodeTraversal t, Node newNode) {
+      Node qNameNode = newNode.getFirstChild();
 
-  /**
-   * Adds a usage for the given type expression (unless it references a variable that is
-   * defined in the externs, in which case no goog.require() is needed). When a usage is
-   * added, it means that there should be a goog.require for that type.
-   */
-  private void maybeAddUsage(NodeTraversal t, Node n, final JSTypeExpression expr) {
-    // Just look at the root node, don't traverse.
-    Predicate<Node> pred =
-        new Predicate<Node>() {
-          @Override
-          public boolean apply(Node n) {
-            return n == expr.getRoot();
-          }
-        };
-    maybeAddUsage(t, n, expr.getRoot(), this.usages, pred);
-  }
+      // If the ctor is something other than a qualified name, ignore it.
+      if (!qNameNode.isQualifiedName()) {
+        return;
+      }
 
-  private void maybeAddUsage(
-      final NodeTraversal t,
-      final Node n,
-      Node rootTypeNode,
-      final Map<String, Node> usagesMap,
-      Predicate<Node> pred) {
-    Visitor visitor =
-        new Visitor() {
-          @Override
-          public void visit(Node typeNode) {
-            if (typeNode.isString()) {
-              String typeString = typeNode.getString();
-              if (mode == Mode.SINGLE_FILE && !typeString.contains(".")) {
-                // If using a single-name type, it's probably something like Error, which we
-                // don't have externs for.
-                return;
-              }
-              String rootName = Splitter.on('.').split(typeString).iterator().next();
-              Var var = t.getScope().getVar(rootName);
-              if (var == null || !var.isExtern()) {
-                usagesMap.put(typeString, n);
+      // Grab the root ctor namespace.
+      Node root = NodeUtil.getRootOfQualifiedName(qNameNode);
 
-                // Regardless of whether we're adding a weak or strong usage here, add weak usages
-                // for the prefixes of the namespace, like we do for GETPROP nodes. Otherwise we get
-                // an extra require warning for cases like:
-                //
-                //     goog.require('foo.bar.SomeService');
-                //
-                //     /** @constructor @extends {foo.bar.SomeService.Handler} */
-                //     var MyHandler = function() {};
-                Node getprop = NodeUtil.newQName(compiler, typeString);
-                getprop.useSourceInfoIfMissingFromForTree(typeNode);
-                visitGetProp(getprop);
-              }
+      // We only consider programmer-defined constructors that are
+      // global variables, or are defined on global variables.
+      if (!root.isName()) {
+        return;
+      }
+
+      String name = root.getString();
+      Var var = t.getScope().getVar(name);
+      if (var != null && (var.isLocal() || var.isExtern())) {
+        return;
+      }
+      usages.put(qNameNode.getQualifiedName(), newNode);
+
+      // for "new foo.bar.Baz.Qux" add weak usages for "foo.bar.Baz", "foo.bar", and "foo"
+      // because those might be goog.provide'd from a different file than foo.bar.Baz.Qux,
+      // so it doesn't make sense to require the user to goog.require all of them.
+      for (; qNameNode != null; qNameNode = qNameNode.getFirstChild()) {
+        weakUsages.put(qNameNode.getQualifiedName(), qNameNode);
+      }
+    }
+
+    private void visitClassNode(Node classNode) {
+      String name = NodeUtil.getClassName(classNode);
+      if (name != null) {
+        constructors.add(name);
+      }
+      Node extendClass = classNode.getFirstChild().getNext();
+      if (extendClass.isQualifiedName()) {
+        usages.put(extendClass.getQualifiedName(), extendClass);
+      }
+    }
+
+    private void maybeAddConstructor(Node n) {
+      JSDocInfo info = n.getJSDocInfo();
+      if (info != null) {
+        String ctorName = n.getFirstChild().getQualifiedName();
+        if (info.isConstructorOrInterface()) {
+          constructors.add(ctorName);
+        } else {
+          JSTypeExpression typeExpr = info.getType();
+          if (typeExpr != null) {
+            Node typeExprRoot = typeExpr.getRoot();
+            if (typeExprRoot.isFunction() && typeExprRoot.getFirstChild().isNew()) {
+              constructors.add(ctorName);
             }
           }
-        };
+        }
+      }
+    }
 
-    NodeUtil.visitPreOrder(rootTypeNode, visitor, pred);
-  }
+    /**
+     * If this returns true, check for @extends and @implements annotations on this node.
+     * Otherwise, it's probably an alias for an existing class, so skip those annotations.
+     *
+     * @return Whether the given node declares a function. True for the following forms:
+     *      <li><pre>function foo() {}</pre>
+     *      <li><pre>var foo = function() {};</pre>
+     *      <li><pre>foo.bar = function() {};</pre>
+     */
+    private boolean declaresFunction(Node n) {
+      if (n.isFunction()) {
+        return true;
+      }
+
+      if (n.isAssign() && n.getLastChild().isFunction()) {
+        return true;
+      }
+
+      if (NodeUtil.isNameDeclaration(n) && n.getFirstChild().hasChildren()
+          && n.getFirstChild().getFirstChild().isFunction()) {
+        return true;
+      }
+
+      return false;
+    }
+
+    private void maybeAddJsDocUsages(NodeTraversal t, Node n) {
+      JSDocInfo info = n.getJSDocInfo();
+      if (info == null) {
+        return;
+      }
+
+      if (declaresFunction(n)) {
+        for (JSTypeExpression expr : info.getImplementedInterfaces()) {
+          maybeAddUsage(t, n, expr);
+        }
+        if (info.getBaseType() != null) {
+          maybeAddUsage(t, n, info.getBaseType());
+        }
+        for (JSTypeExpression extendedInterface : info.getExtendedInterfaces()) {
+          maybeAddUsage(t, n, extendedInterface);
+        }
+      }
+
+      for (Node typeNode : info.getTypeNodes()) {
+        maybeAddWeakUsage(t, n, typeNode);
+      }
+    }
+
+    /**
+     * Adds a weak usage for the given type expression (unless it references a variable that is
+     * defined in the externs, in which case no goog.require() is needed). When a "weak usage"
+     * is added, it means that a goog.require for that type is optional: No
+     * warning is given whether the require is there or not.
+     */
+    private void maybeAddWeakUsage(NodeTraversal t, Node n, Node typeNode) {
+      maybeAddUsage(t, n, typeNode, this.weakUsages, Predicates.<Node>alwaysTrue());
+    }
+
+    /**
+     * Adds a usage for the given type expression (unless it references a variable that is
+     * defined in the externs, in which case no goog.require() is needed). When a usage is
+     * added, it means that there should be a goog.require for that type.
+     */
+    private void maybeAddUsage(NodeTraversal t, Node n, final JSTypeExpression expr) {
+      // Just look at the root node, don't traverse.
+      Predicate<Node> pred = new Predicate<Node>() {
+        @Override
+        public boolean apply(Node n) {
+          return n == expr.getRoot();
+        }
+      };
+      maybeAddUsage(t, n, expr.getRoot(), this.usages, pred);
+    }
+
+    private void maybeAddUsage(final NodeTraversal t, final Node n, Node rootTypeNode,
+        final Map<String, Node> usagesMap, Predicate<Node> pred) {
+      Visitor visitor = new Visitor() {
+        @Override
+        public void visit(Node typeNode) {
+          if (typeNode.isString()) {
+            String typeString = typeNode.getString();
+            String rootName = Splitter.on('.').split(typeString).iterator().next();
+            Var var = t.getScope().getVar(rootName);
+            if (var == null || !var.isExtern()) {
+              usagesMap.put(typeString, n);
+
+              // Regardless of whether we're adding a weak or strong usage here, add weak usages for
+              // the prefixes of the namespace, like we do for GETPROP nodes. Otherwise we get an
+              // extra require warning for cases like:
+              //
+              //     goog.require('foo.bar.SomeService');
+              //
+              //     /** @constructor @extends {foo.bar.SomeService.Handler} */
+              //     var MyHandler = function() {};
+              Node getprop = NodeUtil.newQName(compiler, typeString);
+              getprop.useSourceInfoIfMissingFromForTree(typeNode);
+              visitGetProp(getprop);
+            }
+          }
+        }
+      };
+
+      NodeUtil.visitPreOrder(rootTypeNode, visitor, pred);
+    }
 }

--- a/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
+++ b/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
@@ -183,7 +183,7 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
             (requires == null || (!requires.containsKey(className)
                                   && !requires.containsKey(outermostClassName)
                                   && !requires.containsKey(parentNamespace)));
-        boolean notProvidedByExterns = scopeVar==null || !scopeVar.isExtern();
+        boolean notProvidedByExterns = scopeVar == null || !scopeVar.isExtern();
         if (notProvidedByConstructors && notProvidedByRequires && notProvidedByExterns
             && !classNames.contains(className)) {
           // TODO(mknichel): If the symbol is not explicitly provided, find the next best

--- a/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
+++ b/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
@@ -52,6 +52,14 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
   private final AbstractCompiler compiler;
   private final CodingConvention codingConvention;
 
+  public static enum Mode {
+    // Looking at a single file. Externs are not present.
+    SINGLE_FILE,
+    // Used during a normal compilation. The entire program + externs are available.
+    FULL_COMPILE
+  };
+  private final Mode mode;
+
   private final Set<String> constructors = new HashSet<>();
   private final Map<String, Node> requires = new HashMap<>();
 
@@ -62,6 +70,9 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
   // require a goog.require, such as in a @type annotation. If the only usages of a name are
   // in weakUsages, don't give a missingRequire warning, nor an extraRequire warning.
   private final Map<String, Node> weakUsages = new HashMap<>();
+
+  // Whether the current file is an ES6 module.
+  private boolean isModule = false;
 
   // Warnings
   static final DiagnosticType MISSING_REQUIRE_WARNING =
@@ -79,8 +90,9 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
   private static final Set<String> DEFAULT_EXTRA_NAMESPACES = ImmutableSet.of(
     "goog.testing.asserts", "goog.testing.jsunit");
 
-  CheckRequiresForConstructors(AbstractCompiler compiler) {
+  CheckRequiresForConstructors(AbstractCompiler compiler, Mode mode) {
     this.compiler = compiler;
+    this.mode = mode;
     this.codingConvention = compiler.getCodingConvention();
   }
 
@@ -90,7 +102,7 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
    */
   @Override
   public void process(Node externs, Node root) {
-    NodeTraversal.traverseRoots(compiler, this, externs, root);
+    NodeTraversal.traverseRootsEs6(compiler, this, externs, root);
   }
 
   @Override
@@ -119,311 +131,342 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
     return null;
   }
 
-    @Override
-    public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
-      return parent == null || !parent.isScript() || !t.getInput().isExtern();
-    }
+  @Override
+  public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
+    return parent == null || !parent.isScript() || !t.getInput().isExtern();
+  }
 
-    @Override
-    public void visit(NodeTraversal t, Node n, Node parent) {
-      maybeAddJsDocUsages(t, n);
-      switch (n.getType()) {
-        case Token.ASSIGN:
-        case Token.VAR:
-        case Token.LET:
-        case Token.CONST:
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    maybeAddJsDocUsages(t, n);
+    switch (n.getType()) {
+      case Token.ASSIGN:
+      case Token.VAR:
+      case Token.LET:
+      case Token.CONST:
+        maybeAddConstructor(n);
+        break;
+      case Token.FUNCTION:
+        // Exclude function expressions.
+        if (NodeUtil.isStatement(n)) {
           maybeAddConstructor(n);
-          break;
-        case Token.FUNCTION:
-          // Exclude function expressions.
-          if (NodeUtil.isStatement(n)) {
-            maybeAddConstructor(n);
+        }
+        break;
+      case Token.GETPROP:
+        visitGetProp(n);
+        break;
+      case Token.CALL:
+        visitCallNode(n, parent);
+        break;
+      case Token.SCRIPT:
+        visitScriptNode(t);
+        reset();
+        break;
+      case Token.NEW:
+        visitNewNode(t, n);
+        break;
+      case Token.CLASS:
+        visitClassNode(n);
+        break;
+      case Token.IMPORT:
+      case Token.EXPORT:
+        isModule = true;
+        break;
+    }
+  }
+
+  private void reset() {
+    this.usages.clear();
+    this.weakUsages.clear();
+    this.requires.clear();
+    this.constructors.clear();
+    this.isModule = false;
+  }
+
+  private void visitScriptNode(NodeTraversal t) {
+    if (isModule) {
+      return;
+    }
+
+    Set<String> classNames = new HashSet<>();
+
+    // For every usage, check that there is a goog.require, and warn if not.
+    for (Map.Entry<String, Node> entry : usages.entrySet()) {
+      String className = entry.getKey();
+      Node node = entry.getValue();
+
+      String outermostClassName = getOutermostClassName(className);
+      // The parent namespace is also checked as part of the requires so that classes
+      // used by goog.module are still checked properly. This may cause missing requires
+      // to be missed but in practice that should happen rarely.
+      String nonNullClassName = outermostClassName != null ? outermostClassName : className;
+      String parentNamespace = null;
+      int separatorIndex = nonNullClassName.lastIndexOf('.');
+      if (separatorIndex > 0) {
+        parentNamespace = nonNullClassName.substring(0, separatorIndex);
+      }
+      Var scopeVar = t.getScope().getVar(nonNullClassName);
+      boolean notProvidedByConstructors =
+          (constructors == null
+              || (!constructors.contains(className) && !constructors.contains(outermostClassName)));
+      boolean notProvidedByRequires =
+          (requires == null
+              || (!requires.containsKey(className)
+                  && !requires.containsKey(outermostClassName)
+                  && !requires.containsKey(parentNamespace)));
+      boolean notProvidedByExterns = scopeVar == null || !scopeVar.isExtern();
+      if (notProvidedByConstructors && notProvidedByRequires && notProvidedByExterns
+          && !classNames.contains(className)) {
+        // TODO(mknichel): If the symbol is not explicitly provided, find the next best
+        // symbol from the provides in the same file.
+        compiler.report(t.makeError(node, MISSING_REQUIRE_WARNING, className));
+        classNames.add(className);
+      }
+    }
+
+    // For every goog.require, check that there is a usage (in either usages or weakUsages)
+    // and warn if there is not.
+    for (Map.Entry<String, Node> entry : requires.entrySet()) {
+      String require = entry.getKey();
+      Node call = entry.getValue();
+      Node parent = call.getParent();
+      if (parent.isAssign()) {
+        // var baz = goog.require('foo.bar.baz');
+        // Assume that the var 'baz' is used somewhere, and don't warn.
+        continue;
+      }
+      if (!usages.containsKey(require) && !weakUsages.containsKey(require)) {
+        reportExtraRequireWarning(call, require);
+      }
+    }
+  }
+
+  private void reportExtraRequireWarning(Node call, String require) {
+    if (DEFAULT_EXTRA_NAMESPACES.contains(require)) {
+      return;
+    }
+    JSDocInfo jsDoc = call.getJSDocInfo();
+    if (jsDoc != null && jsDoc.getSuppressions().contains("extraRequire")) {
+      // There is a @suppress {extraRequire} on the call node. Even though the compiler generally
+      // doesn't understand @suppress in that position, respect it in this case,
+      // since lots of people put it there to suppress the closure-linter's extraRequire check.
+      return;
+    }
+    compiler.report(JSError.make(call, EXTRA_REQUIRE_WARNING, require));
+  }
+
+  private void reportDuplicateRequireWarning(Node call, String require) {
+    compiler.report(JSError.make(call, DUPLICATE_REQUIRE_WARNING, require));
+  }
+
+  private void visitCallNode(Node call, Node parent) {
+    String required = codingConvention.extractClassNameIfRequire(call, parent);
+    if (required != null) {
+      if (requires.containsKey(required)) {
+        reportDuplicateRequireWarning(call, required);
+      } else {
+        requires.put(required, call);
+      }
+    }
+
+    Node callee = call.getFirstChild();
+    if (callee.isName()) {
+      weakUsages.put(callee.getString(), callee);
+    }
+  }
+
+  private void visitGetProp(Node getprop) {
+    // For "foo.bar.baz.qux" add weak usages for "foo.bar.baz.qux", foo.bar.baz",
+    // "foo.bar", and "foo" because those might all be goog.provide'd in different files,
+    // so it doesn't make sense to require the user to goog.require all of them.
+    for (; getprop != null; getprop = getprop.getFirstChild()) {
+      weakUsages.put(getprop.getQualifiedName(), getprop);
+    }
+  }
+
+  private void visitNewNode(NodeTraversal t, Node newNode) {
+    Node qNameNode = newNode.getFirstChild();
+
+    // Single names are likely external, but if this is running in single-file mode, they
+    // will not be in the externs, so add a weak usage.
+    if (mode == Mode.SINGLE_FILE && qNameNode.isName()) {
+      weakUsages.put(qNameNode.getString(), qNameNode);
+      return;
+    }
+
+    // If the ctor is something other than a qualified name, ignore it.
+    if (!qNameNode.isQualifiedName()) {
+      return;
+    }
+
+    // Grab the root ctor namespace.
+    Node root = NodeUtil.getRootOfQualifiedName(qNameNode);
+
+    // We only consider programmer-defined constructors that are
+    // global variables, or are defined on global variables.
+    if (!root.isName()) {
+      return;
+    }
+
+    String name = root.getString();
+    Var var = t.getScope().getVar(name);
+    if (var != null && (var.isLocal() || var.isExtern())) {
+      return;
+    }
+    usages.put(qNameNode.getQualifiedName(), newNode);
+
+    // for "new foo.bar.Baz.Qux" add weak usages for "foo.bar.Baz", "foo.bar", and "foo"
+    // because those might be goog.provide'd from a different file than foo.bar.Baz.Qux,
+    // so it doesn't make sense to require the user to goog.require all of them.
+    for (; qNameNode != null; qNameNode = qNameNode.getFirstChild()) {
+      weakUsages.put(qNameNode.getQualifiedName(), qNameNode);
+    }
+  }
+
+  private void visitClassNode(Node classNode) {
+    String name = NodeUtil.getClassName(classNode);
+    if (name != null) {
+      constructors.add(name);
+    }
+    Node extendClass = classNode.getSecondChild();
+    if (extendClass.isQualifiedName()) {
+      usages.put(extendClass.getQualifiedName(), extendClass);
+    }
+  }
+
+  private void maybeAddConstructor(Node n) {
+    JSDocInfo info = n.getJSDocInfo();
+    if (info != null) {
+      String ctorName = n.getFirstChild().getQualifiedName();
+      if (info.isConstructorOrInterface()) {
+        constructors.add(ctorName);
+      } else {
+        JSTypeExpression typeExpr = info.getType();
+        if (typeExpr != null) {
+          Node typeExprRoot = typeExpr.getRoot();
+          if (typeExprRoot.isFunction() && typeExprRoot.getFirstChild().isNew()) {
+            constructors.add(ctorName);
           }
-          break;
-        case Token.GETPROP:
-          visitGetProp(n);
-          break;
-        case Token.CALL:
-          visitCallNode(n, parent);
-          break;
-        case Token.SCRIPT:
-          visitScriptNode(t);
-          break;
-        case Token.NEW:
-          visitNewNode(t, n);
-          break;
-        case Token.CLASS:
-          visitClassNode(n);
-      }
-    }
-
-    private void visitScriptNode(NodeTraversal t) {
-      Set<String> classNames = new HashSet<>();
-
-      // For every usage, check that there is a goog.require, and warn if not.
-      for (Map.Entry<String, Node> entry : usages.entrySet()) {
-        String className = entry.getKey();
-        Node node = entry.getValue();
-
-        String outermostClassName = getOutermostClassName(className);
-        // The parent namespace is also checked as part of the requires so that classes
-        // used by goog.module are still checked properly. This may cause missing requires
-        // to be missed but in practice that should happen rarely.
-        String nonNullClassName = outermostClassName != null ? outermostClassName : className;
-        String parentNamespace = null;
-        int separatorIndex = nonNullClassName.lastIndexOf('.');
-        if (separatorIndex > 0) {
-          parentNamespace = nonNullClassName.substring(0, separatorIndex);
-        }
-        Var scopeVar = t.getScope().getVar(nonNullClassName);
-        boolean notProvidedByConstructors =
-            (constructors == null
-            || (!constructors.contains(className) && !constructors.contains(outermostClassName)));
-        boolean notProvidedByRequires =
-            (requires == null || (!requires.containsKey(className)
-                                  && !requires.containsKey(outermostClassName)
-                                  && !requires.containsKey(parentNamespace)));
-        boolean notProvidedByExterns = scopeVar == null || !scopeVar.isExtern();
-        if (notProvidedByConstructors && notProvidedByRequires && notProvidedByExterns
-            && !classNames.contains(className)) {
-          // TODO(mknichel): If the symbol is not explicitly provided, find the next best
-          // symbol from the provides in the same file.
-          compiler.report(t.makeError(node, MISSING_REQUIRE_WARNING, className));
-          classNames.add(className);
         }
       }
+    }
+  }
 
-      // For every goog.require, check that there is a usage (in either usages or weakUsages)
-      // and warn if there is not.
-      for (Map.Entry<String, Node> entry : requires.entrySet()) {
-        String require = entry.getKey();
-        Node call = entry.getValue();
-        Node parent = call.getParent();
-        if (parent.isAssign()) {
-          // var baz = goog.require('foo.bar.baz');
-          // Assume that the var 'baz' is used somewhere, and don't warn.
-          continue;
-        }
-        if (!usages.containsKey(require) && !weakUsages.containsKey(require)) {
-          reportExtraRequireWarning(call, require);
-        }
-      }
-
-      // for the next script, if there is one, we don't want the new, ctor, and
-      // require nodes to spill over.
-      this.usages.clear();
-      this.weakUsages.clear();
-      this.requires.clear();
-      this.constructors.clear();
+  /**
+   * If this returns true, check for @extends and @implements annotations on this node.
+   * Otherwise, it's probably an alias for an existing class, so skip those annotations.
+   *
+   * @return Whether the given node declares a function. True for the following forms:
+   *      <li><pre>function foo() {}</pre>
+   *      <li><pre>var foo = function() {};</pre>
+   *      <li><pre>foo.bar = function() {};</pre>
+   */
+  private boolean declaresFunction(Node n) {
+    if (n.isFunction()) {
+      return true;
     }
 
-    private void reportExtraRequireWarning(Node call, String require) {
-      if (DEFAULT_EXTRA_NAMESPACES.contains(require)) {
-        return;
-      }
-      JSDocInfo jsDoc = call.getJSDocInfo();
-      if (jsDoc != null && jsDoc.getSuppressions().contains("extraRequire")) {
-        // There is a @suppress {extraRequire} on the call node. Even though the compiler generally
-        // doesn't understand @suppress in that position, respect it in this case,
-        // since lots of people put it there to suppress the closure-linter's extraRequire check.
-        return;
-      }
-      compiler.report(JSError.make(call, EXTRA_REQUIRE_WARNING, require));
+    if (n.isAssign() && n.getLastChild().isFunction()) {
+      return true;
     }
 
-    private void reportDuplicateRequireWarning(Node call, String require) {
-      compiler.report(JSError.make(call, DUPLICATE_REQUIRE_WARNING, require));
+    if (NodeUtil.isNameDeclaration(n)
+        && n.getFirstChild().hasChildren()
+        && n.getFirstChild().getFirstChild().isFunction()) {
+      return true;
     }
 
-    private void visitCallNode(Node call, Node parent) {
-      String required = codingConvention.extractClassNameIfRequire(call, parent);
-      if (required != null) {
-        if (requires.containsKey(required)) {
-          reportDuplicateRequireWarning(call, required);
-        } else {
-          requires.put(required, call);
-        }
-      }
+    return false;
+  }
 
-      Node callee = call.getFirstChild();
-      if (callee.isName()) {
-        weakUsages.put(callee.getString(), callee);
+  private void maybeAddJsDocUsages(NodeTraversal t, Node n) {
+    JSDocInfo info = n.getJSDocInfo();
+    if (info == null) {
+      return;
+    }
+
+    if (declaresFunction(n)) {
+      for (JSTypeExpression expr : info.getImplementedInterfaces()) {
+        maybeAddUsage(t, n, expr);
+      }
+      if (info.getBaseType() != null) {
+        maybeAddUsage(t, n, info.getBaseType());
+      }
+      for (JSTypeExpression extendedInterface : info.getExtendedInterfaces()) {
+        maybeAddUsage(t, n, extendedInterface);
       }
     }
 
-    private void visitGetProp(Node getprop) {
-      // For "foo.bar.baz.qux" add weak usages for "foo.bar.baz.qux", foo.bar.baz",
-      // "foo.bar", and "foo" because those might all be goog.provide'd in different files,
-      // so it doesn't make sense to require the user to goog.require all of them.
-      for (; getprop != null; getprop = getprop.getFirstChild()) {
-        weakUsages.put(getprop.getQualifiedName(), getprop);
-      }
+    for (Node typeNode : info.getTypeNodes()) {
+      maybeAddWeakUsage(t, n, typeNode);
     }
+  }
 
-    private void visitNewNode(NodeTraversal t, Node newNode) {
-      Node qNameNode = newNode.getFirstChild();
+  /**
+   * Adds a weak usage for the given type expression (unless it references a variable that is
+   * defined in the externs, in which case no goog.require() is needed). When a "weak usage"
+   * is added, it means that a goog.require for that type is optional: No
+   * warning is given whether the require is there or not.
+   */
+  private void maybeAddWeakUsage(NodeTraversal t, Node n, Node typeNode) {
+    maybeAddUsage(t, n, typeNode, this.weakUsages, Predicates.<Node>alwaysTrue());
+  }
 
-      // If the ctor is something other than a qualified name, ignore it.
-      if (!qNameNode.isQualifiedName()) {
-        return;
-      }
+  /**
+   * Adds a usage for the given type expression (unless it references a variable that is
+   * defined in the externs, in which case no goog.require() is needed). When a usage is
+   * added, it means that there should be a goog.require for that type.
+   */
+  private void maybeAddUsage(NodeTraversal t, Node n, final JSTypeExpression expr) {
+    // Just look at the root node, don't traverse.
+    Predicate<Node> pred =
+        new Predicate<Node>() {
+          @Override
+          public boolean apply(Node n) {
+            return n == expr.getRoot();
+          }
+        };
+    maybeAddUsage(t, n, expr.getRoot(), this.usages, pred);
+  }
 
-      // Grab the root ctor namespace.
-      Node root = NodeUtil.getRootOfQualifiedName(qNameNode);
+  private void maybeAddUsage(
+      final NodeTraversal t,
+      final Node n,
+      Node rootTypeNode,
+      final Map<String, Node> usagesMap,
+      Predicate<Node> pred) {
+    Visitor visitor =
+        new Visitor() {
+          @Override
+          public void visit(Node typeNode) {
+            if (typeNode.isString()) {
+              String typeString = typeNode.getString();
+              if (mode == Mode.SINGLE_FILE && !typeString.contains(".")) {
+                // If using a single-name type, it's probably something like Error, which we
+                // don't have externs for.
+                return;
+              }
+              String rootName = Splitter.on('.').split(typeString).iterator().next();
+              Var var = t.getScope().getVar(rootName);
+              if (var == null || !var.isExtern()) {
+                usagesMap.put(typeString, n);
 
-      // We only consider programmer-defined constructors that are
-      // global variables, or are defined on global variables.
-      if (!root.isName()) {
-        return;
-      }
-
-      String name = root.getString();
-      Var var = t.getScope().getVar(name);
-      if (var != null && (var.isLocal() || var.isExtern())) {
-        return;
-      }
-      usages.put(qNameNode.getQualifiedName(), newNode);
-
-      // for "new foo.bar.Baz.Qux" add weak usages for "foo.bar.Baz", "foo.bar", and "foo"
-      // because those might be goog.provide'd from a different file than foo.bar.Baz.Qux,
-      // so it doesn't make sense to require the user to goog.require all of them.
-      for (; qNameNode != null; qNameNode = qNameNode.getFirstChild()) {
-        weakUsages.put(qNameNode.getQualifiedName(), qNameNode);
-      }
-    }
-
-    private void visitClassNode(Node classNode) {
-      String name = NodeUtil.getClassName(classNode);
-      if (name != null) {
-        constructors.add(name);
-      }
-      Node extendClass = classNode.getFirstChild().getNext();
-      if (extendClass.isQualifiedName()) {
-        usages.put(extendClass.getQualifiedName(), extendClass);
-      }
-    }
-
-    private void maybeAddConstructor(Node n) {
-      JSDocInfo info = n.getJSDocInfo();
-      if (info != null) {
-        String ctorName = n.getFirstChild().getQualifiedName();
-        if (info.isConstructorOrInterface()) {
-          constructors.add(ctorName);
-        } else {
-          JSTypeExpression typeExpr = info.getType();
-          if (typeExpr != null) {
-            Node typeExprRoot = typeExpr.getRoot();
-            if (typeExprRoot.isFunction() && typeExprRoot.getFirstChild().isNew()) {
-              constructors.add(ctorName);
+                // Regardless of whether we're adding a weak or strong usage here, add weak usages
+                // for the prefixes of the namespace, like we do for GETPROP nodes. Otherwise we get
+                // an extra require warning for cases like:
+                //
+                //     goog.require('foo.bar.SomeService');
+                //
+                //     /** @constructor @extends {foo.bar.SomeService.Handler} */
+                //     var MyHandler = function() {};
+                Node getprop = NodeUtil.newQName(compiler, typeString);
+                getprop.useSourceInfoIfMissingFromForTree(typeNode);
+                visitGetProp(getprop);
+              }
             }
           }
-        }
-      }
-    }
+        };
 
-    /**
-     * If this returns true, check for @extends and @implements annotations on this node.
-     * Otherwise, it's probably an alias for an existing class, so skip those annotations.
-     *
-     * @return Whether the given node declares a function. True for the following forms:
-     *      <li><pre>function foo() {}</pre>
-     *      <li><pre>var foo = function() {};</pre>
-     *      <li><pre>foo.bar = function() {};</pre>
-     */
-    private boolean declaresFunction(Node n) {
-      if (n.isFunction()) {
-        return true;
-      }
-
-      if (n.isAssign() && n.getLastChild().isFunction()) {
-        return true;
-      }
-
-      if (NodeUtil.isNameDeclaration(n) && n.getFirstChild().hasChildren()
-          && n.getFirstChild().getFirstChild().isFunction()) {
-        return true;
-      }
-
-      return false;
-    }
-
-    private void maybeAddJsDocUsages(NodeTraversal t, Node n) {
-      JSDocInfo info = n.getJSDocInfo();
-      if (info == null) {
-        return;
-      }
-
-      if (declaresFunction(n)) {
-        for (JSTypeExpression expr : info.getImplementedInterfaces()) {
-          maybeAddUsage(t, n, expr);
-        }
-        if (info.getBaseType() != null) {
-          maybeAddUsage(t, n, info.getBaseType());
-        }
-        for (JSTypeExpression extendedInterface : info.getExtendedInterfaces()) {
-          maybeAddUsage(t, n, extendedInterface);
-        }
-      }
-
-      for (Node typeNode : info.getTypeNodes()) {
-        maybeAddWeakUsage(t, n, typeNode);
-      }
-    }
-
-    /**
-     * Adds a weak usage for the given type expression (unless it references a variable that is
-     * defined in the externs, in which case no goog.require() is needed). When a "weak usage"
-     * is added, it means that a goog.require for that type is optional: No
-     * warning is given whether the require is there or not.
-     */
-    private void maybeAddWeakUsage(NodeTraversal t, Node n, Node typeNode) {
-      maybeAddUsage(t, n, typeNode, this.weakUsages, Predicates.<Node>alwaysTrue());
-    }
-
-    /**
-     * Adds a usage for the given type expression (unless it references a variable that is
-     * defined in the externs, in which case no goog.require() is needed). When a usage is
-     * added, it means that there should be a goog.require for that type.
-     */
-    private void maybeAddUsage(NodeTraversal t, Node n, final JSTypeExpression expr) {
-      // Just look at the root node, don't traverse.
-      Predicate<Node> pred = new Predicate<Node>() {
-        @Override
-        public boolean apply(Node n) {
-          return n == expr.getRoot();
-        }
-      };
-      maybeAddUsage(t, n, expr.getRoot(), this.usages, pred);
-    }
-
-    private void maybeAddUsage(final NodeTraversal t, final Node n, Node rootTypeNode,
-        final Map<String, Node> usagesMap, Predicate<Node> pred) {
-      Visitor visitor = new Visitor() {
-        @Override
-        public void visit(Node typeNode) {
-          if (typeNode.isString()) {
-            String typeString = typeNode.getString();
-            String rootName = Splitter.on('.').split(typeString).iterator().next();
-            Var var = t.getScope().getVar(rootName);
-            if (var == null || !var.isExtern()) {
-              usagesMap.put(typeString, n);
-
-              // Regardless of whether we're adding a weak or strong usage here, add weak usages for
-              // the prefixes of the namespace, like we do for GETPROP nodes. Otherwise we get an
-              // extra require warning for cases like:
-              //
-              //     goog.require('foo.bar.SomeService');
-              //
-              //     /** @constructor @extends {foo.bar.SomeService.Handler} */
-              //     var MyHandler = function() {};
-              Node getprop = NodeUtil.newQName(compiler, typeString);
-              getprop.useSourceInfoIfMissingFromForTree(typeNode);
-              visitGetProp(getprop);
-            }
-          }
-        }
-      };
-
-      NodeUtil.visitPreOrder(rootTypeNode, visitor, pred);
-    }
+    NodeUtil.visitPreOrder(rootTypeNode, visitor, pred);
+  }
 }

--- a/test/com/google/javascript/jscomp/MissingRequireTest.java
+++ b/test/com/google/javascript/jscomp/MissingRequireTest.java
@@ -162,8 +162,8 @@ public final class MissingRequireTest extends Es6CompilerTestCase {
     setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
     String js = "var goog = {}; class SubClass extends MyExterns.SomethingInExterns {}";
     List<SourceFile> externs = ImmutableList.of(SourceFile.fromCode("externs", 
-        "var MyExterns;\n" +
-        "/** @constructor */ MyExterns.SomethingInExterns;")); 
+        "var MyExterns;\n"
+        + "/** @constructor */ MyExterns.SomethingInExterns;")); 
     test(externs, js, js, null, null, null);
   }
   

--- a/test/com/google/javascript/jscomp/MissingRequireTest.java
+++ b/test/com/google/javascript/jscomp/MissingRequireTest.java
@@ -19,10 +19,10 @@ package com.google.javascript.jscomp;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.javascript.jscomp.CheckRequiresForConstructors.MISSING_REQUIRE_WARNING;
 
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+
+import java.util.List;
 
 /**
  * Tests for the "missing requires" check in {@link CheckRequiresForConstructors}.

--- a/test/com/google/javascript/jscomp/MissingRequireTest.java
+++ b/test/com/google/javascript/jscomp/MissingRequireTest.java
@@ -19,6 +19,8 @@ package com.google.javascript.jscomp;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.javascript.jscomp.CheckRequiresForConstructors.MISSING_REQUIRE_WARNING;
 
+import java.util.List;
+
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 
@@ -140,7 +142,31 @@ public final class MissingRequireTest extends Es6CompilerTestCase {
     String warning = "'goog.foo.Bar.Inner' used but not goog.require'd";
     test(js, js, null, MISSING_REQUIRE_WARNING, warning);
   }
-
+  
+  public void testFailEs6ClassExtendsSomethingWithoutNS() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    String js = "var goog = {}; class SubClass extends SomethingWithoutNS {}";
+    String warning = "'SomethingWithoutNS' used but not goog.require'd";
+    test(js, js, null, MISSING_REQUIRE_WARNING, warning);
+  }
+  
+  public void testEs6ClassExtendsSomethingInExterns() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    String js = "var goog = {}; class SubClass extends SomethingInExterns {}";
+    List<SourceFile> externs = ImmutableList.of(SourceFile.fromCode("externs", 
+        "/** @constructor */ var SomethingInExterns;")); 
+    test(externs, js, js, null, null, null);
+  }
+  
+  public void testEs6ClassExtendsSomethingInExternsWithNS() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    String js = "var goog = {}; class SubClass extends MyExterns.SomethingInExterns {}";
+    List<SourceFile> externs = ImmutableList.of(SourceFile.fromCode("externs", 
+        "var MyExterns;\n" +
+        "/** @constructor */ MyExterns.SomethingInExterns;")); 
+    test(externs, js, js, null, null, null);
+  }
+  
   public void testFailWithNestedNewNodes() {
     String[] js =
         new String[] {"var goog = {}; goog.require('goog.foo.Bar'); "


### PR DESCRIPTION
This is to fix the case where you have React defined globally in externs:
``` javascript
// Externs:

var React = {};

/**
 * @constructor
 * @param {Object} props
 */
React.Component = function(props) {};

// Main code:

class X extends React.Component {
}
```
Without this PR you get the following warning, which is incorrect since externs don't need to be required as they are global:
```
'React.Component' used but not goog.require'd
```

If this is accepted, PR https://github.com/google/closure-compiler/pull/1147 for suppressing missing requires on class nodes can be deleted.