### PR TITLE
Platform settings for line endings and encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Always use UNIX line endings, even on Windows
+*.java eol=lf

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.core.runtime.prefs
+++ b/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n


### PR DESCRIPTION
So I develop with Eclipse Windows, and my last PR initially changed 100s of lines due to a line ending change. I had to undo the commit and fix the line endings. Tedious.

Not sure how this came about, it could be Eclipse or Git. I suspect Git.

Here are Eclipse settings to enforce the existing project style (UTF-8 encoding and UNIX line endings).

Also here is a .gitattributes file to fix (for now, just) .java files to use UNIX line endings, and thereby avoid any undesired conversion on checkout for Windows developers.
See https://help.github.com/articles/dealing-with-line-endings/
This change didn't affect Git's handling of any existing project files.