### PR TITLE
Allow ES6 imports from namespaces.

### DIFF
--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -578,4 +578,33 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "use(foo, bar);"),
         LHS_OF_GOOG_REQUIRE_MUST_BE_CONST);
   }
+
+  public void testNamespaceImports() {
+    testModules(
+        LINE_JOINER.join(
+            "import Foo from 'goog:other.Foo';",
+            "use(Foo);"),
+        LINE_JOINER.join(
+            "goog.require('other.Foo');",
+            "use(other.Foo)"));
+    testModules(
+        LINE_JOINER.join(
+            "import {x, y} from 'goog:other.Foo';",
+            "use(x);",
+            "use(y);"),
+        LINE_JOINER.join(
+            "goog.require('other.Foo');",
+            "use(other.Foo.x); use(other.Foo.y);"));
+    testModules(
+        LINE_JOINER.join(
+            "import Foo from 'goog:other.Foo';",
+            "/** @type {Foo} */ var foo = new Foo();"),
+        LINE_JOINER.join(
+            "goog.require('other.Foo');",
+            "/** @type {other.Foo} */",
+            "var foo$$module$testcode = new other.Foo();"));
+
+    testModules("import * as Foo from 'goog:other.Foo';",
+        ProcessEs6Modules.NAMESPACE_IMPORT_CANNOT_USE_STAR);
+  }
 }


### PR DESCRIPTION
This allows code that uses ES6 imports in a heterogeneous code base
that has ES6 and ES5-style Closure imports to consistently use ES6
import syntax, allowing a smoother migration path.