### PR TITLE
Revert "Remove unused field "acceptTypeSyntax" from CompilerOptions"

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -90,6 +90,11 @@ public class CompilerOptions {
   }
 
   /**
+   * Whether the compiler accepts type syntax ({@code var foo: string;}).
+   */
+  boolean acceptTypeSyntax;
+
+  /**
    * Whether to infer consts. This should not be configurable by
    * external clients. This is a transitional flag for a new type
    * of const analysis.
@@ -972,6 +977,9 @@ public class CompilerOptions {
 
     // Which environment to use
     environment = Environment.BROWSER;
+
+    // Language variation
+    acceptTypeSyntax = false;
 
     // Checks
     skipNonTranspilationPasses = false;


### PR DESCRIPTION
Reverts google/closure-compiler#1295

I'll rollforward this one internally.