### PR TITLE
Adding missing 'conformanceViolations' to @suppress values list

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
+++ b/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
@@ -140,6 +140,7 @@ jsdoc.suppressions =\
     closureDepMethodUsageChecks,\
     const,\
     constantProperty,\
+    conformanceViolations,\
     deprecated,\
     duplicate,\
     es5Strict,\


### PR DESCRIPTION
So I can use ```@suppress {conformanceViolations}``` within my code (which works)