### PR TITLE
Allow trailing comma in JSDoc record types.

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -2381,8 +2381,14 @@ public final class JsDocInfoParser {
       // Move to the comma token.
       next();
 
-      // Move to the token passed the comma.
+      // Move to the token past the comma
       skipEOLs();
+
+      if (match(JsDocToken.RIGHT_CURLY)) {
+        // Allow trailing comma (ie, right curly following the comma)
+        break;
+      }
+
       token = next();
     } while (true);
 

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -1147,6 +1147,10 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
     parseFull("/** @param {{x : function(), 'y'}|function()} n\n*/");
   }
 
+  public void testParseRecordType24() throws Exception {
+    parseFull("/** @param {{a : b, c,}} n\n*/");
+  }
+
   public void testParseParamError1() throws Exception {
     parseFull("/** @param\n*/",
         "Bad type annotation. expecting a variable name in a @param tag");


### PR DESCRIPTION
Fixes: #796


