### PR TITLE
jQuery.prototype.not - arg1 as a function can take 2 arguments and should return boolean

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -1237,7 +1237,7 @@ jQuery.noConflict = function(removeAll) {};
 jQuery.noop = function() {};
 
 /**
- * @param {(jQuerySelector|Array<Element>|function(number)|jQuery)} arg1
+ * @param {(jQuerySelector|Array<Element>|function(this:Element,number,Element=):boolean|jQuery)} arg1
  * @return {!jQuery}
  */
 jQuery.prototype.not = function(arg1) {};


### PR DESCRIPTION
From jQuery API:

function
Type: Function( Integer index, Element element ) => Boolean

A function used as a test for each element in the set. It accepts two arguments, index, which is the element's index in the jQuery collection, and element, which is the DOM element. Within the function, this refers to the current DOM element.

https://api.jquery.com/not/