### PR TITLE
Simplify dependency flags to use a common set for all module types.

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -277,34 +277,26 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
    * A helper function for creating the dependency options object.
    */
   static DependencyOptions createDependencyOptions(
-      boolean manageClosureDependencies,
-      boolean onlyClosureDependencies,
-      boolean processCommonJSModules,
-      List<String> closureEntryPoints)
+      CompilerOptions.DependencyMode dependencyMode,
+      List<DependencyOptions.ModuleIdentifier> entryPoints)
       throws FlagUsageException {
-    if (onlyClosureDependencies) {
-      if (closureEntryPoints.isEmpty()) {
-        throw new FlagUsageException("When only_closure_dependencies is "
-          + "on, you must specify at least one closure_entry_point");
+    if (dependencyMode == CompilerOptions.DependencyMode.STRICT) {
+      if (entryPoints.isEmpty()) {
+        throw new FlagUsageException("When dependency_mode=STRICT, you must "
+            + "specify at least one entry_point");
       }
 
       return new DependencyOptions()
           .setDependencyPruning(true)
           .setDependencySorting(true)
           .setMoocherDropping(true)
-          .setEntryPoints(closureEntryPoints);
-    } else if (processCommonJSModules) {
-      return new DependencyOptions()
-        .setDependencyPruning(false)
-        .setDependencySorting(true)
-        .setMoocherDropping(false)
-        .setEntryPoints(closureEntryPoints);
-    } else if (manageClosureDependencies || !closureEntryPoints.isEmpty()) {
+          .setEntryPoints(entryPoints);
+    } else if (dependencyMode == CompilerOptions.DependencyMode.LOOSE || !entryPoints.isEmpty()) {
       return new DependencyOptions()
           .setDependencyPruning(true)
           .setDependencySorting(true)
           .setMoocherDropping(false)
-          .setEntryPoints(closureEntryPoints);
+          .setEntryPoints(entryPoints);
     }
     return null;
   }
@@ -355,10 +347,8 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     createDefineOrTweakReplacements(config.tweak, options, true);
 
     DependencyOptions depOptions = createDependencyOptions(
-        config.manageClosureDependencies,
-        config.onlyClosureDependencies,
-        config.processCommonJSModules,
-        config.closureEntryPoints);
+        config.dependencyMode,
+        config.entryPoints);
     if (depOptions != null) {
       options.setDependencyOptions(depOptions);
     }
@@ -1771,8 +1761,8 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   }
 
   /**
-   * Writes the manifest or bundle of all compiler input files that survived
-   * manage_closure_dependencies, if requested.
+   * Writes the manifest or bundle of all compiler input files that were included
+   * as controlled by --dependency_mode, if requested.
    */
   private void outputManifestOrBundle(List<String> outputFiles,
       boolean isManifest) throws IOException {
@@ -2287,38 +2277,26 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       return this;
     }
 
-    private boolean manageClosureDependencies = false;
+    private CompilerOptions.DependencyMode dependencyMode = CompilerOptions.DependencyMode.NONE;
 
     /**
      * Sets whether to sort files by their goog.provide/require deps,
      * and prune inputs that are not required.
      */
-    CommandLineConfig setManageClosureDependencies(boolean newVal) {
-      this.manageClosureDependencies = newVal;
+    CommandLineConfig setDependencyMode(CompilerOptions.DependencyMode newVal) {
+      this.dependencyMode = newVal;
       return this;
     }
 
-    private boolean onlyClosureDependencies = false;
-
-    /**
-     * Sets whether to sort files by their goog.provide/require deps,
-     * and prune inputs that are not required, and drop all non-closure
-     * files.
-     */
-    CommandLineConfig setOnlyClosureDependencies(boolean newVal) {
-      this.onlyClosureDependencies = newVal;
-      return this;
-    }
-
-    private List<String> closureEntryPoints = ImmutableList.of();
+    private List<DependencyOptions.ModuleIdentifier> entryPoints = ImmutableList.of();
 
     /**
      * Set closure entry points, which makes the compiler only include
      * those files and sort them in dependency order.
      */
-    CommandLineConfig setClosureEntryPoints(List<String> entryPoints) {
+    CommandLineConfig setEntryPoints(List<DependencyOptions.ModuleIdentifier> entryPoints) {
       Preconditions.checkNotNull(entryPoints);
-      this.closureEntryPoints = entryPoints;
+      this.entryPoints = entryPoints;
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1581,7 +1581,15 @@ public class CompilerOptions {
   public void setManageClosureDependencies(List<String> entryPoints) {
     Preconditions.checkNotNull(entryPoints);
     setManageClosureDependencies(true);
-    dependencyOptions.setEntryPoints(entryPoints);
+
+    List<DependencyOptions.ModuleIdentifier> normalizedEntryPoints =
+        new ArrayList<>();
+
+    for (String entryPoint : entryPoints) {
+      normalizedEntryPoints.add(DependencyOptions.ModuleIdentifier.forClosure(entryPoint));
+    }
+
+    dependencyOptions.setEntryPoints(normalizedEntryPoints);
   }
 
   /**
@@ -2666,5 +2674,28 @@ public class CompilerOptions {
      * stdin and stdout are both json streams.
      */
     BOTH
+  }
+
+  static enum DependencyMode {
+    /**
+     * All files will be included in the compilation
+     */
+    NONE,
+
+    /**
+     * Files must be discoverable from specified entry points. Files
+     * which do not goog.provide a namespace and and are not either
+     * an ES6 or CommonJS module will be automatically treated as entry points.
+     * Module files will be included only if referenced from an entry point.
+     */
+    LOOSE,
+
+    /**
+     * Files must be discoverable from specified entry points. Files which
+     * do not goog.provide a namespace and are neither
+     * an ES6 or CommonJS module will be dropped. Module files will be included
+     * only if referenced from an entry point.
+     */
+    STRICT
   }
 }

--- a/src/com/google/javascript/jscomp/DependencyOptions.java
+++ b/src/com/google/javascript/jscomp/DependencyOptions.java
@@ -17,6 +17,7 @@
 package com.google.javascript.jscomp;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,7 +43,7 @@ public final class DependencyOptions implements Serializable {
   private boolean pruneDependencies = false;
   private boolean dropMoochers = false;
   private boolean es6ModuleOrder = false;
-  private final Set<String> entryPoints = new HashSet<>();
+  private final Set<ModuleIdentifier> entryPoints = new HashSet<>();
 
   /**
    * Enables or disables dependency sorting mode.
@@ -124,7 +125,7 @@ public final class DependencyOptions implements Serializable {
    *
    * @return this for easy chaining.
    */
-  public DependencyOptions setEntryPoints(Collection<String> symbols) {
+  public DependencyOptions setEntryPoints(Collection<ModuleIdentifier> symbols) {
     entryPoints.clear();
     entryPoints.addAll(symbols);
     return this;
@@ -151,7 +152,88 @@ public final class DependencyOptions implements Serializable {
     return pruneDependencies && dropMoochers;
   }
 
-  Collection<String> getEntryPoints() {
+  Collection<ModuleIdentifier> getEntryPoints() {
     return entryPoints;
+  }
+
+  /**
+   * Basic information on an entry point module.
+   * While closure entry points are namespaces,
+   * ES6 and CommonJS entry points are file paths
+   * which are normalized to a closure namespace.
+   *
+   * This class allows error messages to the user to
+   * be based on the input name rather than the
+   * normalized version.
+   */
+  public static final class ModuleIdentifier {
+    private final String name;
+    private final String closureNamespace;
+    private final String moduleName;
+
+    /**
+     * @param name as provided by the user
+     * @param closureNamespace entry point normalized to a closure namespace
+     * @param moduleName For closure namespaces, the module name may be different than
+     *     the namespace
+     */
+    ModuleIdentifier(String name, String closureNamespace, String moduleName) {
+      this.name = name;
+      this.closureNamespace = closureNamespace;
+      this.moduleName = moduleName;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getClosureNamespace() {
+      return closureNamespace;
+    }
+
+    public String getModuleName() {
+      return moduleName;
+    }
+
+    public String toString() {
+      if (closureNamespace.equals(moduleName)) {
+        return closureNamespace;
+      }
+      return moduleName + ":" + closureNamespace;
+    }
+
+    /**
+     * @param name Closure namespace used as an entry point. May start
+     *     "goog:" when provided as a flag from the command line.
+     *
+     * Closure entry points may also be formatted as:
+     *     'moduleName:name.space'
+     * which specifies that the module name and provided namespace
+     * are different
+     */
+    public static ModuleIdentifier forClosure(String name) {
+      String normalizedName = name;
+      if (normalizedName.startsWith("goog:")) {
+        normalizedName = normalizedName.substring(5);
+      }
+
+      String namespace = normalizedName;
+      String moduleName = normalizedName;
+      int splitPoint = normalizedName.indexOf(':');
+      if (splitPoint != -1) {
+        moduleName = normalizedName.substring(0, splitPoint);
+        namespace = normalizedName.substring(Math.min(splitPoint + 1, normalizedName.length() - 1));
+      }
+
+      return new ModuleIdentifier(normalizedName, namespace, moduleName);
+    }
+
+    /**
+     * @param filepath ES6 or CommonJS module used as an entry point.
+     */
+    public static ModuleIdentifier forFile(String filepath) {
+      String normalizedName = ES6ModuleLoader.toModuleName(URI.create(filepath));
+      return new ModuleIdentifier(filepath, normalizedName, normalizedName);
+    }
   }
 }

--- a/src/com/google/javascript/jscomp/DependencyOptions.java
+++ b/src/com/google/javascript/jscomp/DependencyOptions.java
@@ -207,14 +207,14 @@ public final class DependencyOptions implements Serializable {
      *     "goog:" when provided as a flag from the command line.
      *
      * Closure entry points may also be formatted as:
-     *     'moduleName:name.space'
+     *     'goog:moduleName:name.space'
      * which specifies that the module name and provided namespace
      * are different
      */
     public static ModuleIdentifier forClosure(String name) {
       String normalizedName = name;
       if (normalizedName.startsWith("goog:")) {
-        normalizedName = normalizedName.substring(5);
+        normalizedName = normalizedName.substring("goog:".length());
       }
 
       String namespace = normalizedName;

--- a/src/com/google/javascript/jscomp/JSModuleGraph.java
+++ b/src/com/google/javascript/jscomp/JSModuleGraph.java
@@ -345,7 +345,7 @@ public final class JSModuleGraph {
    * @see DependencyOptions for more info on how this works.
    */
   public List<CompilerInput> manageDependencies(
-      List<String> entryPoints,
+      List<DependencyOptions.ModuleIdentifier> entryPoints,
       List<CompilerInput> inputs)
       throws CircularDependencyException,
           MissingModuleException,
@@ -452,26 +452,22 @@ public final class JSModuleGraph {
         entryPointInputs.addAll(sorter.getInputsWithoutProvides());
       }
 
-      for (String entryPoint : depOptions.getEntryPoints()) {
-        // An entry point is either formatted as:
-        // 'foo.bar' - peg foo.bar to its current module
-        // 'modC:foo.bar' - peg foo.bar to modC
-        String inputName = entryPoint;
-        int splitPoint = entryPoint.indexOf(':');
+      for (DependencyOptions.ModuleIdentifier entryPoint : depOptions.getEntryPoints()) {
         CompilerInput entryPointInput = null;
-        if (splitPoint != -1) {
-          String moduleName = entryPoint.substring(0, splitPoint);
-          inputName = entryPoint.substring(
-              Math.min(splitPoint + 1, entryPoint.length() - 1));
-          JSModule module = modulesByName.get(moduleName);
-          if (module == null) {
-            throw new MissingModuleException(moduleName);
+        try {
+          if (entryPoint.getClosureNamespace().equals(entryPoint.getModuleName())) {
+            entryPointInput = sorter.getInputProviding(entryPoint.getClosureNamespace());
           } else {
-            entryPointInput = sorter.getInputProviding(inputName);
-            entryPointInput.overrideModule(module);
+            JSModule module = modulesByName.get(entryPoint.getModuleName());
+            if (module == null) {
+              throw new MissingModuleException(entryPoint.getModuleName());
+            } else {
+              entryPointInput = sorter.getInputProviding(entryPoint.getClosureNamespace());
+              entryPointInput.overrideModule(module);
+            }
           }
-        } else {
-          entryPointInput = sorter.getInputProviding(inputName);
+        } catch (MissingProvideException e) {
+          throw new MissingProvideException(entryPoint.getName(), e);
         }
 
         entryPointInputs.add(entryPointInput);

--- a/src/com/google/javascript/jscomp/deps/SortedDependencies.java
+++ b/src/com/google/javascript/jscomp/deps/SortedDependencies.java
@@ -71,8 +71,12 @@ public interface SortedDependencies<INPUT extends DependencyInfo> {
   }
 
   public static class MissingProvideException extends Exception {
-    MissingProvideException(String provide) {
+    public MissingProvideException(String provide) {
       super(provide);
+    }
+
+    public MissingProvideException(String provide, Exception e) {
+      super(provide, e);
     }
   }
 }

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -718,7 +718,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourceSortingOn3() {
-    args.add("--manage_closure_dependencies=true");
+    args.add("--dependency_mode=LOOSE");
     args.add("--language_in=ECMASCRIPT5");
     test(new String[] {
           "goog.addDependency('sym', [], []);\nvar x = 3;",
@@ -731,7 +731,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourceSortingCircularDeps1() {
-    args.add("--manage_closure_dependencies=true");
+    args.add("--dependency_mode=LOOSE");
     args.add("--language_in=ECMASCRIPT5");
     test(new String[] {
           "goog.provide('gin'); goog.require('tonic'); var gin = {};",
@@ -742,7 +742,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourceSortingCircularDeps2() {
-    args.add("--manage_closure_dependencies=true");
+    args.add("--dependency_mode=LOOSE");
     args.add("--language_in=ECMASCRIPT5");
     test(new String[] {
           "goog.provide('roses.lime.juice');",
@@ -755,7 +755,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn1() {
-    args.add("--manage_closure_dependencies=true");
+    args.add("--dependency_mode=LOOSE");
     args.add("--language_in=ECMASCRIPT5");
     test(new String[] {
           "goog.require('beer');",
@@ -769,7 +769,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn2() {
-    args.add("--closure_entry_point=guinness");
+    args.add("--entry_point=goog:guinness");
     test(new String[] {
           "goog.provide('guinness');\ngoog.require('beer');",
           "goog.provide('beer');",
@@ -782,7 +782,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn3() {
-    args.add("--closure_entry_point=scotch");
+    args.add("--entry_point=goog:scotch");
     test(new String[] {
           "goog.provide('guinness');\ngoog.require('beer');",
           "goog.provide('beer');",
@@ -794,8 +794,8 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn4() {
-    args.add("--closure_entry_point=scotch");
-    args.add("--closure_entry_point=beer");
+    args.add("--entry_point=goog:scotch");
+    args.add("--entry_point=goog:beer");
     test(new String[] {
           "goog.provide('guinness');\ngoog.require('beer');",
           "goog.provide('beer');",
@@ -808,7 +808,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn5() {
-    args.add("--closure_entry_point=shiraz");
+    args.add("--entry_point=goog:shiraz");
     test(new String[] {
           "goog.provide('guinness');\ngoog.require('beer');",
           "goog.provide('beer');",
@@ -818,7 +818,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn6() {
-    args.add("--closure_entry_point=scotch");
+    args.add("--entry_point=goog:scotch");
     test(new String[] {
           "goog.require('beer');",
           "goog.provide('beer');",
@@ -832,7 +832,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn7() {
-    args.add("--manage_closure_dependencies=true");
+    args.add("--dependency_mode=LOOSE");
     test(new String[] {
           "var COMPILED = false;",
          },
@@ -842,8 +842,8 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testSourcePruningOn8() {
-    args.add("--only_closure_dependencies");
-    args.add("--closure_entry_point=scotch");
+    args.add("--dependency_mode=STRICT");
+    args.add("--entry_point=goog:scotch");
     args.add("--warning_level=VERBOSE");
     test(new String[] {
           "/** @externs */\n" +
@@ -857,8 +857,8 @@ public final class CommandLineRunnerTest extends TestCase {
 
   public void testModuleEntryPoint() throws Exception {
     useModules = ModulePattern.STAR;
-    args.add("--only_closure_dependencies");
-    args.add("--closure_entry_point=m1:a");
+    args.add("--dependency_mode=STRICT");
+    args.add("--entry_point=goog:m1:a");
     test(
         new String[] {
           "goog.provide('a');",
@@ -886,7 +886,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testDependencySortingWhitespaceMode() {
-    args.add("--manage_closure_dependencies");
+    args.add("--dependency_mode=LOOSE");
     args.add("--compilation_level=WHITESPACE_ONLY");
     test(new String[] {
           "goog.require('beer');",
@@ -901,18 +901,18 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testForwardDeclareDroppedTypes() {
-    args.add("--manage_closure_dependencies=true");
+    args.add("--dependency_mode=LOOSE");
 
     args.add("--warning_level=VERBOSE");
-    test(new String[] {
-          "goog.require('beer');",
-          "goog.provide('beer'); /** @param {Scotch} x */ function f(x) {}",
-          "goog.provide('Scotch'); var x = 3;"
-         },
-         new String[] {
-           "var beer = {}; function f(a) {}",
-           ""
-         });
+    test(new String[]{
+            "goog.require('beer');",
+            "goog.provide('beer'); /** @param {Scotch} x */ function f(x) {}",
+            "goog.provide('Scotch'); var x = 3;"
+        },
+        new String[]{
+            "var beer = {}; function f(a) {}",
+            ""
+        });
 
     test(new String[] {
           "goog.require('beer');",
@@ -929,20 +929,20 @@ public final class CommandLineRunnerTest extends TestCase {
     // Prevents this from trying to load externs.zip
     args.add("--env=CUSTOM");
 
-    args.add("--only_closure_dependencies=true");
+    args.add("--dependency_mode=STRICT");
     try {
       CommandLineRunner runner = createCommandLineRunner(new String[0]);
       runner.doRun();
       fail("Expected FlagUsageException");
     } catch (FlagUsageException e) {
       assertTrue(e.getMessage(),
-          e.getMessage().contains("only_closure_dependencies"));
+          e.getMessage().contains("dependency_mode=STRICT"));
     }
   }
 
   public void testOnlyClosureDependenciesOneEntryPoint() throws Exception {
-    args.add("--only_closure_dependencies=true");
-    args.add("--closure_entry_point=beer");
+    args.add("--dependency_mode=STRICT");
+    args.add("--entry_point=goog:beer");
     test(new String[] {
           "goog.require('beer'); var beerRequired = 1;",
           "goog.provide('beer');\ngoog.require('hops');\nvar beerProvided = 1;",
@@ -971,7 +971,7 @@ public final class CommandLineRunnerTest extends TestCase {
     useModules = ModulePattern.CHAIN;
     args.add("--create_source_map=%outname%.map");
     args.add("--module_output_path_prefix=foo");
-    testSame(new String[] {"var x = 3;", "var y = 5;"});
+    testSame(new String[]{"var x = 3;", "var y = 5;"});
     assertThat(lastCommandLineRunner.expandSourceMapPath(lastCompiler.getOptions(), null))
         .isEqualTo("foo.map");
   }
@@ -980,7 +980,7 @@ public final class CommandLineRunnerTest extends TestCase {
     useModules = ModulePattern.CHAIN;
     args.add("--create_source_map=%outname%.map");
     args.add("--module_output_path_prefix=foo_");
-    testSame(new String[] {"var x = 3;", "var y = 5;"});
+    testSame(new String[]{"var x = 3;", "var y = 5;"});
     assertThat(
         lastCommandLineRunner.expandSourceMapPath(
             lastCompiler.getOptions(), lastCompiler.getModuleGraph().getRootModule()))
@@ -1028,7 +1028,7 @@ public final class CommandLineRunnerTest extends TestCase {
     assertThat(ImmutableSet.copyOf(mappings).toString())
         .isEqualTo(
             ImmutableSet.of(new LocationMapping("foo/", "http://bar"), new LocationMapping(
-                                                                           "xxx/", "http://yyy"))
+                "xxx/", "http://yyy"))
                 .toString());
   }
 
@@ -1132,8 +1132,8 @@ public final class CommandLineRunnerTest extends TestCase {
 
   public void testChainModuleManifest() throws Exception {
     useModules = ModulePattern.CHAIN;
-    testSame(new String[] {
-          "var x = 3;", "var y = 5;", "var z = 7;", "var a = 9;"});
+    testSame(new String[]{
+        "var x = 3;", "var y = 5;", "var z = 7;", "var a = 9;"});
 
     StringBuilder builder = new StringBuilder();
     lastCommandLineRunner.printModuleGraphManifestOrBundleTo(
@@ -1176,7 +1176,7 @@ public final class CommandLineRunnerTest extends TestCase {
 
   public void testOutputModuleGraphJson() throws Exception {
     useModules = ModulePattern.STAR;
-    testSame(new String[] {
+    testSame(new String[]{
         "var x = 3;", "var y = 5;", "var z = 7;", "var a = 9;"});
 
     StringBuilder builder = new StringBuilder();
@@ -1239,13 +1239,13 @@ public final class CommandLineRunnerTest extends TestCase {
     args.add("--jscomp_error=checkVars");
     args.add("--warning_level=VERBOSE");
     test("var theirVar = {}; var myVar = {}; var myVar = {};",
-         VarCheck.VAR_MULTIPLY_DECLARED_ERROR);
+        VarCheck.VAR_MULTIPLY_DECLARED_ERROR);
   }
 
   public void testGoogAssertStripping() {
     args.add("--compilation_level=ADVANCED_OPTIMIZATIONS");
     test("goog.asserts.assert(false)",
-         "");
+        "");
     args.add("--debug");
     test("goog.asserts.assert(false)", "goog.$asserts$.$assert$(!1)");
   }
@@ -1381,7 +1381,7 @@ public final class CommandLineRunnerTest extends TestCase {
   public void testProcessCJS() {
     useStringComparison = true;
     args.add("--process_common_js_modules");
-    args.add("--common_js_entry_module=foo/bar");
+    args.add("--entry_point=foo/bar");
     setFilename(0, "foo/bar.js");
     String expected = "var module$foo$bar={test:1};";
     test("exports.test = 1", expected);
@@ -1389,9 +1389,8 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testProcessCJSWithModuleOutput() {
-    useStringComparison = true;
     args.add("--process_common_js_modules");
-    args.add("--common_js_entry_module=foo/bar");
+    args.add("--entry_point=foo/bar");
     args.add("--module=auto");
     setFilename(0, "foo/bar.js");
     test("exports.test = 1",
@@ -1407,37 +1406,37 @@ public final class CommandLineRunnerTest extends TestCase {
    */
   public void testProcessCJSWithClosureRequires() {
     args.add("--process_common_js_modules");
-    args.add("--common_js_entry_module=app.js");
-    args.add("--manage_closure_dependencies");
+    args.add("--entry_point=app");
+    args.add("--dependency_mode=STRICT");
     setFilename(0, "base.js");
     setFilename(1, "array.js");
     setFilename(2, "Baz.js");
     setFilename(3, "app.js");
     test(new String[] {
            "/** @provideGoog */\n" +
-           "/** @const */ var goog = goog || {};\n" +
-           "var COMPILED = false;\n" +
-           "goog.provide = function (arg) {};\n" +
-           "goog.require = function (arg) {};\n",
+               "/** @const */ var goog = goog || {};\n" +
+               "var COMPILED = false;\n" +
+               "goog.provide = function (arg) {};\n" +
+               "goog.require = function (arg) {};",
 
-           "goog.provide('goog.array');\n",
+           "goog.provide('goog.array');",
 
-           "goog.require('goog.array');\n" +
-           "function Baz() {}\n" +
-           "Baz.prototype = {\n" +
-           "  baz: function() {\n" +
-           "    return goog.array.last(['asdf','asd','baz']);\n" +
-           "  },\n" +
-           "  bar: function () {\n" +
-           "    return 4 + 4;\n" +
-           "  }\n" +
-           "}\n" +
-           "module.exports = Baz;",
+           "goog.require('goog.array');" +
+               "function Baz() {}" +
+               "Baz.prototype = {" +
+               "  baz: function() {" +
+               "    return goog.array.last(['asdf','asd','baz']);" +
+               "  }," +
+               "  bar: function () {" +
+               "    return 4 + 4;" +
+               "  }" +
+               "};" +
+               "module.exports = Baz;",
 
-           "var Baz = require('./Baz');\n" +
-           "var baz = new Baz();\n" +
-           "console.log(baz.baz());\n" +
-           "console.log(baz.bar());\n"
+           "var Baz = require('./Baz');" +
+               "var baz = new Baz();" +
+               "console.log(baz.baz());" +
+               "console.log(baz.bar());"
          },
          new String[] {
            "var goog=goog||{},COMPILED=!1;" +
@@ -1460,6 +1459,123 @@ public final class CommandLineRunnerTest extends TestCase {
          });
   }
 
+  /**
+   * closure requires mixed with cjs, raised in
+   * https://github.com/google/closure-compiler/pull/630
+   * https://gist.github.com/sayrer/c4c4ce0c1748573f863e
+   */
+  public void testProcessCJSWithClosureRequires2() {
+    args.add("--process_common_js_modules");
+    args.add("--dependency_mode=LOOSE");
+    args.add("--entry_point=app");
+    setFilename(0, "base.js");
+    setFilename(1, "array.js");
+    setFilename(2, "Baz.js");
+    setFilename(3, "app.js");
+
+    test(new String[]{
+            "/** @provideGoog */" +
+                "/** @const */ var goog = goog || {};" +
+                "var COMPILED = false;" +
+                "goog.provide = function (arg) {};" +
+                "goog.require = function (arg) {};",
+
+            "goog.provide('goog.array');",
+
+            "goog.require('goog.array');" +
+                "function Baz() {}" +
+                "Baz.prototype = {" +
+                "  baz: function() {" +
+                "    return goog.array.last(['asdf','asd','baz']);" +
+                "  }," +
+                "  bar: function () {" +
+                "    return 4 + 4;" +
+                "  }" +
+                "};" +
+                "module.exports = Baz;",
+
+            "var Baz = require('./Baz');" +
+                "var baz = new Baz();" +
+                "console.log(baz.baz());" +
+                "console.log(baz.bar());"
+        },
+        new String[]{
+            "var goog=goog||{},COMPILED=!1;" +
+                "goog.provide=function(a){};goog.require=function(a){};",
+
+            "goog.array={};",
+
+            "function Baz$$module$Baz(){}" +
+                "Baz$$module$Baz.prototype={" +
+                "baz:function(){return goog.array.last([\"asdf\",\"asd\",\"baz\"])}," +
+                "bar:function(){return 8}" +
+                "};" +
+                "var module$Baz=Baz$$module$Baz;",
+
+            "var module$app={}," +
+                "Baz$$module$app=Baz$$module$Baz," +
+                "baz$$module$app=new Baz$$module$app;" +
+                "console.log(baz$$module$app.baz());" +
+                "console.log(baz$$module$app.bar());"
+        });
+  }
+
+  public void testProcessCJSWithES6Export() {
+    args.add("--process_common_js_modules");
+    args.add("--entry_point=app");
+    args.add("--dependency_mode=STRICT");
+    args.add("--language_in=ECMASCRIPT6");
+    setFilename(0, "foo.js");
+    setFilename(1, "app.js");
+    test(new String[]{
+            "export default class Foo {"
+                + "  bar() { console.log('bar'); }"
+                + "}",
+
+            "var FooBar = require('./foo');" +
+                "var baz = new FooBar.default();" +
+                "console.log(baz.bar());"
+        },
+        new String[]{
+            "var module$foo={}," +
+                "Foo$$module$foo=function(){};" +
+                "Foo$$module$foo.prototype.bar=function(){console.log(\"bar\")};" +
+                "module$foo.default=Foo$$module$foo;",
+
+            "var module$app={}," +
+                "FooBar$$module$app=module$foo," +
+                "baz$$module$app=new FooBar$$module$app.default();" +
+                "console.log(baz$$module$app.bar());"
+        });
+  }
+
+  public void testES6ImportOfCJS() {
+    args.add("--process_common_js_modules");
+    args.add("--entry_point=app");
+    args.add("--dependency_mode=STRICT");
+    args.add("--language_in=ECMASCRIPT6");
+    setFilename(0, "foo.js");
+    setFilename(1, "app.js");
+    test(new String[] {
+            "/** @constructor */ function Foo () {}" +
+                "Foo.prototype.bar = function() { console.log('bar'); };" +
+                "module.exports = Foo;",
+
+            "import * as FooBar from './foo';" +
+                "var baz = new FooBar();" +
+                "console.log(baz.bar());"
+        },
+        new String[] {
+            "function Foo$$module$foo(){}" +
+                "Foo$$module$foo.prototype.bar=function(){console.log(\"bar\")};" +
+                "var module$foo=Foo$$module$foo;",
+
+            "var module$app={}," +
+                "baz$$module$app$$module$app=new Foo$$module$foo();" +
+                "console.log(baz$$module$app$$module$app.bar());"
+        });
+  }
+
   public void testFormattingSingleQuote() {
     testSame("var x = '';");
     assertThat(lastCompiler.toSource()).isEqualTo("var x=\"\";");
@@ -1470,20 +1586,18 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testTransformAMDAndProcessCJS() {
-    useStringComparison = true;
     args.add("--transform_amd_modules");
     args.add("--process_common_js_modules");
-    args.add("--common_js_entry_module=foo/bar");
+    args.add("--entry_point=foo/bar");
     setFilename(0, "foo/bar.js");
     test("define({foo: 1})",
         "var module$foo$bar={foo:1};");
   }
 
   public void testModuleJSON() {
-    useStringComparison = true;
     args.add("--transform_amd_modules");
     args.add("--process_common_js_modules");
-    args.add("--common_js_entry_module=foo/bar");
+    args.add("--entry_point=foo/bar");
     args.add("--output_module_dependencies=test.json");
     setFilename(0, "foo/bar.js");
     test("define({foo: 1})",

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -123,25 +123,6 @@ public final class CompilerTest extends TestCase {
     compiler.compile(externs, input, options);
   }
 
-  public void testCommonJSProvidesAndRequire() throws Exception {
-    List<SourceFile> inputs = ImmutableList.of(
-        SourceFile.fromCode("gin.js", "require('tonic')"),
-        SourceFile.fromCode("tonic.js", ""),
-        SourceFile.fromCode("mix.js", "require('gin'); require('tonic');"));
-    List<String> entryPoints = ImmutableList.of("module$mix");
-
-    Compiler compiler = initCompilerForCommonJS(inputs, entryPoints);
-    JSModuleGraph graph = compiler.getModuleGraph();
-    assertEquals(3, graph.getModuleCount());
-    List<CompilerInput> result = graph.manageDependencies(entryPoints,
-        compiler.getInputsForTesting());
-    assertEquals("module$tonic$fillFile", result.get(0).getName());
-    assertEquals("module$gin$fillFile", result.get(1).getName());
-    assertEquals("tonic.js", result.get(2).getName());
-    assertEquals("gin.js", result.get(3).getName());
-    assertEquals("mix.js", result.get(4).getName());
-  }
-
   public void testCommonJSMissingRequire() throws Exception {
     List<SourceFile> inputs = ImmutableList.of(
         SourceFile.fromCode("gin.js", "require('missing')"));

--- a/test/com/google/javascript/jscomp/JSModuleGraphTest.java
+++ b/test/com/google/javascript/jscomp/JSModuleGraphTest.java
@@ -166,7 +166,7 @@ public final class JSModuleGraphTest extends TestCase {
     DependencyOptions depOptions = new DependencyOptions();
     depOptions.setDependencySorting(true);
     depOptions.setDependencyPruning(true);
-    depOptions.setEntryPoints(ImmutableList.<String>of());
+    depOptions.setEntryPoints(ImmutableList.<DependencyOptions.ModuleIdentifier>of());
     depOptions.setEs6ModuleOrder(es6ModuleOrder);
     List<CompilerInput> results = graph.manageDependencies(depOptions, inputs);
 
@@ -193,7 +193,8 @@ public final class JSModuleGraphTest extends TestCase {
     DependencyOptions depOptions = new DependencyOptions();
     depOptions.setDependencySorting(true);
     depOptions.setDependencyPruning(true);
-    depOptions.setEntryPoints(ImmutableList.of("c2"));
+    depOptions.setEntryPoints(ImmutableList.of(
+        DependencyOptions.ModuleIdentifier.forClosure("c2")));
     depOptions.setEs6ModuleOrder(es6ModuleOrder);
     List<CompilerInput> results = graph.manageDependencies(depOptions, inputs);
 
@@ -221,7 +222,8 @@ public final class JSModuleGraphTest extends TestCase {
     depOptions.setDependencySorting(true);
     depOptions.setDependencyPruning(true);
     depOptions.setMoocherDropping(true);
-    depOptions.setEntryPoints(ImmutableList.of("c2"));
+    depOptions.setEntryPoints(ImmutableList.of(
+        DependencyOptions.ModuleIdentifier.forClosure("c2")));
     depOptions.setEs6ModuleOrder(es6ModuleOrder);
     List<CompilerInput> results = graph.manageDependencies(depOptions, inputs);
 

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -273,38 +273,4 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "goog.provide('module$test');"
             + "module$test = { prop: 'value', foo() { console.log('bar'); }}" );
   }
-
-  public void testSortInputs() throws Exception {
-    SourceFile a = SourceFile.fromCode("a.js", "require('b');require('c')");
-    SourceFile b = SourceFile.fromCode("b.js", "require('d')");
-    SourceFile c = SourceFile.fromCode("c.js", "require('d')");
-    SourceFile d = SourceFile.fromCode("d.js", "1;");
-
-    assertSortedInputs(ImmutableList.of(d, b, c, a), ImmutableList.of(a, b, c, d));
-    assertSortedInputs(ImmutableList.of(d, b, c, a), ImmutableList.of(d, b, c, a));
-    assertSortedInputs(ImmutableList.of(d, c, b, a), ImmutableList.of(d, c, b, a));
-    assertSortedInputs(ImmutableList.of(d, b, c, a), ImmutableList.of(d, a, b, c));
-  }
-
-  private void assertSortedInputs(List<SourceFile> expected, List<SourceFile> shuffled)
-      throws Exception {
-    Compiler compiler = new Compiler(System.err);
-    compiler.initCompilerOptionsIfTesting();
-    compiler.getOptions().setProcessCommonJSModules(true);
-    compiler
-        .getOptions()
-        .dependencyOptions
-        .setEntryPoints(ImmutableList.of(ES6ModuleLoader.toModuleName(URI.create("a"))));
-    compiler.compile(
-        ImmutableList.of(SourceFile.fromCode("externs.js", "")), shuffled, compiler.getOptions());
-
-    List<SourceFile> result = new ArrayList<>();
-    for (JSModule m : compiler.getModuleGraph().getAllModules()) {
-      for (CompilerInput i : m.getInputs()) {
-        result.add(i.getSourceFile());
-      }
-    }
-
-    assertEquals(expected, result);
-  }
 }


### PR DESCRIPTION
Fixes #1319.

Removes the `--manage_closure_dependencies`, `--only_closure_dependencies`, `--closure_entry_point` and `--common_js_entry_module` flags in favor of simplified set:

* `--dependencies_mode` - Enum with `NONE`, `LOOSE` or `STRICT` as options. None is default. Loose is equivalent to the old `--manage_closure_dependencies`. Strict is equivalent to `--only_closure_dependencies`.
* `--entry_point` - for ES6 and CommonJS moduels, this is the file path without the extension. For closure, it uses the module import syntax: goog:namespace

This change also allows the `--dependency_mode` flag to fully control CommonJS modules. Previously, CommonJS module dependencies implied `--only_closure_dependencies` and supported only a single entry point.