### PR TITLE
Fix bug in Intl extern: param type for DateTimeFormat.format()

### DIFF
--- a/externs/browser/intl.js
+++ b/externs/browser/intl.js
@@ -146,7 +146,7 @@ Intl.DateTimeFormat = function(opt_locales, opt_options) {};
 Intl.DateTimeFormat.supportedLocalesOf = function(locales, opt_options) {};
 
 /**
- * @param {?(!Date|number|string)=} date
+ * @param {(!Date|number)=} date
  * @return {string}
  */
 Intl.DateTimeFormat.prototype.format = function(date) {};

--- a/externs/browser/intl.js
+++ b/externs/browser/intl.js
@@ -146,7 +146,7 @@ Intl.DateTimeFormat = function(opt_locales, opt_options) {};
 Intl.DateTimeFormat.supportedLocalesOf = function(locales, opt_options) {};
 
 /**
- * @param {number} date
+ * @param {?(!Date|number|string)=} date
  * @return {string}
  */
 Intl.DateTimeFormat.prototype.format = function(date) {};


### PR DESCRIPTION
There appears to be a bug in [`/externs/browser/intl.js`](https://github.com/google/closure-compiler/blob/e1d0bb2/externs/browser/intl.js#L149):

```js
/**
 * @param {number} date
 * @return {string}
 */
Intl.DateTimeFormat.prototype.format = function(date) {};
```

I think the `date` parameter is allowed to contain a value of other types besides `number`.

The spec for `DateTimeFormat.format()` in the [ECMAScript Internationalization API, 1st Edition, section 12.3.2](http://www.ecma-international.org/ecma-402/1.0/index.html#sec-12.3.2) says:

> ... takes the argument `date` and performs the following steps:
>
>   * If `date` is not provided or is `undefined`, then let `x` be the result as if by the expression `Date.now()` ...
>   * Else let `x` be `ToNumber(date)`.
>   * ...

The spec in the [2nd Edition, section 12.3.3](http://www.ecma-international.org/ecma-402/2.0/ECMA-402.pdf) is basically identical.

So the type of the `date` parameter can be:

  * [`undefined`](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-4.3.10)
  * Any value which seems reasonable to pass to [`ToNumber()`](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-9.3), which I think includes:
    * [`number`](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-4.3.20) – [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time)
    * [`string`](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-4.3.17) – containing a Unix timestamp
    * A [`Date`](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-15.9) object – `ToNumber()` will return the `Date`'s [`[[PrimitiveValue]]` internal property](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-15.9.6), which is its [time value](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-15.9.1.1) (Unix timestamp)
    * [`null`](http://www.ecma-international.org/ecma-262/5.1/index.html#sec-4.3.12) – `ToNumber()` will return `+0` (the Unix epoch)
