### PR TITLE
Update the CommonJS module rewriting to match an ES6 default export

### DIFF
--- a/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
@@ -100,6 +100,86 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
          TypeValidator.TYPE_MISMATCH_WARNING);
   }
 
+  public void testMultipleExportAssignments1() {
+    test(createCompilerOptions(),
+        new String[] {
+            "/** @constructor */ function Hello() {} " +
+                "module.exports = Hello;" +
+                "/** @constructor */ function Bar() {} " +
+                "Bar.prototype.foobar = function() { alert('foobar'); };" +
+                "module.exports = Bar;",
+            "var Foobar = require('./i0');" +
+                "var show = new Foobar();" +
+                "show.foobar();"
+        },
+        new String[] {
+            "var module$i0 = {};" +
+                "function Hello$$module$i0(){} " +
+                "module$i0.default = Hello$$module$i0;" +
+                "function Bar$$module$i0(){} " +
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
+                "module$i0.default=Bar$$module$i0;",
+            "var module$i1 = {};" +
+                "var Foobar$$module$i1=module$i0.default;" +
+                "var show$$module$i1=new Foobar$$module$i1();" +
+                "show$$module$i1.foobar();"
+        });
+  }
+
+  public void testMultipleExportAssignments2() {
+    test(createCompilerOptions(),
+        new String[] {
+            "/** @constructor */ function Hello() {} " +
+                "module.exports.foo = Hello;" +
+                "/** @constructor */ function Bar() {} " +
+                "Bar.prototype.foobar = function() { alert('foobar'); };" +
+                "module.exports.foo = Bar;",
+            "var Foobar = require('./i0');" +
+                "var show = new Foobar.foo();" +
+                "show.foobar();"
+        },
+        new String[] {
+            "var module$i0 = {};" +
+                "module$i0.default = {};" +
+                "function Hello$$module$i0(){} " +
+                "module$i0.default.foo = Hello$$module$i0;" +
+                "function Bar$$module$i0(){} " +
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
+                "module$i0.default.foo=Bar$$module$i0;",
+            "var module$i1 = {};" +
+                "var Foobar$$module$i1=module$i0.default;" +
+                "var show$$module$i1=new Foobar$$module$i1.foo();" +
+                "show$$module$i1.foobar();"
+        });
+  }
+
+  public void testMultipleExportAssignments3() {
+    test(createCompilerOptions(),
+        new String[] {
+            "/** @constructor */ function Hello() {} " +
+                "module.exports.foo = Hello;" +
+                "/** @constructor */ function Bar() {} " +
+                "Bar.prototype.foobar = function() { alert('foobar'); };" +
+                "exports.foo = Bar;",
+            "var Foobar = require('./i0');" +
+                "var show = new Foobar.foo();" +
+                "show.foobar();"
+        },
+        new String[] {
+            "var module$i0 = {};" +
+                "module$i0.default = {};" +
+                "function Hello$$module$i0(){} " +
+                "module$i0.default.foo = Hello$$module$i0;" +
+                "function Bar$$module$i0(){} " +
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
+                "module$i0.default.foo=Bar$$module$i0;",
+            "var module$i1 = {};" +
+                "var Foobar$$module$i1=module$i0.default;" +
+                "var show$$module$i1=new Foobar$$module$i1.foo();" +
+                "show$$module$i1.foobar();"
+        });
+  }
+
   public void testCrossModuleSubclass1() {
     test(createCompilerOptions(),
          new String[] {

--- a/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
@@ -34,11 +34,12 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "var hello = new Hello();"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0 = Hello$$module$i0;",
+           "module$i0.default = Hello$$module$i0;",
 
            "var module$i1 = {};" +
-           "var Hello$$module$i1 = module$i0;" +
+           "var Hello$$module$i1 = Hello$$module$i0;" +
            "var hello$$module$i1 = new Hello$$module$i1();"
          });
   }
@@ -63,9 +64,10 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "module.exports = Hello;"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
            "var hello$$module$i0 = new Hello$$module$i0();" +
-           "var module$i0 = Hello$$module$i0;"
+           "module$i0.default = Hello$$module$i0;"
          });
   }
 
@@ -78,10 +80,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "/** @type {!Hello} */ var hello = new Hello();"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0 = Hello$$module$i0;",
+           "module$i0.default = Hello$$module$i0;",
            "var module$i1 = {};" +
-           "var Hello$$module$i1 = module$i0;" +
+           "var Hello$$module$i1 = Hello$$module$i0;" +
            "var hello$$module$i1 = new Hello$$module$i1();"
          });
   }
@@ -112,10 +115,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "util.inherits(SubHello, Hello);"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
+           "module$i0.default=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "var SubHello$$module$i1=function(){};" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -137,10 +141,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "util.inherits(SubHello, Hello);"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
+           "module$i0.default=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){}" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -162,10 +167,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "util.inherits(SubHello, Hello);"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
+           "module$i0.default=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){ Hello$$module$i1.call(this); }" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -187,10 +193,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "util.inherits(SubHello, i0.Hello);"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0={Hello: Hello$$module$i0};",
+           "module$i0.default={Hello: Hello$$module$i0};",
            "var module$i1={};" +
-           "var i0$$module$i1=module$i0;" +
+           "var i0$$module$i1=module$i0.default;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){ i0$$module$i1.Hello.call(this); }" +
            "util$$module$i1.inherits(SubHello$$module$i1,i0$$module$i1.Hello);"
@@ -212,10 +219,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "util.inherits(SubHello, Hello);"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
+           "module$i0.default=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){ Hello$$module$i1.call(this); }" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -237,10 +245,11 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "util.inherits(SubHello, i0.Hello);"
          },
          new String[] {
+           "var module$i0 = {};" +
            "function Hello$$module$i0(){}" +
-           "var module$i0={Hello: Hello$$module$i0};",
+           "module$i0.default={Hello: Hello$$module$i0};",
            "var module$i1={};" +
-           "var i0$$module$i1=module$i0;" +
+           "var i0$$module$i1=module$i0.default;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){ i0$$module$i1.Hello.call(this); }" +
            "util$$module$i1.inherits(SubHello$$module$i1,i0$$module$i1.Hello);"
@@ -254,6 +263,8 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     WarningLevel.VERBOSE.setOptionsForWarningLevel(options);
     options.setProcessCommonJSModules(true);
     options.setClosurePass(true);
+    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT5);
+    options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT3);
     return options;
   }
 }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -208,7 +208,6 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "} else {" +
         "  this.foobar = foobar;}",
         "goog.provide('module$test');" +
-        "module$test.default={};" +
         "var foobar$$module$test = {foo: 'bar'};" +
         "module$test.default = foobar$$module$test;");
     testModules(
@@ -220,7 +219,6 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "} else {" +
         "  this.foobar = foobar;}",
         "goog.provide('module$test');" +
-        "module$test.default={};" +
         "var foobar$$module$test = {foo: 'bar'};" +
         "module$test.default = foobar$$module$test;");
     testModules(
@@ -230,7 +228,6 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "if (typeof define === 'function' && define.amd) {" +
         "  define([], function () {return foobar;});}",
         "goog.provide('module$test');" +
-        "module$test.default={};" +
         "var foobar$$module$test = {foo: 'bar'};" +
         "module$test.default = foobar$$module$test;");
   }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -69,7 +69,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "var name = require('other');" + "name()",
         "goog.provide('module$test');"
             + "goog.require('module$other');"
-            + "var name$$module$test = module$other;"
+            + "var name$$module$test= module$other.default;"
             + "name$$module$test();");
     setFilename("test/sub");
     ProcessEs6ModulesTest.testModules(
@@ -82,7 +82,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
                 + "(function() { name(); })();")),
                 "goog.provide('module$test$sub');"
                 + "goog.require('module$mod$name');"
-                + "var name$$module$test$sub = module$mod$name;"
+                + "var name$$module$test$sub = module$mod$name.default;"
                 + "(function() { name$$module$test$sub(); })();");
   }
 
@@ -91,15 +91,16 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "var name = require('other');" + "exports.foo = 1;",
         "goog.provide('module$test');"
+            + "module$test.default={};"
             + "goog.require('module$other');"
-            + "var name$$module$test = module$other;"
-            + "module$test.foo = 1;");
+            + "var name$$module$test = module$other.default;"
+            + "module$test.default.foo = 1;");
     testModules(
         "var name = require('other');" + "module.exports = function() {};",
         "goog.provide('module$test');"
             + "goog.require('module$other');"
-            + "var name$$module$test = module$other;"
-            + "module$test = function () {};");
+            + "var name$$module$test=module$other.default;"
+            + "module$test.default = function () {};");
   }
 
   public void testPropertyExports() {
@@ -107,9 +108,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "exports.one = 1;" + "module.exports.obj = {};" + "module.exports.obj.two = 2;",
         "goog.provide('module$test');"
-            + "module$test.one = 1;"
-            + "module$test.obj = {};"
-            + "module$test.obj.two = 2;");
+            + "module$test.default = {};"
+            + "module$test.default.one = 1;"
+            + "module$test.default.obj = {};"
+            + "module$test.default.obj.two = 2;");
   }
 
   public void testModuleExportsWrittenWithExportsRefs() {
@@ -117,9 +119,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "exports.one = 1;" + "module.exports = {};",
         "goog.provide('module$test');"
-            + "var exports$$module$test = module$test;"
+            + "module$test.default = {};"
+            + "var exports$$module$test = module$test.default;"
             + "exports$$module$test.one = 1;"
-            + "module$test = {};");
+            + "module$test.default = {};");
   }
 
   public void testVarRenaming() {
@@ -136,9 +139,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "var name = require('other'); exports.foo = 1;",
         "goog.provide('module$test_test');"
+            + "module$test_test.default = {};"
             + "goog.require('module$other');"
-            + "var name$$module$test_test = module$other;"
-            + "module$test_test.foo = 1;");
+            + "var name$$module$test_test = module$other.default;"
+            + "module$test_test.default.foo = 1;");
   }
 
   public void testIndex() {
@@ -146,9 +150,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "var name = require('../other'); exports.bar = 1;",
         "goog.provide('module$foo$index');"
+            + "module$foo$index.default={};"
             + "goog.require('module$other');"
-            + "var name$$module$foo$index = module$other;"
-            + "module$foo$index.bar = 1;");
+            + "var name$$module$foo$index = module$other.default;"
+            + "module$foo$index.default.bar = 1;");
   }
 
   public void testModuleName() {
@@ -157,7 +162,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "var name = require('other');",
         "goog.provide('module$foo$bar');"
             + "goog.require('module$other');"
-            + "var name$$module$foo$bar = module$other;");
+            + "var name$$module$foo$bar = module$other.default;");
     ProcessEs6ModulesTest.testModules(
         this,
         ImmutableList.of(
@@ -165,7 +170,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"), "var name = require('./name');")),
         "goog.provide('module$foo$bar');"
             + "goog.require('module$foo$name');"
-            + "var name$$module$foo$bar = module$foo$name;");
+            + "var name$$module$foo$bar = module$foo$name.default;");
   }
 
   public void testModuleExportsScope() {
@@ -175,13 +180,13 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "module.exports = foo;",
         "goog.provide('module$test');" +
         "var foo$$module$test=function(module){module.exports={}};" +
-        "module$test=foo$$module$test");
+        "module$test.default=foo$$module$test");
     testModules(
         "var foo = function () {var module = {};module.exports = {};};" +
         "module.exports = foo;",
         "goog.provide('module$test');" +
         "var foo$$module$test=function(){var module={};module.exports={}};" +
-        "module$test=foo$$module$test");
+        "module$test.default=foo$$module$test");
     testModules(
         "var foo = function () {if (true) var module = {};" +
         "module.exports = {};};" +
@@ -189,7 +194,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "goog.provide('module$test');" +
         "var foo$$module$test=function(){if(true)var module={};" +
         "module.exports={}};" +
-        "module$test=foo$$module$test");
+        "module$test.default=foo$$module$test");
   }
 
   public void testUMDPatternConversion() {
@@ -203,8 +208,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "} else {" +
         "  this.foobar = foobar;}",
         "goog.provide('module$test');" +
+        "module$test.default={};" +
         "var foobar$$module$test = {foo: 'bar'};" +
-        "module$test = foobar$$module$test;");
+        "module$test.default = foobar$$module$test;");
     testModules(
         "var foobar = {foo: 'bar'};" +
         "if (typeof define === 'function' && define.amd) {" +
@@ -214,8 +220,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "} else {" +
         "  this.foobar = foobar;}",
         "goog.provide('module$test');" +
+        "module$test.default={};" +
         "var foobar$$module$test = {foo: 'bar'};" +
-        "module$test = foobar$$module$test;");
+        "module$test.default = foobar$$module$test;");
     testModules(
         "var foobar = {foo: 'bar'};" +
         "if (typeof module === 'object' && module.exports) {" +
@@ -223,8 +230,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "if (typeof define === 'function' && define.amd) {" +
         "  define([], function () {return foobar;});}",
         "goog.provide('module$test');" +
+        "module$test.default={};" +
         "var foobar$$module$test = {foo: 'bar'};" +
-        "module$test = foobar$$module$test;");
+        "module$test.default = foobar$$module$test;");
   }
 
   public void testEs6ObjectShorthand() {
@@ -239,7 +247,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             + "}",
         "goog.provide('module$test');"
             + "function foo$$module$test() {}"
-            + "module$test = { prop: 'value', foo }");
+            + "module$test.default = { prop: 'value', foo }");
 
     testModules(
         "module.exports = {\n"
@@ -249,7 +257,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             + "  }\n"
             + "};",
         "goog.provide('module$test');"
-            + "module$test = { prop: 'value', foo() { console.log('bar'); }}" );
+            + "module$test.default = { prop: 'value', foo() { console.log('bar'); }}" );
   }
 
   public void testSortInputs() throws Exception {


### PR DESCRIPTION
This allows CommonJS and ES6 modules greater compatibility. Previously, the only way to import a CommonJS module using ES6 syntax was:

```js
import * as Foo from './bar';
```

Using default property exports makes interoperability much cleaner. See the added tests for examples.