### PR TITLE
Create the path structure, if necessary, to write a sourcemap.

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1376,6 +1376,8 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     }
 
     String outName = expandSourceMapPath(options, null);
+    File outPath = new File(outName);
+    maybeCreateDirsForPath(outPath.getParent());
     try (Writer out = fileNameToOutputWriter2(outName)) {
       compiler.getSourceMap().appendTo(out, associatedName);
     }


### PR DESCRIPTION
Multiple plugins in the npm ecosystem complain (in code comments) that closure-compiler doesn't create the directory structure for soucemap files if needed. This fixes the issue.