### PR TITLE
Update the .project and .classpath to use maven build paths. 

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry excluding="**/gwt/**" including="**/*.java|**/*.properties" kind="src" path="src"/>
 	<classpathentry including="**/*.java" kind="src" path="gen"/>
-	<classpathentry including="**/*.java" kind="src" output="build/test-classes" path="test"/>
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="test"/>
 	<classpathentry kind="lib" path="lib/ant.jar"/>
 	<classpathentry kind="lib" path="lib/ant-launcher.jar"/>
 	<classpathentry kind="lib" path="lib/args4j.jar"/>
@@ -13,5 +13,5 @@
 	<classpathentry kind="lib" path="lib/protobuf-java.jar"/>
 	<classpathentry kind="lib" path="lib/truth.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ junit*.properties
 target/
 *~
 .settings
+externs/.classpath
+externs/.project

--- a/.project
+++ b/.project
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-        <name>closure-compiler</name>
-        <comment></comment>
-        <projects>
-        </projects>
-        <buildSpec>
-                <buildCommand>
-                        <name>org.eclipse.jdt.core.javabuilder</name>
-                        <arguments>
-                        </arguments>
-                </buildCommand>
-        </buildSpec>
-        <natures>
-                <nature>org.eclipse.jdt.core.javanature</nature>
-        </natures>
+	<name>closure-compiler</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
 </projectDescription>

--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ unit tests too).
 ### Using [Eclipse](http://www.eclipse.org/)
 
 1. Download and open the [Eclipse IDE](http://www.eclipse.org/).
-2. Navigate to ```File > New > Project ...``` and create a Java Project. Give
-   the project a name.
-3. Select ```Create project from existing source``` and choose the root of the
-   checked-out source tree as the existing directory.
-3. Navigate to the ```build.xml``` file. You will see all the build rules in
-   the Outline pane. Run the ```jar``` rule to build the compiler in
-   ```build/compiler.jar```.
+2. **Right click** in the package explorer and choose *Import*.
+3. Select the ```Maven > Existing Maven Projects``` source.
+4. In the Root Directory selection, enter the path to your clone of the closure-compiler repository.
+5. **Right click** on the ```closure-compiler-parent``` project in the package explorer
+and select ```Run As > Maven Install```.
+The compiler will be built to ```target/closure-compiler-1.0-SNAPSHOT.jar```
 
 ## Running
 

--- a/externs/pom.xml
+++ b/externs/pom.xml
@@ -68,5 +68,38 @@
         <directory>target/generated-resources//</directory>
       </resource>
     </resources>
+    <pluginManagement>
+    	<plugins>
+    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    		<plugin>
+    			<groupId>org.eclipse.m2e</groupId>
+    			<artifactId>lifecycle-mapping</artifactId>
+    			<version>1.0.0</version>
+    			<configuration>
+    				<lifecycleMappingMetadata>
+    					<pluginExecutions>
+    						<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>
+    									org.apache.maven.plugins
+    								</groupId>
+    								<artifactId>
+    									maven-antrun-plugin
+    								</artifactId>
+    								<versionRange>[1.7,)</versionRange>
+    								<goals>
+    									<goal>run</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
+    					</pluginExecutions>
+    				</lifecycleMappingMetadata>
+    			</configuration>
+    		</plugin>
+    	</plugins>
+    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
Switch the eclipse build instructions and settings to use maven. We may want to consider officially deprecating ant builds and eventually remove the build.xml file as it will quickly get out of date.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1268)
<!-- Reviewable:end -->
