### PR TITLE
Mark angular.$timeout fn argument optional

### DIFF
--- a/contrib/externs/angular-1.4.js
+++ b/contrib/externs/angular-1.4.js
@@ -2415,7 +2415,7 @@ angular.$templateCache;
  *****************************************************************************/
 
 /**
- * @typedef {function(Function, number=, boolean=, ...*):!angular.$q.Promise}
+ * @typedef {function(Function=, number=, boolean=, ...*):!angular.$q.Promise}
  */
 angular.$timeout;
 


### PR DESCRIPTION
The fn argument to angular.$timeout service is optional, update the externs.
See https://code.angularjs.org/1.4.8/docs/api/ng/service/$timeout