### PR TITLE
Added nosideeffects for more jQuery methods

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -267,7 +267,10 @@ jQuery.callbacks.prototype.empty = function() {};
 /** @param {...*} var_args */
 jQuery.callbacks.prototype.fire = function(var_args) {};
 
-/** @return {boolean} */
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
 jQuery.callbacks.prototype.fired = function() {};
 
 /** @param {...*} var_args */
@@ -283,7 +286,10 @@ jQuery.callbacks.prototype.has = function(callback) {};
 /** @return {undefined} */
 jQuery.callbacks.prototype.lock = function() {};
 
-/** @return {boolean} */
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
 jQuery.callbacks.prototype.locked = function() {};
 
 /** @param {function()} callbacks */
@@ -336,6 +342,7 @@ jQuery.prototype.closest = function(arg1, context) {};
  * @param {Element} container
  * @param {Element} contained
  * @return {boolean}
+ * @nosideeffects
  */
 jQuery.contains = function(container, contained) {};
 
@@ -556,6 +563,7 @@ jQuery.prototype.end = function() {};
 /**
  * @param {number} arg1
  * @return {!jQuery}
+ * @nosideeffects
  */
 jQuery.prototype.eq = function(arg1) {};
 
@@ -780,7 +788,10 @@ jQuery.prototype.filter = function(arg1) {};
  */
 jQuery.prototype.find = function(arg1) {};
 
-/** @return {!jQuery} */
+/**
+ * @return {!jQuery}
+ * @nosideeffects
+ */
 jQuery.prototype.first = function() {};
 
 /** @see http://docs.jquery.com/Plugins/Authoring */
@@ -925,6 +936,7 @@ jQuery.inArray = function(value, arr, fromIndex) {};
 /**
  * @param {(jQuerySelector|Element|jQuery)=} arg1
  * @return {number}
+ * @nosideeffects
  */
 jQuery.prototype.index = function(arg1) {};
 
@@ -1110,7 +1122,10 @@ jQuery.prototype.keypress = function(arg1, handler) {};
  */
 jQuery.prototype.keyup = function(arg1, handler) {};
 
-/** @return {!jQuery} */
+/**
+ * @return {!jQuery}
+ * @nosideeffects
+ */
 jQuery.prototype.last = function() {};
 
 /** @type {number} */
@@ -1130,6 +1145,7 @@ jQuery.prototype.load = function(arg1, arg2, complete) {};
 /**
  * @param {*} obj
  * @return {Array<*>}
+ * @nosideeffects
  */
 jQuery.makeArray = function(obj) {};
 
@@ -1614,6 +1630,7 @@ jQuery.prototype.size = function() {};
  * @param {number} start
  * @param {number=} end
  * @return {!jQuery}
+ * @nosideeffects
  */
 jQuery.prototype.slice = function(start, end) {};
 

--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -567,7 +567,10 @@ jQuery.prototype.end = function() {};
  */
 jQuery.prototype.eq = function(arg1) {};
 
-/** @param {string} message */
+/**
+ * @param {string} message
+ * @throws {Error}
+ */
 jQuery.error = function(message) {};
 
 /**


### PR DESCRIPTION
I went through the jQuery docs and source code and found out that these calls can be safely removed if their return value is not used.

Plus I've included small patch for jQuery.error annotation. Or do you prefer sending it as a new PR?