### PR TITLE
Add --hide_warnings_for to suppress warnings by path.

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -336,6 +336,12 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       addWhitelistWarningsGuard(options, new File(config.warningsWhitelistFile));
     }
 
+    if (!config.hideWarningsFor.isEmpty()) {
+      options.addWarningsGuard(new ShowByPathWarningsGuard(
+          config.hideWarningsFor.toArray(new String[] {}),
+          ShowByPathWarningsGuard.ShowType.EXCLUDE));
+    }
+
     createDefineOrTweakReplacements(config.define, options, false);
 
     options.setTweakProcessing(config.tweakProcessing);
@@ -2422,6 +2428,16 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
      */
     CommandLineConfig setWarningsWhitelistFile(String fileName) {
       this.warningsWhitelistFile = fileName;
+      return this;
+    }
+
+    private List<String> hideWarningsFor = ImmutableList.of();
+
+    /**
+     * Sets the paths for which warnings will be hidden.
+     */
+    CommandLineConfig setHideWarningsFor(List<String> hideWarningsFor) {
+      this.hideWarningsFor = hideWarningsFor;
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -568,6 +568,12 @@ public class CommandLineRunner extends
             "<file-name>:<line-number>?  <warning-description>")
     private String warningsWhitelistFile = "";
 
+    @Option(name = "--hide_warnings_for",
+        hidden = true,
+        usage = "If specified, files whose path contains this string will " +
+            "have their warnings hidden. You may specify multiple.")
+    private List<String> hideWarningsFor = new ArrayList<>();
+
     @Option(name = "--extra_annotation_name",
         hidden = true,
         usage = "A whitelist of tag names in JSDoc. You may specify multiple")
@@ -1133,6 +1139,7 @@ public class CommandLineRunner extends
           .setModuleRoots(moduleRoots)
           .setTransformAMDToCJSModules(flags.transformAmdModules)
           .setWarningsWhitelistFile(flags.warningsWhitelistFile)
+          .setHideWarningsFor(flags.hideWarningsFor)
           .setAngularPass(flags.angularPass)
           .setTracerMode(flags.tracerMode)
           .setInstrumentationTemplateFile(flags.instrumentationFile)

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -182,6 +182,13 @@ public final class CommandLineRunnerTest extends TestCase {
     testSame("function f() { this.a = 3; }");
   }
 
+  public void testWarningGuardHideWarningsFor() {
+    args.add("--jscomp_warning=globalThis");
+    args.add("--hide_warnings_for=foo/bar");
+    setFilename(0, "foo/bar.js");
+    testSame("function f() { this.a = 3; }");
+  }
+
   public void testSimpleModeLeavesUnusedParams() {
     args.add("--compilation_level=SIMPLE_OPTIMIZATIONS");
     testSame("window.f = function(a) {};");


### PR DESCRIPTION
I'd love the ability to hide warnings for all code in a given path, such as for third-party projects that I don't control. This change attempts to support that.

If I should send a CL instead, let me know. This is my first PR, so be gentle (ish). =)

Thanks!