### PR TITLE
Add dependency-reduced-pom.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+dependency-reduced-pom.xml
 TESTS-TestSuites.xml
 junit*.properties
 target/


### PR DESCRIPTION
This file is generated by the Maven Shade Plugin and should be ignored.