### PR TITLE
Report early errors for invalid increment/decrement target.

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/IRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/IRFactory.java
@@ -1792,6 +1792,8 @@ class IRFactory {
               msg,
               sourceName,
               operand.getLineno(), 0);
+        } else if (type == Token.INC || type == Token.DEC) {
+          return createIncrDecrNode(type, false, operand);
         }
 
         return newNode(type, operand);
@@ -1800,8 +1802,26 @@ class IRFactory {
 
     Node processPostfixExpression(PostfixExpressionTree exprNode) {
       int type = transformPostfixTokenType(exprNode.operator.type);
-      Node node = newNode(type, transform(exprNode.operand));
-      node.putBooleanProp(Node.INCRDECR_PROP, true);
+      Node operand = transform(exprNode.operand);
+      if (type == Token.INC || type == Token.DEC) {
+        return createIncrDecrNode(type, true, operand);
+      }
+      Node node = newNode(type, operand);
+      return node;
+    }
+
+    private Node createIncrDecrNode(int type, boolean postfix, Node operand) {
+      if (!operand.isValidAssignmentTarget()) {
+        errorReporter.error(
+            SimpleFormat.format("Invalid %s %s operand.",
+                (postfix ? "postfix" : "prefix"),
+                (type == Token.INC ? "increment" : "decrement")),
+            sourceName,
+            operand.getLineno(),
+            operand.getCharno());
+      }
+      Node node = newNode(type, operand);
+      node.putBooleanProp(Node.INCRDECR_PROP, postfix);
       return node;
     }
 

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -939,6 +939,43 @@ public final class NewParserTest extends BaseJSTypeTestCase {
     }
   }
 
+  public void testPostfixExpression() {
+    parse("a++");
+    parse("a.b--");
+    parse("a[0]++");
+
+    parseError("a()++", "Invalid postfix increment operand.");
+    parseError("(new C)--", "Invalid postfix decrement operand.");
+    parseError("this++", "Invalid postfix increment operand.");
+    parseError("(a--)++", "Invalid postfix increment operand.");
+    parseError("(+a)++", "Invalid postfix increment operand.");
+    parseError("[1,2]++", "Invalid postfix increment operand.");
+    parseError("'literal'++", "Invalid postfix increment operand.");
+  }
+
+  public void testUnaryExpression() {
+    mode = LanguageMode.ECMASCRIPT6;
+    parse("delete a.b");
+    parse("delete a[0]");
+    parse("void f()");
+    parse("typeof new C");
+    parse("++a[0]");
+    parse("--a.b");
+    parse("+{a: 1}");
+    parse("-[1,2]");
+    parse("~'42'");
+    parse("!super.a");
+
+    parseError("delete f()", "Invalid delete operand. Only properties can be deleted.");
+    parseError("++a++", "Invalid prefix increment operand.");
+    parseError("--{a: 1}", "Invalid prefix decrement operand.");
+    parseError("++this", "Invalid prefix increment operand.");
+    parseError("++(-a)", "Invalid prefix increment operand.");
+    parseError("++{a: 1}", "Invalid prefix increment operand.");
+    parseError("++'literal'", "Invalid prefix increment operand.");
+    parseError("++delete a.b", "Invalid prefix increment operand.");
+  }
+
   public void testAutomaticSemicolonInsertion() {
     // var statements
     assertNodeEquality(


### PR DESCRIPTION
Reports something like:

```javascript
test.js:1: ERROR - Parse error. Invalid postfix increment operand.
12++;
^

test.js:2: ERROR - Parse error. Invalid postfix decrement operand.
(+foo)--;
 ^

test.js:3: ERROR - Parse error. Invalid prefix increment operand.
++this;
  ^

test.js:4: ERROR - Parse error. Invalid prefix decrement operand.
--(a + b);
   ^
```