### PR TITLE
Fix spurious compiler warnings for Element.prototype.scrollIntoView

### DIFF
--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -2119,7 +2119,7 @@ Element.prototype.getClientRects = function() {};
 Element.prototype.getBoundingClientRect = function() {};
 
 /**
- * @param {boolean=} opt_top
+ * @param {(boolean|{behavior: string, block: string})=} opt_top
  * @see http://www.w3.org/TR/cssom-view/#dom-element-scrollintoview
  */
 Element.prototype.scrollIntoView = function(opt_top) {};


### PR DESCRIPTION
MDN describes `scrollIntoView` as accepting "scrollIntoViewOptions":

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView, but
closure does not accept on object as input to `scrollIntoView`.

This commit fixes that error.

See issue #1211 