### PR TITLE
Throwable.printStackTrace(...) should not be called

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -149,6 +150,8 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     "browser/webkit_css.js",
     "browser/w3c_touch_event.js"
   );
+
+  private static final Logger logger = Logger.getLogger(AbstractCommandLineRunner.class.getName());
 
   private final CommandLineConfig config;
 
@@ -556,9 +559,10 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       }
     } catch (AbstractCommandLineRunner.FlagUsageException e) {
       System.err.println(e.getMessage());
+      logger.log(Level.WARNING, "Flag using error", e);
       result = -1;
     } catch (Throwable t) {
-      t.printStackTrace();
+      logger.log(Level.WARNING, "Compiler running error", t);
       result = -2;
     }
 

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -45,6 +45,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -54,6 +56,8 @@ import java.util.zip.ZipOutputStream;
  * @author nicksantos@google.com (Nick Santos)
  */
 public final class CommandLineRunnerTest extends TestCase {
+
+  private static final Logger logger = Logger.getLogger(CommandLineRunnerTest.class.getName());
 
   private Compiler lastCompiler = null;
   private CommandLineRunner lastCommandLineRunner = null;
@@ -1519,7 +1523,7 @@ public final class CommandLineRunnerTest extends TestCase {
     try {
       runner.doRun();
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.log(Level.WARNING, "Unexpected exception", e);
       fail("Unexpected exception " + e);
     }
     String output = runner.getCompiler().toSource();
@@ -1540,7 +1544,7 @@ public final class CommandLineRunnerTest extends TestCase {
     try {
       runner.doRun();
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.log(Level.WARNING, "Unexpected exception", e);
       fail("Unexpected exception " + e);
     }
     String output = new String(outReader.toByteArray(), UTF_8);
@@ -1567,7 +1571,7 @@ public final class CommandLineRunnerTest extends TestCase {
     try {
       runner.doRun();
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.log(Level.WARNING, "Unexpected exception", e);
       fail("Unexpected exception " + e);
     }
     String output = new String(outReader.toByteArray(), UTF_8);
@@ -1594,7 +1598,7 @@ public final class CommandLineRunnerTest extends TestCase {
     try {
       runner.doRun();
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.log(Level.WARNING, "Unexpected exception", e);
       fail("Unexpected exception " + e);
     }
     String output = new String(outReader.toByteArray(), UTF_8);
@@ -1751,7 +1755,7 @@ public final class CommandLineRunnerTest extends TestCase {
     try {
       runner.doRun();
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.log(Level.WARNING, "Unexpected exception", e);
       fail("Unexpected exception " + e);
     }
     String output = runner.getCompiler().toSource();

--- a/test/com/google/javascript/jscomp/InstrumentFunctionsTest.java
+++ b/test/com/google/javascript/jscomp/InstrumentFunctionsTest.java
@@ -22,12 +22,17 @@ import com.google.protobuf.TextFormat;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Tests for {@link InstrumentFunctions}
  *
  */
 public final class InstrumentFunctionsTest extends CompilerTestCase {
+
+  private static final Logger logger = Logger.getLogger(InstrumentFunctionsTest.class.getName());
+
   private String instrumentationPb;
 
   public InstrumentFunctionsTest() {
@@ -247,7 +252,7 @@ public final class InstrumentFunctionsTest extends CompilerTestCase {
       try {
         TextFormat.merge(instrumentationPb, builder);
       } catch (IOException e) {
-        e.printStackTrace();
+        logger.log(Level.WARNING, "Unexpected exception", e);
       }
 
       InstrumentFunctions instrumentation = new InstrumentFunctions(


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1148 - Throwable.printStackTrace(...) should not be called
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1148
Please let me know if you have any questions.
Kirill Vlasov