### PR TITLE
Allow es6 object shorthand in commonjs module exports

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -392,10 +392,11 @@ public final class ProcessCommonJSModules implements CompilerPass {
               .createScope(script, null);
           for (Node key = rhsValue.getFirstChild();
                key != null; key = key.getNext()) {
-            if (key.getJSDocInfo() == null
-                && key.getFirstChild().isName()) {
-              Var aliasedVar =
-                  globalScope.getVar(key.getFirstChild().getString());
+            if (key.getJSDocInfo() == null &&
+                (key.getFirstChild() == null || key.getFirstChild().isName())) {
+              String aliasedVarName = key.getFirstChild() == null ?
+                  key.getString() : key.getFirstChild().getString();
+              Var aliasedVar = globalScope.getVar(aliasedVarName);
               JSDocInfo info =
                   aliasedVar == null ? null : aliasedVar.getJSDocInfo();
               if (info != null &&

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -225,7 +225,32 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "goog.provide('module$test');" +
         "var foobar$$module$test = {foo: 'bar'};" +
         "module$test = foobar$$module$test;");
-}
+  }
+
+  public void testEs6ObjectShorthand() {
+    setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6,
+        CompilerOptions.LanguageMode.ECMASCRIPT5);
+    setFilename("test");
+    testModules(
+        "function foo() {}"
+            + "module.exports = {"
+            + "  prop: 'value',"
+            + "  foo"
+            + "}",
+        "goog.provide('module$test');"
+            + "function foo$$module$test() {}"
+            + "module$test = { prop: 'value', foo }");
+
+    testModules(
+        "module.exports = {\n"
+            + "  prop: 'value',\n"
+            + "  foo() {\n"
+            + "    console.log('bar');\n"
+            + "  }\n"
+            + "};",
+        "goog.provide('module$test');"
+            + "module$test = { prop: 'value', foo() { console.log('bar'); }}" );
+  }
 
   public void testSortInputs() throws Exception {
     SourceFile a = SourceFile.fromCode("a.js", "require('b');require('c')");


### PR DESCRIPTION
Fixes #1224

Allows CommonJS module exports to use ES6 object literal shorthand syntax:

```JavaScript
var foo = 'bar';
module.exports = {
  foo,
  foobar() { console.log(foo); }
}
```