### PR TITLE
Switch cases should end with an unconditional "break" statement

### DIFF
--- a/src/com/google/javascript/jscomp/CollapseProperties.java
+++ b/src/com/google/javascript/jscomp/CollapseProperties.java
@@ -233,7 +233,7 @@ class CollapseProperties implements CompilerPass {
         for (Ref ref : refs) {
           switch (ref.type) {
             case SET_FROM_GLOBAL:
-              continue;
+              break;
             case DIRECT_GET:
             case ALIASING_GET:
             case PROTOTYPE_GET:

--- a/src/com/google/javascript/jscomp/GlobalNamespace.java
+++ b/src/com/google/javascript/jscomp/GlobalNamespace.java
@@ -1150,14 +1150,14 @@ class GlobalNamespace
         switch (ref.type) {
           case SET_FROM_GLOBAL:
             // Expect one global set
-            continue;
+            break;
           case SET_FROM_LOCAL:
             throw new IllegalStateException();
           case ALIASING_GET:
           case DIRECT_GET:
           case PROTOTYPE_GET:
           case CALL_GET:
-            continue;
+            break;
           case DELETE_PROP:
             return false;
           default:

--- a/src/com/google/javascript/jscomp/PeepholeFoldConstants.java
+++ b/src/com/google/javascript/jscomp/PeepholeFoldConstants.java
@@ -1485,7 +1485,7 @@ class PeepholeFoldConstants extends AbstractPeepholeOptimization {
       if (c.getString().equals(right.getString())) {
         switch (c.getType()) {
           case Token.SETTER_DEF:
-            continue;
+            break;
           case Token.GETTER_DEF:
           case Token.STRING_KEY:
             if (value != null && mayHaveSideEffects(value)) {

--- a/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java
+++ b/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java
@@ -932,7 +932,7 @@ class PeepholeMinimizeConditions
         case Token.WHILE:
         case Token.FOR:
           n = n.getLastChild();
-          continue;
+          break;
         default:
           return false;
       }

--- a/src/com/google/javascript/jscomp/parsing/IRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/IRFactory.java
@@ -661,25 +661,25 @@ class IRFactory {
       switch (tree.type) {
         case EXPRESSION_STATEMENT:
           tree = tree.asExpressionStatement().expression;
-          continue;
+          break;
         case CALL_EXPRESSION:
           tree = tree.asCallExpression().operand;
-          continue;
+          break;
         case BINARY_OPERATOR:
           tree = tree.asBinaryOperator().left;
-          continue;
+          break;
         case CONDITIONAL_EXPRESSION:
           tree = tree.asConditionalExpression().condition;
-          continue;
+          break;
         case MEMBER_EXPRESSION:
           tree = tree.asMemberExpression().operand;
-          continue;
+          break;
         case MEMBER_LOOKUP_EXPRESSION:
           tree = tree.asMemberLookupExpression().operand;
-          continue;
+          break;
         case POSTFIX_EXPRESSION:
           tree = tree.asPostfixExpression().operand;
-          continue;
+          break;
         default:
           return tree;
       }

--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -1709,7 +1709,7 @@ public final class JsDocInfoParser {
             builder.append('*');
             token = next();
           }
-          continue;
+          break;
 
         case EOL:
           if (option != WhitespaceOption.SINGLE_LINE) {
@@ -1719,7 +1719,7 @@ public final class JsDocInfoParser {
           ignoreStar = true;
           lineStartChar = 0;
           token = next();
-          continue;
+          break;
 
         default:
           ignoreStar = false;
@@ -1762,6 +1762,7 @@ public final class JsDocInfoParser {
 
           builder.append(line);
           token = next();
+          break;
       }
     } while (true);
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S128 - Switch cases should end with an unconditional "break" statement
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S128
Please let me know if you have any questions.
Kirill Vlasov