### PR TITLE
Revert "Use Guava 20.0-SNAPSHOT and GWT 2.8.0-beta1 to fix the GWT build"

### DIFF
--- a/pom-gwt.xml
+++ b/pom-gwt.xml
@@ -70,13 +70,13 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0-SNAPSHOT</version>
+      <version>19.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-gwt</artifactId>
-      <version>20.0-SNAPSHOT</version>
+      <version>19.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -122,15 +122,40 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>2.8.0-beta1</version>
+      <version>2.8.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-dev</artifactId>
-      <version>2.8.0-beta1</version>
+      <version>2.8.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>google-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/google-snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>plugin-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/public/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <defaultGoal>install</defaultGoal>


### PR DESCRIPTION
Reverts google/closure-compiler#1327

Tyler is working on updating these, but reverting for now so we can get our internal/external repos in sync.