### PR TITLE
Add tests for the --json_streams flag

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -152,6 +152,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
 
   private final CommandLineConfig config;
 
+  private final InputStream in;
   private final PrintStream defaultJsOutput;
   private final PrintStream err;
   private A compiler;
@@ -185,11 +186,16 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   private final List<JsonFileSpec> filesToStreamOut = new ArrayList<>();
 
   AbstractCommandLineRunner() {
-    this(System.out, System.err);
+    this(System.in, System.out, System.err);
   }
 
   AbstractCommandLineRunner(PrintStream out, PrintStream err) {
+    this(System.in, out, err);
+  }
+
+  AbstractCommandLineRunner(InputStream in, PrintStream out, PrintStream err) {
     this.config = new CommandLineConfig();
+    this.in = Preconditions.checkNotNull(in);
     this.defaultJsOutput = Preconditions.checkNotNull(out);
     this.err = Preconditions.checkNotNull(err);
     this.gson = new Gson();
@@ -584,7 +590,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
 
   public List<JsonFileSpec> parseJsonFilesFromInputStream() throws IOException {
     List<JsonFileSpec> jsonFiles = new ArrayList<>();
-    try (JsonReader reader = new JsonReader(new InputStreamReader(System.in, inputCharset))) {
+    try (JsonReader reader = new JsonReader(new InputStreamReader(this.in, inputCharset))) {
       reader.beginArray();
       while (reader.hasNext()) {
         JsonFileSpec jsonFile = gson.fromJson(reader, JsonFileSpec.class);
@@ -683,7 +689,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
         }
 
         this.err.println(WAITING_FOR_INPUT_WARNING);
-        inputs.add(SourceFile.fromInputStream("stdin", System.in, inputCharset));
+        inputs.add(SourceFile.fromInputStream("stdin", this.in, inputCharset));
         usingStdin = true;
       }
     }

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -44,6 +44,7 @@ import org.kohsuke.args4j.spi.StringOptionHandler;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
@@ -905,6 +906,11 @@ public class CommandLineRunner extends
 
   protected CommandLineRunner(String[] args, PrintStream out, PrintStream err) {
     super(out, err);
+    initConfigFromFlags(args, out, err);
+  }
+
+  protected CommandLineRunner(String[] args, InputStream in, PrintStream out, PrintStream err) {
+    super(in, out, err);
     initConfigFromFlags(args, out, err);
   }
 


### PR DESCRIPTION
#1310 highlighted the need to test output file naming. The easiest way to accomplish this was to utilize the `--json_streams` flag so that the output string can simply be tested rather than generate actual files.

This was also suggested in the original PR for the flag, but wasn't done due to AbstractCommandLineRunner only using the hard-coded `System.in` stream. I added fields and constructor overrides so that the input stream can optionally be provided.