### PR TITLE
All boolean flags should specify the BooleanOptionHandler

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -362,6 +362,7 @@ public class CommandLineRunner extends
 
     @Option(name = "--checks-only",
         hidden = true,
+        handler = BooleanOptionHandler.class,
         usage = "Don't generate output. Run checks, but no compiler passes.")
     private boolean checksOnly = false;
 
@@ -406,6 +407,7 @@ public class CommandLineRunner extends
 
     @Option(name = "--process_common_js_modules",
         hidden = true,
+        handler = BooleanOptionHandler.class,
         usage = "Process CommonJS modules to a concatenable form.")
     private boolean processCommonJsModules = false;
 
@@ -431,6 +433,7 @@ public class CommandLineRunner extends
 
     @Option(name = "--transform_amd_modules",
         hidden = true,
+        handler = BooleanOptionHandler.class,
         usage = "Transform AMD to CommonJS modules.")
     private boolean transformAmdModules = false;
 
@@ -575,6 +578,7 @@ public class CommandLineRunner extends
 
     @Option(name = "--new_type_inf",
         hidden = true,
+        handler = BooleanOptionHandler.class,
         usage = "Checks for type errors using the new type inference algorithm.")
     private boolean useNewTypeInference = false;
 


### PR DESCRIPTION
Without the BooleanOptionHandler, the args4j doesn't handle `--flag=true`. All boolean flags should use the BooleanOptionHandler.