### PR TITLE
Support mixing ES6, CommonJS and goog.module systems

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -428,7 +428,7 @@ public class CommandLineRunner extends
         hidden = true,
         usage = "Root of your common JS dependency hierarchy. " +
             "Your main script.")
-    private String commonJsEntryModule;
+    private List<String> commonJsEntryModule;
 
     @Option(name = "--transform_amd_modules",
         hidden = true,
@@ -1049,11 +1049,15 @@ public class CommandLineRunner extends
       if (flags.commonJsEntryModule == null && flags.closureEntryPoint == null) {
         reportError("Please specify --common_js_entry_module.");
       } else if (flags.commonJsEntryModule != null) {
-        String moduleEntryPoint = ES6ModuleLoader.toModuleName(URI.create(flags.commonJsEntryModule));
+        List<String> moduleEntryPoints = new ArrayList();
+        for (String entryPoint : flags.commonJsEntryModule) {
+          moduleEntryPoints.add(ES6ModuleLoader.toModuleName(URI.create(entryPoint)));
+        }
+
         if (flags.closureEntryPoint == null) {
-          flags.closureEntryPoint = ImmutableList.of(moduleEntryPoint);
+          flags.closureEntryPoint = moduleEntryPoints;
         } else {
-          flags.closureEntryPoint.add(moduleEntryPoint);
+          flags.closureEntryPoint.addAll(moduleEntryPoints);
         }
       }
     }

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1043,11 +1043,19 @@ public class CommandLineRunner extends
     if (flags.processCommonJsModules) {
       flags.processClosurePrimitives = true;
       flags.manageClosureDependencies = true;
-      if (flags.commonJsEntryModule == null) {
+
+      // When module systems are mixed, the entry point can be either a CommonJS module
+      // or a closure namespace
+      if (flags.commonJsEntryModule == null && flags.closureEntryPoint == null) {
         reportError("Please specify --common_js_entry_module.");
+      } else if (flags.commonJsEntryModule != null) {
+        String moduleEntryPoint = ES6ModuleLoader.toModuleName(URI.create(flags.commonJsEntryModule));
+        if (flags.closureEntryPoint == null) {
+          flags.closureEntryPoint = ImmutableList.of(moduleEntryPoint);
+        } else {
+          flags.closureEntryPoint.add(moduleEntryPoint);
+        }
       }
-      flags.closureEntryPoint =
-          ImmutableList.of(ES6ModuleLoader.toModuleName(URI.create(flags.commonJsEntryModule)));
     }
 
     if (flags.outputWrapperFile != null && !flags.outputWrapperFile.isEmpty()) {

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -1517,7 +1518,11 @@ public class Compiler extends AbstractCompiler {
     }
 
     if (options.processCommonJSModules) {
-      List<JSModule> modules = new ArrayList<>(modulesByProvide.values());
+      // Get the unique set of modules but preserve the relative order.
+      // While CommonJS modules always have a single export,
+      // ES6 modules and goog.provides/modules can be mixed in here too.
+      List<JSModule> modules = new ArrayList<>(new LinkedHashSet<>(modulesByProvide.values()));
+
       if (!modules.isEmpty()) {
         this.modules = modules;
         this.moduleGraph = new JSModuleGraph(this.modules);


### PR DESCRIPTION
When processing commonjs modules, the compiler assumed that all modules had a single export. This does not hold true for ES6 modules, so a "duplicate module detected" error was thrown. This change uses the unique set of modules found to build the module graph.

Also, when mixing module systems, the entry point can be specified as either a closure entry point or a commonjs entry point or a combination of the two. Keep the warning for the most common use case, but allow advanced users to specify a single entry point in whichever format they choose.

This allows full dependency pruning across multiple module types to properly function :100: 