### PR TITLE
Switch the --json_streams flag to an enumeration

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -607,12 +607,13 @@ public class CommandLineRunner extends
 
     @Option(name = "--json_streams",
         hidden = true,
-        handler = BooleanOptionHandler.class,
-        usage = "Specifies that standard input and output streams will be "
+        usage = "Specifies whether standard input and output streams will be "
             + "a JSON array of sources. Each source will be an object of the "
             + "form {path: filename, src: file_contents, srcmap: srcmap_contents }. "
-            + "Intended for use by stream-based build systems such as gulpjs.")
-    private boolean jsonStreams = false;
+            + "Intended for use by stream-based build systems such as gulpjs. "
+            + "Options: NONE, IN, OUT, BOTH. Defaults to NONE.")
+    private CompilerOptions.JsonStreamMode jsonStreamMode =
+        CompilerOptions.JsonStreamMode.NONE;
 
     @Argument
     private List<String> arguments = new ArrayList<>();
@@ -1131,7 +1132,7 @@ public class CommandLineRunner extends
           .setTracerMode(flags.tracerMode)
           .setInstrumentationTemplateFile(flags.instrumentationFile)
           .setNewTypeInference(flags.useNewTypeInference)
-          .setUseJsonStreams(flags.jsonStreams);
+          .setJsonStreamMode(flags.jsonStreamMode);
     }
     errorStream = null;
   }

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -2639,4 +2639,30 @@ public class CompilerOptions {
      */
     CUSTOM
   }
+
+  /**
+   * Whether standard input or standard output should be an array of
+   * JSON encoded files
+   */
+  static enum JsonStreamMode {
+    /**
+     * stdin/out are both single files.
+     */
+    NONE,
+
+    /**
+     * stdin is a json stream.
+     */
+    IN,
+
+    /**
+     * stdout is a json stream.
+     */
+    OUT,
+
+    /**
+     * stdin and stdout are both json streams.
+     */
+    BOTH
+  }
 }


### PR DESCRIPTION
I realize we just merged this feature yesterday, but it has worked so well for the gulp plugin that I also would like to use it for the grunt plugin as it completely mitigates problems with windows command length restrictions.

However, if both stdin and stdout are json streams, the plugin has to recreate much of the functionality of the CommandLineRunner in regards to smartly parsing sourcemap, module and output file flags. This is further complicated if a flagfile is used.

By allowing control of input/output streams independently, build systems can choose to allow the compiler to handle these tasks.