### PR TITLE
Support multiplexing files via stdin/out streams

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -606,6 +606,14 @@ public class CommandLineRunner extends
             usage = "A file containing an instrumentation template.")
         private String instrumentationFile = "";
 
+    @Option(name = "--json_streams",
+        hidden = true,
+        handler = BooleanOptionHandler.class,
+        usage = "Specifies that standard input and output streams will be "
+            + "a JSON array of sources. Each source will be an object of the "
+            + "form {path: filename, src: file_contents, srcmap: srcmap_contents }. "
+            + "Intended for use by stream-based build systems such as gulpjs.")
+    private boolean jsonStreams = false;
 
     @Argument
     private List<String> arguments = new ArrayList<>();
@@ -1123,7 +1131,8 @@ public class CommandLineRunner extends
           .setAngularPass(flags.angularPass)
           .setTracerMode(flags.tracerMode)
           .setInstrumentationTemplateFile(flags.instrumentationFile)
-          .setNewTypeInference(flags.useNewTypeInference);
+          .setNewTypeInference(flags.useNewTypeInference)
+          .setUseJsonStreams(flags.jsonStreams);
     }
     errorStream = null;
   }


### PR DESCRIPTION
As discusses last meeting, this is the initial work to support sending multiple input files to the compiler via stdin. This is needed to support stream based build systems like [Gulp](http://gulpjs.com/).

This currently uses a new boolean flag `--json_streams`. Ideally we'd avoid this, but I haven't come up with another good solution.

When the `--json_streams` flag is true, standard input is expected to be an array of json encoded files of the form:

```JSON
[
  {
    "src": "file source",
    "path": "/absolute/path/of/file.js",
    "source_map": "optional. source of input sourcemap"
  }
]
```

When the compiled source is written to standard output, it will also use the same format.

Currently this only supports single binaries. I'll be working to add modules shortly.