### PR TITLE
Add pom-gwt.xml to use Maven for GWT build

### DIFF
--- a/pom-gwt.xml
+++ b/pom-gwt.xml
@@ -1,0 +1,272 @@
+<!--
+ Copyright 2015 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  >
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.javascript</groupId>
+  <artifactId>closure-compiler-gwt</artifactId>
+  <packaging>gwt-app</packaging>
+
+  <name>Closure Compiler GWT App</name>
+  <version>1.0-SNAPSHOT</version>
+
+  <url>https://developers.google.com/closure/compiler/</url>
+  <description>
+    Closure Compiler is a JavaScript optimizing compiler. It parses your
+    JavaScript, analyzes it, removes dead code and rewrites and minimizes
+    what's left. It also checks syntax, variable references, and types, and
+    warns about common JavaScript pitfalls. It is used in many of Google's
+    JavaScript apps, including Gmail, Google Web Search, Google Maps, and
+    Google Docs.
+  </description>
+  <inceptionYear>2009</inceptionYear>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <jdk.version>1.7</jdk.version>
+    <!-- for substitution in ParserConfig.properties -->
+    <compiler.date>${maven.build.timestamp}</compiler.date>
+    <maven.build.timestamp.format>yyyy-MM-dd HH\:mm</maven.build.timestamp.format>
+    <compiler.version>${project.version}</compiler.version>
+  </properties>
+
+  <parent>
+    <groupId>com.google.javascript</groupId>
+    <artifactId>closure-compiler-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.javascript</groupId>
+      <artifactId>closure-compiler-externs</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+      <version>2.0.26</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0-rc2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-gwt</artifactId>
+      <version>19.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.2.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>1.3.9</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.24</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Ant is a provided scope as it is only needed to compile; ant will provide itself when using the jar -->
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <scope>provided</scope>
+      <version>1.9.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <version>2.8.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <version>2.8.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>google-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/google-snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>plugin-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/public/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <sourceDirectory>${basedir}/src</sourceDirectory>
+    <testSourceDirectory>${basedir}/test</testSourceDirectory>
+
+    <resources>
+      <resource>
+        <directory>src/</directory>
+        <excludes>
+          <exclude>**/*.java</exclude>
+        </excludes>
+        <includes>
+          <include>**/*</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals><goal>add-source</goal></goals>
+            <configuration>
+              <sources>
+                <source>gen</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals><goal>add-test-source</goal></goals>
+            <configuration>
+              <sources>
+                <source>src/com/google/javascript/rhino/testing</source>
+                <source>src/com/google/javascript/jscomp/testing</source>
+                <source>src/com/google/javascript/refactoring/testing</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+
+        <!-- Move Messages.properties where ScriptRuntime.java expects it. -->
+        <executions>
+          <execution>
+            <id>rhino_ast-custom</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/rhino_ast</outputDirectory>
+              <resources>
+                <resource>
+                  <targetPath>${basedir}/target/classes</targetPath>
+                  <directory>src</directory>
+                  <includes>
+                    <include>com/google/javascript/rhino/Messages.properties</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/gwt/**</exclude>
+            <exclude>**/testing/**</exclude>
+            <exclude>**/webservice/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>net.ltgt.gwt.maven</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <version>1.0-rc-4</version>
+        <extensions>true</extensions>
+        <configuration>
+	  <moduleName>com.google.JsComp</moduleName>
+	  <moduleShortName>jscomp</moduleShortName>
+          <skipModule>true</skipModule>
+	  <failOnError>true</failOnError>
+        </configuration>
+       </plugin>
+    </plugins>
+  </build>
+
+  <!-- reporting -->
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 
   <modules>
     <module>externs/pom.xml</module>
+    <module>pom-gwt.xml</module>
     <module>pom-main.xml</module>
   </modules>
 

--- a/src/com/google/JsComp.gwt.xml
+++ b/src/com/google/JsComp.gwt.xml
@@ -1,0 +1,12 @@
+<module rename-to="jscomp">
+  <inherits name="com.google.gwt.user.User" />
+  <inherits name="com.google.common.base.Base"/>
+  <inherits name="com.google.common.collect.Collect"/>
+  <source path="debugging/sourcemap" />
+  <source path="javascript/jscomp" excludes=".svn,.git,**/ant/**,**/refactoring/**,**/webservice/**,**/testing/**" />
+  <source path="javascript/rhino" excludes=".svn,.git,**/testing/**" />
+  <super-source path="javascript/jscomp/gwt/super" />
+  <set-property name="user.agent" value="safari" />
+  <entry-point class="com.google.javascript.jscomp.gwt.client.JsCompGwtMain" />
+  <public path="javascript/jscomp/gwt/public" />
+</module>

--- a/src/com/google/javascript/jscomp/gwt/public/gwt_demo.html
+++ b/src/com/google/javascript/jscomp/gwt/public/gwt_demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
 <html>
-   <script src="com.google.javascript.jscomp.GwtModule.nocache.js"></script>
+   <script src="jscomp.nocache.js"></script>
 </html>
 

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/debugging/sourcemap/SourceMapConsumerFactory.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/debugging/sourcemap/SourceMapConsumerFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.debugging.sourcemap;
+
+/** GWT compatible no-op replacement of {@code SourceMapConsumerFactory} */
+public final class SourceMapConsumerFactory {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/debugging/sourcemap/proto/Mapping.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/debugging/sourcemap/proto/Mapping.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.debugging.sourcemap.proto;
+
+/** GWT compatible no-op replacement of {@code Mapping} */
+public final class Mapping {
+  public static final class OriginalMapping {
+    public static final class Builder {
+      public Builder setOriginalFile(String value) {
+        throw new UnsupportedOperationException(
+	  "Mapping.OriginalMapping.Builder.setOriginalFile not implemented");
+      }
+
+      public Builder setColumnPosition(int value) {
+        throw new UnsupportedOperationException(
+	  "Mapping.OriginalMapping.Builder.setColumnPosition not implemented");
+      }
+
+      public OriginalMapping build() {
+        throw new UnsupportedOperationException(
+	  "Mapping.OriginalMapping.Builder.build not implemented");
+      }
+    }
+
+    public String getOriginalFile() {
+      throw new UnsupportedOperationException(
+          "Mapping.OriginalMapping.getOriginalFile not implemented");
+    }
+
+    public int getLineNumber() {
+      throw new UnsupportedOperationException(
+          "Mapping.OriginalMapping.getLineNumber not implemented");
+    }
+
+    public int getColumnPosition() {
+      throw new UnsupportedOperationException(
+          "Mapping.OriginalMapping.getColumnPosition not implemented");
+    }
+
+    public Builder toBuilder() {
+      throw new UnsupportedOperationException(
+          "Mapping.OriginalMapping.toBuilder not implemented");
+    }
+  }
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Conformance.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Conformance.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code Conformance} */
+public final class Conformance {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/ConformanceConfig.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/ConformanceConfig.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code ConformanceConfig} */
+public final class ConformanceConfig {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/ConformanceConfigOrBuilder.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/ConformanceConfigOrBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code ConformanceConfigOrBuilder} */
+public interface ConformanceConfigOrBuilder {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/FunctionInfo.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/FunctionInfo.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code FunctionInfo} */
+public final class FunctionInfo {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/FunctionInformationMap.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/FunctionInformationMap.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code FunctionInformationMap} */
+public final class FunctionInformationMap {
+  public static final class Builder {
+    public Builder addEntry(Entry value) {
+      throw new UnsupportedOperationException(
+        "FunctionInformationMap.Builder.addEntry not implemented");
+    }
+
+    public FunctionInformationMap build() {
+      throw new UnsupportedOperationException(
+          "FunctionInformationMap.Builder.build not implemented");
+    }
+  }
+
+  public static final class Entry {
+    public static final class Builder {
+      public Builder setId(int value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setId not implemented");
+      }
+
+      public Builder setSourceName(String value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setSourceName not implemented");
+      }
+
+      public Builder setLineNumber(int value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setLineNumber not implemented");
+      }
+
+      public Builder setModuleName(String value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setModuleName not implemented");
+      }
+
+      public Builder setSize(int value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setSize not implemented");
+      }
+
+      public Builder setName(String value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setName not implemented");
+      }
+
+      public Builder setCompiledSource(String value) {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.setCompiledSource not implemented");
+      }
+
+      public Entry build() {
+        throw new UnsupportedOperationException(
+            "FunctionInformationMap.Entry.Builder.build not implemented");
+      }
+    }
+
+    public static Builder newBuilder() {
+      throw new UnsupportedOperationException(
+          "FunctionInformationMap.Entry.newBuilder not implemented");
+    }
+  }
+
+  public static Builder newBuilder() {
+    throw new UnsupportedOperationException(
+        "FunctionInformationMap.newBuilder not implemented");
+  }
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/FunctionInformationMapOrBuilder.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/FunctionInformationMapOrBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code FunctionInformationMapOrBuilder} */
+public interface FunctionInformationMapOrBuilder {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Instrumentation.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Instrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import java.util.List;
+
+/** GWT compatible no-op replacement for {@code Instrumentation} */
+public final class Instrumentation {
+  public List<String> getInitList() {
+    throw new UnsupportedOperationException(
+        "Instrumentation.getInitList not implemented");
+  }
+
+  public String getReportDefined() {
+    throw new UnsupportedOperationException(
+        "Instrumentation.getReportDefined not implemented");
+  }
+
+  public String getReportCall() {
+    throw new UnsupportedOperationException(
+        "Instrumentation.getReportCall not implemented");
+  }
+
+  public String getReportExit() {
+    throw new UnsupportedOperationException(
+        "Instrumentation.getReportExit not implemented");
+  }
+
+  public String getAppNameSetter() {
+    throw new UnsupportedOperationException(
+        "Instrumentation.getAppNameSetter not implemented");
+  }
+
+  public List<String> getDeclarationToRemoveList() {
+    throw new UnsupportedOperationException(
+        "Instrumentation.getDeclarationToRemoveList not implemented");
+  }
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/InstrumentationOrBuilder.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/InstrumentationOrBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code InstrumentationOrBuilder} */
+public interface InstrumentationOrBuilder {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/InstrumentationTemplate.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/InstrumentationTemplate.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code InstrumentationTemplate} */
+public final class InstrumentationTemplate {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Linter.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Linter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement of {@code Linter} */
+public class Linter {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Requirement.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/Requirement.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code Requirement} */
+public final class Requirement {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/RequirementOrBuilder.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/RequirementOrBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/** GWT compatible no-op replacement for {@code RequirementOrBuilder} */
+public interface RequirementOrBuilder {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/ClosureBundler.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/ClosureBundler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+/** GWT compatible no-op replacement for {@code ClosureBundler} */
+public class ClosureBundler {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/DefaultDependencyResolver.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/DefaultDependencyResolver.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+/** GWT compatible no-op replacement for {@code DefaultDependencyResolver} */
+public class DefaultDependencyResolver {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/DependencyFile.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/DependencyFile.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+/** GWT compatible no-op replacement for {@code DependencyFile} */
+public class DependencyFile {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/DepsGenerator.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/DepsGenerator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+/** GWT compatible no-op replacement for {@code DepsGenerator} */
+public class DepsGenerator {
+}

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/SourceCodeEscapers.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/SourceCodeEscapers.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+/** GWT compatible no-op replacement for {@code SourceCodeEscapers} */
+public final class SourceCodeEscapers {
+}


### PR DESCRIPTION
This makes use of Thomas Broyer's gwt-maven-plugin.

Shortened module name in gwt_demo.html to be "jscomp"

Also added extra super sources for GWT incompatible classes.