### PR TITLE
"private" methods that don't access instance data should be "static"

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
@@ -478,7 +478,7 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
     addNameMap(out, originalNameMap);
   }
 
-  private void addNameMap(Appendable out, Map<String, Integer> map)
+  private static void addNameMap(Appendable out, Map<String, Integer> map)
       throws IOException {
     int i = 0;
     for (Entry<String, Integer> entry : map.entrySet()) {
@@ -801,7 +801,7 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
     out.append("\n}\n");
   }
 
-  private CharSequence offsetValue(int line, int column) throws IOException {
+  private static CharSequence offsetValue(int line, int column) throws IOException {
     StringBuilder out = new StringBuilder();
     out.append("{\n");
     appendFirstField(out, "line", String.valueOf(line));

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -553,7 +553,7 @@ public class Compiler extends AbstractCompiler {
    * base path is interpreted as a filename rather than a directory. E.g.:
    *   getRelativeTo("../foo/bar.js", "baz/bam/qux.js") --> "baz/foo/bar.js"
    */
-  private String getRelativeTo(String relative, String base) {
+  private static String getRelativeTo(String relative, String base) {
     return FileSystems.getDefault().getPath(base)
         .resolveSibling(relative)
         .normalize()

--- a/src/com/google/javascript/jscomp/LightweightMessageFormatter.java
+++ b/src/com/google/javascript/jscomp/LightweightMessageFormatter.java
@@ -128,7 +128,7 @@ public final class LightweightMessageFormatter extends AbstractMessageFormatter 
     return b.toString();
   }
 
-  private String formatPosition(String sourceName, int lineNumber) {
+  private static String formatPosition(String sourceName, int lineNumber) {
     StringBuilder b = new StringBuilder();
     if (sourceName != null) {
       b.append(sourceName);

--- a/src/com/google/javascript/jscomp/RhinoErrorReporter.java
+++ b/src/com/google/javascript/jscomp/RhinoErrorReporter.java
@@ -109,7 +109,7 @@ class RhinoErrorReporter {
    * holder {0} with a wild card that matches all possible strings.
    * Also put the any non-place-holder in quotes for regex matching later.
    */
-  private Pattern replacePlaceHolders(String s) {
+  private static Pattern replacePlaceHolders(String s) {
     s = Pattern.quote(s);
     return Pattern.compile(s.replaceAll("\\{\\d+\\}", "\\\\E.*\\\\Q"));
   }

--- a/src/com/google/javascript/jscomp/TypeCheck.java
+++ b/src/com/google/javascript/jscomp/TypeCheck.java
@@ -1498,7 +1498,7 @@ public final class TypeCheck implements NodeTraversal.Callback, CompilerPass {
     }
   }
 
-  private SuggestionPair getClosestPropertySuggestion(
+  private static SuggestionPair getClosestPropertySuggestion(
       JSType objectType, String propName) {
     return null;
   }

--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -740,7 +740,7 @@ public final class CompileTask
   /**
    * Returns the last modified timestamp of the given File.
    */
-  private long getLastModifiedTime(File file) {
+  private static long getLastModifiedTime(File file) {
     long fileLastModified = file.lastModified();
     // If the file is absent, we don't know if it changed (maybe was deleted),
     // so assume it has just changed.

--- a/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
@@ -210,11 +210,11 @@ public class Scanner {
     return true;
   }
 
-  private boolean isRegularExpressionFirstChar(char ch) {
+  private static boolean isRegularExpressionFirstChar(char ch) {
     return isRegularExpressionChar(ch) && ch != '*';
   }
 
-  private boolean isRegularExpressionChar(char ch) {
+  private static boolean isRegularExpressionChar(char ch) {
     switch (ch) {
     case '/':
       return false;
@@ -741,7 +741,7 @@ public class Scanner {
     return value;
   }
 
-  private boolean isIdentifierStart(char ch) {
+  private static boolean isIdentifierStart(char ch) {
     switch (ch) {
     case '$':
     case '_':
@@ -752,7 +752,7 @@ public class Scanner {
     }
   }
 
-  private boolean isIdentifierPart(char ch) {
+  private static boolean isIdentifierPart(char ch) {
     // TODO: identifier part character classes
     // CombiningMark
     //   Non-Spacing mark (Mn)

--- a/src/com/google/javascript/rhino/Node.java
+++ b/src/com/google/javascript/rhino/Node.java
@@ -2500,7 +2500,7 @@ public class Node implements Serializable {
   /**
    * returns true if all the flags are set in value.
    */
-  private boolean areBitFlagsSet(int value, int flags) {
+  private static boolean areBitFlagsSet(int value, int flags) {
     return (value & flags) == flags;
   }
 

--- a/src/com/google/javascript/rhino/SimpleErrorReporter.java
+++ b/src/com/google/javascript/rhino/SimpleErrorReporter.java
@@ -72,7 +72,7 @@ public class SimpleErrorReporter implements ErrorReporter {
         errors.add(formatDetailedMessage(message, sourceName, line));
     }
 
-    private String formatDetailedMessage(
+    private static String formatDetailedMessage(
         String message, String sourceName, int lineNumber) {
       String details = message;
       if (sourceName == null || lineNumber <= 0) {

--- a/test/com/google/debugging/sourcemap/SourceMapGeneratorV3Test.java
+++ b/test/com/google/debugging/sourcemap/SourceMapGeneratorV3Test.java
@@ -52,7 +52,7 @@ public final class SourceMapGeneratorV3Test extends SourceMapTestCase {
     return SourceMap.Format.V3;
   }
 
-  private String getEncodedFileName() {
+  private static String getEncodedFileName() {
     if (File.separatorChar == '\\') {
       return "c:/myfile.js";
     } else {

--- a/test/com/google/javascript/jscomp/CheckConformanceTest.java
+++ b/test/com/google/javascript/jscomp/CheckConformanceTest.java
@@ -1053,7 +1053,7 @@ public final class CheckConformanceTest extends CompilerTestCase {
         "function f() {goog.asserts.assertInstanceof(this, Error);}");
   }
 
-  private String config(String rule, String message, String... fields) {
+  private static String config(String rule, String message, String... fields) {
     String result = "requirement: {\n"
         + "  type: CUSTOM\n"
         + "  java_class: '" + rule + "'\n";
@@ -1064,11 +1064,11 @@ public final class CheckConformanceTest extends CompilerTestCase {
     return result;
   }
 
-  private String rule(String rule) {
+  private static String rule(String rule) {
     return "com.google.javascript.jscomp.ConformanceRules$" + rule;
   }
 
-  private String value(String value) {
+  private static String value(String value) {
     return "  value: '" + value + "'\n";
   }
 

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1719,7 +1719,7 @@ public final class CommandLineRunnerTest extends TestCase {
         new PrintStream(errReader));
   }
 
-  private String createZipFile(Map<String, String> entryContentsByName) throws IOException {
+  private static String createZipFile(Map<String, String> entryContentsByName) throws IOException {
     File tempZipFile = File.createTempFile("testdata", ".js.zip");
 
     try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(tempZipFile))) {

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -155,7 +155,7 @@ public final class CompilerTest extends TestCase {
         error.contains("Failed to load module \"missing\" at gin.js"));
   }
 
-  private String normalize(String path) {
+  private static String normalize(String path) {
     return path.replace(File.separator, "/");
   }
 

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -633,7 +633,7 @@ public abstract class CompilerTestCase extends TestCase {
     test(compiler, maybeCreateArray(expected), error, warning, description);
   }
 
-  private String[] maybeCreateArray(String expected) {
+  private static String[] maybeCreateArray(String expected) {
     if (expected != null) {
       return new String[] {expected};
     }

--- a/test/com/google/javascript/jscomp/MakeDeclaredNamesUniqueTest.java
+++ b/test/com/google/javascript/jscomp/MakeDeclaredNamesUniqueTest.java
@@ -100,7 +100,7 @@ public final class MakeDeclaredNamesUniqueTest extends Es6CompilerTestCase {
     invert = false;
   }
 
-  private String wrapInFunction(String s) {
+  private static String wrapInFunction(String s) {
     return "function f(){" + s + "}";
   }
 

--- a/test/com/google/javascript/jscomp/NormalizeTest.java
+++ b/test/com/google/javascript/jscomp/NormalizeTest.java
@@ -187,7 +187,7 @@ public final class NormalizeTest extends CompilerTestCase {
          "function f() { f(); if (true) {var bar = function () {}}}");
   }
 
-  private String inFunction(String code) {
+  private static String inFunction(String code) {
     return "(function(){" + code + "})";
   }
 

--- a/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java
@@ -1267,7 +1267,7 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
     foldSame("var x = 3 * (r ? Infinity : -Infinity);");
   }
 
-  private String join(String operandA, String op, String operandB) {
+  private static String join(String operandA, String op, String operandB) {
     return operandA + " " + op + " " + operandB;
   }
 

--- a/test/com/google/javascript/jscomp/StrictModeCheckTest.java
+++ b/test/com/google/javascript/jscomp/StrictModeCheckTest.java
@@ -340,7 +340,7 @@ public final class StrictModeCheckTest extends Es6CompilerTestCase {
         "}"), StrictModeCheck.ARGUMENTS_CALLER_FORBIDDEN);
   }
 
-  private String inFn(String body) {
+  private static String inFn(String body) {
     return "function func() {" + body + "}";
   }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
Please let me know if you have any questions.
Kirill Vlasov