### PR TITLE
Remove nosideeffects tag from JSON.parse and JSON.stringify

### DIFF
--- a/externs/es5.js
+++ b/externs/es5.js
@@ -246,7 +246,6 @@ function JSONType() {}
  * @param {(function(string, *) : *)=} opt_reviver
  * @return {*} The JSON object.
  * @throws {Error}
- * @nosideeffects
  */
 JSONType.prototype.parse = function(jsonStr, opt_reviver) {};
 
@@ -257,7 +256,6 @@ JSONType.prototype.parse = function(jsonStr, opt_reviver) {};
  * @param {(number|string)=} opt_space
  * @return {string} JSON string which represents jsonObj.
  * @throws {Error}
- * @nosideeffects
  */
 JSONType.prototype.stringify = function(jsonObj, opt_replacer, opt_space) {};
 


### PR DESCRIPTION
Or does it make any sence to mix throw and nosideeffects tags?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1281)
<!-- Reviewable:end -->
