### PR TITLE
Remove the ability to generate a single sourcemap file for multiple output modules

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -116,6 +116,10 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   static final DiagnosticType NO_TREE_GENERATED_ERROR = DiagnosticType.error(
       "JSC_NO_TREE_GENERATED_ERROR",
       "Code contains errors. No tree was generated.");
+  static final DiagnosticType INVALID_MODULE_SOURCEMAP_PATTERN = DiagnosticType.error(
+      "JSC_INVALID_MODULE_SOURCEMAP_PATTERN",
+      "When using --module flags, the --create_source_map flag must contain "
+      + "%outname% in the value.");
 
   static final String WAITING_FOR_INPUT_WARNING =
       "The compiler is waiting for input via stdin.";
@@ -1132,7 +1136,11 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
           outputSourceMap(options, config.jsOutputFile);
         }
       } else {
-        outputModuleBinaryAndSourceMaps(modules, options);
+        DiagnosticType error = outputModuleBinaryAndSourceMaps(modules, options);
+        if (error != null) {
+          compiler.report(JSError.make(error));
+          return 1;
+        }
       }
 
       // Output the externs if required.
@@ -1226,8 +1234,9 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     }
   }
 
-  private void outputModuleBinaryAndSourceMaps(List<JSModule> modules, B options)
-      throws IOException {
+  private DiagnosticType outputModuleBinaryAndSourceMaps(
+      List<JSModule> modules, B options)
+      throws FlagUsageException, IOException {
     parsedModuleWrappers = parseModuleWrappers(
         config.moduleWrapper, modules);
     maybeCreateDirsForPath(config.moduleOutputPathPrefix);
@@ -1239,9 +1248,11 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
 
     // When the json_streams flag is specified, sourcemaps are always generated
     // per module
-    if (!(shouldGenerateMapPerModule(options) || isOutputInJson())) {
-      mapFileOut = fileNameToOutputWriter2(
-          expandSourceMapPath(options, null));
+    if (!(shouldGenerateMapPerModule(options) || options.sourceMapOutputPath == null ||
+        config.jsonStreamMode == JsonStreamMode.OUT ||
+        config.jsonStreamMode == JsonStreamMode.BOTH)) {
+      // warn that this is not supported
+      return INVALID_MODULE_SOURCEMAP_PATTERN;
     }
 
     for (JSModule m : modules) {
@@ -1252,14 +1263,14 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
           mapFileOut = fileNameToOutputWriter2(expandSourceMapPath(options, m));
         }
 
-        try (Writer writer = fileNameToLegacyOutputWriter(
-            getModuleOutputFileName(m))) {
+        String moduleFilename = getModuleOutputFileName(m);
+        try (Writer writer = fileNameToLegacyOutputWriter(moduleFilename)) {
           if (options.sourceMapOutputPath != null) {
             compiler.getSourceMap().reset();
           }
           writeModuleOutput(writer, m);
           if (options.sourceMapOutputPath != null) {
-            compiler.getSourceMap().appendTo(mapFileOut, m.getName());
+            compiler.getSourceMap().appendTo(mapFileOut, moduleFilename);
           }
         }
 
@@ -1273,6 +1284,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     if (mapFileOut != null) {
       mapFileOut.close();
     }
+    return null;
   }
 
   /**

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -984,6 +984,13 @@ public final class CommandLineRunnerTest extends TestCase {
         .isEqualTo("foo_m0.js.map");
   }
 
+  public void testInvalidSourceMapPattern() {
+    useModules = ModulePattern.CHAIN;
+    args.add("--create_source_map=out.map");
+    args.add("--module_output_path_prefix=foo_");
+    test(new String[] {"var x = 3;", "var y = 5;"}, AbstractCommandLineRunner.INVALID_MODULE_SOURCEMAP_PATTERN);
+  }
+
   public void testSourceMapFormat1() {
     args.add("--js_output_file");
     args.add("/path/to/out.js");


### PR DESCRIPTION
If `--module` flags are specified along with a `--create_source_map` flag, the value of the `--create_source_map` determines whether the compiler will generate a sourcemap for each output file or a single sourcemap file.

After chatting with @concavelenz this morning, we determined that a single sourcemap is not valid and this is most likely is not what was intended by the user. This PR removes the ability to generate a single sourcemap for multiple modules and reports an error to the user in this case. 

As further support, every unit test for CommandLineRunner which tested sourcemaps for modules generated one sourcemap per module.

In addition, the `file` property of a sourcemap, while optional, is intended to point back to the file which loaded it. Currently we are only using the module name - not the full module filename.

So for `java -jar compiler.jar --js input.js --module base:1 --create_source_map="%outname%.map"` the compiler would generate:

```Javascript
   {
      "file": "base" // this should be base.js at a minimum - and ideally would include the full module path
     /// ...
```

This PR changes the file reference to be the full module output path.

The module flags are not widely used, but it is still possible that someone is depending on this functionality - broken as it is.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1266)
<!-- Reviewable:end -->
