### PR TITLE
Enable GWT logging in JsComp.gwt.xml

### DIFF
--- a/src/com/google/JsComp.gwt.xml
+++ b/src/com/google/JsComp.gwt.xml
@@ -7,6 +7,7 @@
   <source path="javascript/rhino" excludes=".svn,.git,**/testing/**" />
   <super-source path="javascript/jscomp/gwt/super" />
   <set-property name="user.agent" value="safari" />
+  <set-property name="gwt.logging.enabled" value="TRUE"/>
   <entry-point class="com.google.javascript.jscomp.gwt.client.JsCompGwtMain" />
   <public path="javascript/jscomp/gwt/public" />
 </module>


### PR DESCRIPTION
This enables printing of errors / warnings to the browser's console from
gwt_demo.html.