### PR TITLE
Add angular mock passThrough extern

### DIFF
--- a/contrib/externs/angular-1.4-mocks.js
+++ b/contrib/externs/angular-1.4-mocks.js
@@ -59,6 +59,10 @@ angular.mock.$httpBackend.RequestHandler.prototype.respond = function(
     opt_statusText) {};
 
 
+/** @return {!angular.mock.$httpBackend.RequestHandler} */
+angular.mock.$httpBackend.RequestHandler.prototype.passThrough = function() {};
+
+
 /**
  * @param {string} method
  * @param {(string|RegExp|function(string): boolean)} url


### PR DESCRIPTION
$httpBackend.RequestHandler.passThrough is available in angular mock 1.4
but never made it to this extern file for some reason. This commit takes
care of that.

Refer to
https://code.angularjs.org/1.4.0/docs/api/ngMockE2E/service/$httpBackend
for more details.