### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/src/com/google/javascript/jscomp/gwt/super/java/net/URI.java
+++ b/src/com/google/javascript/jscomp/gwt/super/java/net/URI.java
@@ -16,6 +16,8 @@
 
 package java.net;
 
+import com.google.common.base.Preconditions;
+
 import java.io.Serializable;
 
 /** GWT compatible minimal emulation of {@code URI} */
@@ -38,6 +40,9 @@ public class URI implements Comparable<URI>, Serializable  {
 
   @Override
   public boolean equals(Object o) {
+    if (o == null)
+      return false;
+    Preconditions.checkState(o instanceof URI);
     URI other = (URI) o;
     return uriString.equals(other.toString());
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - "equals(Object obj)" should test argument type
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2097
Please let me know if you have any questions.
Kirill Vlasov