### PR TITLE
Add const annotations to CommonJS module exports

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -21,10 +21,13 @@ import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPreOrderCallback;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.JSDocInfo;
+import com.google.javascript.rhino.JSDocInfoBuilder;
 import com.google.javascript.rhino.Node;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 /**
@@ -179,6 +182,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
     private int scriptNodeCount = 0;
     private List<Node> moduleExportRefs = new ArrayList<>();
     private List<Node> exportRefs = new ArrayList<>();
+    Map<String, Integer> propertyExportRefCount = new HashMap<>();
 
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
@@ -243,6 +247,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
         // variable or function parameter
         if (v == null) {
           moduleExportRefs.add(n);
+          maybeAddReferenceCount(n);
         }
       }
 
@@ -250,8 +255,46 @@ public final class ProcessCommonJSModules implements CompilerPass {
         Var v = t.getScope().getVar(n.getString());
         if (v == null || v.isGlobal()) {
           exportRefs.add(n);
+          maybeAddReferenceCount(n);
         }
       }
+    }
+
+    private Node getBaseQualifiedNameNode(Node n) {
+      Node refParent = n;
+      while (refParent.getParent() != null && refParent.getParent().isQualifiedName()) {
+        refParent = refParent.getParent();
+      }
+
+      if (refParent == null || !refParent.getParent().isAssign()) {
+        return null;
+      }
+
+      return refParent;
+    }
+
+    private void maybeAddReferenceCount(Node n) {
+      Node refParent = getBaseQualifiedNameNode(n);
+
+      if (refParent == null) {
+        return;
+      }
+
+      String qName = refParent.getQualifiedName();
+      if (qName.startsWith("module.exports.")) {
+        qName = qName.substring(15);
+      } else if (qName.startsWith("exports.")) {
+        qName = qName.substring(8);
+      } else {
+        return;
+      }
+
+      int assignCount = 1;
+      if (propertyExportRefCount.containsKey(qName)) {
+        assignCount = propertyExportRefCount.get(qName) + 1;
+        propertyExportRefCount.remove(qName);
+      }
+      propertyExportRefCount.put(qName, assignCount);
     }
 
     /**
@@ -377,57 +420,36 @@ public final class ProcessCommonJSModules implements CompilerPass {
         // One top-level assign: transform to
         // moduleName = rhs
         Node ref = moduleExportRefs.get(0);
-        Node newName = IR.name(moduleName);
+        Node newName = IR.name(moduleName).srcref(ref);
         newName.putProp(Node.ORIGINALNAME_PROP, ref.getQualifiedName());
+        Node rhsValue = ref.getNext();
 
-        Node rhsValue = ref.getNext().detachFromParent();
-        Node newExprResult = IR.exprResult(IR.assign(newName, rhsValue)
-          .useSourceInfoIfMissingFromForTree(ref.getParent()));
-
-        // If the rValue is an object literal, check each property to see if
-        // it's an alias, and if it is, copy the annotation over.
-        // This is a common idiom to export a set of constructors.
         if (rhsValue.isObjectLit()) {
-          Scope globalScope = SyntacticScopeCreator.makeUntyped(compiler)
-              .createScope(script, null);
-          for (Node key = rhsValue.getFirstChild();
-               key != null; key = key.getNext()) {
-            if (key.getJSDocInfo() == null &&
-                (key.getFirstChild() == null || key.getFirstChild().isName())) {
-              String aliasedVarName = key.getFirstChild() == null ?
-                  key.getString() : key.getFirstChild().getString();
-              Var aliasedVar = globalScope.getVar(aliasedVarName);
-              JSDocInfo info =
-                  aliasedVar == null ? null : aliasedVar.getJSDocInfo();
-              if (info != null &&
-                  info.getVisibility() != JSDocInfo.Visibility.PRIVATE) {
-                key.setJSDocInfo(info);
-              }
-            }
-          }
+          addConstToObjLitKeys(rhsValue);
         }
 
         Node assign = ref.getParent();
-        Node exprResult = assign.getParent();
-        script.replaceChild(exprResult, newExprResult);
+        assign.replaceChild(ref, newName);
+        JSDocInfoBuilder builder = new JSDocInfoBuilder(true);
+        builder.recordConstancy();
+        JSDocInfo info = builder.build();
+        assign.setJSDocInfo(info);
         return;
       }
 
-      if (!hasExportLValues()) {
-        // Transform to:
-        //
-        // moduleName.prop0 = 0; // etc.
-        for (Node ref : Iterables.concat(moduleExportRefs, exportRefs)) {
-          Node newRef = IR.name(moduleName).useSourceInfoIfMissingFrom(ref);
-          newRef.putProp(Node.ORIGINALNAME_PROP, ref.getQualifiedName());
-          ref.getParent().replaceChild(ref, newRef);
-        }
-        return;
+      Iterable<Node> exports;
+      boolean hasLValues = hasExportLValues();
+      if (hasLValues) {
+        exports = moduleExportRefs;
+      } else {
+        exports = Iterables.concat(moduleExportRefs, exportRefs);
       }
 
-      // Transform module.exports to moduleName
+      // Transform to:
+      //
+      // moduleName.prop0 = 0; // etc.
       boolean declaredModuleExports = false;
-      for (Node ref : moduleExportRefs) {
+      for (Node ref : exports) {
         // If there is a module exports assignment at this point, we need to
         // add a variable declaration for the module name, because otherwise
         // the default declaration for the goog.provide is a constant and the
@@ -445,8 +467,43 @@ public final class ProcessCommonJSModules implements CompilerPass {
                   .useSourceInfoIfMissingFromForTree(ref));
           declaredModuleExports = true;
         }
-        Node newRef = IR.name(moduleName).useSourceInfoIfMissingFrom(ref);
-        ref.getParent().replaceChild(ref, newRef);
+
+        String qName = null;
+        if (ref.isQualifiedName()) {
+          Node baseName = getBaseQualifiedNameNode(ref);
+          if (baseName != null) {
+            qName = baseName.getQualifiedName();
+            if (qName.startsWith("module.exports.")) {
+              qName = qName.substring(15);
+            } else {
+              qName = qName.substring(8);
+            }
+          }
+        }
+
+        Node rhsValue = ref.getNext();
+        Node newName = IR.name(moduleName).srcref(ref);
+        newName.putProp(Node.ORIGINALNAME_PROP, rhsValue);
+
+        Node parent = ref.getParent();
+        parent.replaceChild(ref, newName);
+
+        // If the property was assigned to exactly once, add an @const annotation
+        if (parent.isAssign() && qName != null && propertyExportRefCount.containsKey(qName) &&
+            propertyExportRefCount.get(qName) == 1) {
+          if (rhsValue != null && rhsValue.isObjectLit()) {
+            addConstToObjLitKeys(rhsValue);
+          }
+
+          JSDocInfoBuilder builder = new JSDocInfoBuilder(true);
+          builder.recordConstancy();
+          JSDocInfo info = builder.build();
+          parent.setJSDocInfo(info);
+        }
+      }
+
+      if(!hasLValues) {
+        return;
       }
 
       // Transform exports to exports$$moduleName and set to point
@@ -460,6 +517,22 @@ public final class ProcessCommonJSModules implements CompilerPass {
         for (Node ref : exportRefs) {
           ref.putProp(Node.ORIGINALNAME_PROP, ref.getString());
           ref.setString(aliasName);
+        }
+      }
+    }
+
+    /**
+     * Add an @const annotation to each key of an object literal
+     */
+    private void addConstToObjLitKeys(Node n) {
+      Preconditions.checkState(n.isObjectLit());
+      for (Node key = n.getFirstChild();
+           key != null; key = key.getNext()) {
+        if (key.getJSDocInfo() == null) {
+          JSDocInfoBuilder builder = new JSDocInfoBuilder(true);
+          builder.recordConstancy();
+          JSDocInfo info = builder.build();
+          key.setJSDocInfo(info);
         }
       }
     }

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -282,9 +282,9 @@ public final class ProcessCommonJSModules implements CompilerPass {
 
       String qName = refParent.getQualifiedName();
       if (qName.startsWith("module.exports.")) {
-        qName = qName.substring(15);
+        qName = qName.substring("module.exports.".length());
       } else if (qName.startsWith("exports.")) {
-        qName = qName.substring(8);
+        qName = qName.substring("exports.".length());
       } else {
         return;
       }
@@ -474,9 +474,9 @@ public final class ProcessCommonJSModules implements CompilerPass {
           if (baseName != null) {
             qName = baseName.getQualifiedName();
             if (qName.startsWith("module.exports.")) {
-              qName = qName.substring(15);
+              qName = qName.substring("module.exports.".length());
             } else {
-              qName = qName.substring(8);
+              qName = qName.substring("exports.".length());
             }
           }
         }

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -483,7 +483,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
 
         Node rhsValue = ref.getNext();
         Node newName = IR.name(moduleName).srcref(ref);
-        newName.putProp(Node.ORIGINALNAME_PROP, rhsValue);
+        newName.putProp(Node.ORIGINALNAME_PROP, qName);
 
         Node parent = ref.getParent();
         parent.replaceChild(ref, newName);

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1452,7 +1452,7 @@ public final class CommandLineRunnerTest extends TestCase {
            "var module$Baz=Baz$$module$Baz;",
 
            "var module$app={}," +
-           "    Baz$$module$app=module$Baz," +
+           "    Baz$$module$app=Baz$$module$Baz," +
            "    baz$$module$app=new Baz$$module$app;" +
            "console.log(baz$$module$app.baz());" +
            "console.log(baz$$module$app.bar())"

--- a/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
@@ -38,7 +38,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "var module$i0 = Hello$$module$i0;",
 
            "var module$i1 = {};" +
-           "var Hello$$module$i1 = module$i0;" +
+           "var Hello$$module$i1 = Hello$$module$i0;" +
            "var hello$$module$i1 = new Hello$$module$i1();"
          });
   }
@@ -81,7 +81,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "function Hello$$module$i0(){}" +
            "var module$i0 = Hello$$module$i0;",
            "var module$i1 = {};" +
-           "var Hello$$module$i1 = module$i0;" +
+           "var Hello$$module$i1 = Hello$$module$i0;" +
            "var hello$$module$i1 = new Hello$$module$i1();"
          });
   }
@@ -95,6 +95,83 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "/** @type {!Hello} */ var hello = 1;"
          },
          TypeValidator.TYPE_MISMATCH_WARNING);
+  }
+
+  public void testMultipleExportAssignments1() {
+    test(createCompilerOptions(),
+        new String[] {
+            "/** @constructor */ function Hello() {} " +
+                "module.exports = Hello;" +
+                "/** @constructor */ function Bar() {} " +
+                "Bar.prototype.foobar = function() { alert('foobar'); };" +
+                "module.exports = Bar;",
+            "var Foobar = require('./i0');" +
+                "var show = new Foobar();" +
+                "show.foobar();"
+        },
+        new String[] {
+            "function Hello$$module$i0(){} " +
+                "var module$i0 = Hello$$module$i0;" +
+                "function Bar$$module$i0(){} " +
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
+                "module$i0=Bar$$module$i0;",
+            "var module$i1 = {};" +
+                "var Foobar$$module$i1=module$i0;" +
+                "var show$$module$i1=new Foobar$$module$i1();" +
+                "show$$module$i1.foobar();"
+        });
+  }
+
+  public void testMultipleExportAssignments2() {
+    test(createCompilerOptions(),
+        new String[] {
+            "/** @constructor */ function Hello() {} " +
+                "module.exports.foo = Hello;" +
+                "/** @constructor */ function Bar() {} " +
+                "Bar.prototype.foobar = function() { alert('foobar'); };" +
+                "module.exports.foo = Bar;",
+            "var Foobar = require('./i0');" +
+                "var show = new Foobar.foo();" +
+                "show.foobar();"
+        },
+        new String[] {
+            "var module$i0 = {};" +
+                "function Hello$$module$i0(){} " +
+                "module$i0.foo = Hello$$module$i0;" +
+                "function Bar$$module$i0(){} " +
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
+                "module$i0.foo=Bar$$module$i0;",
+            "var module$i1 = {};" +
+                "var Foobar$$module$i1=module$i0;" +
+                "var show$$module$i1=new Foobar$$module$i1.foo();" +
+                "show$$module$i1.foobar();"
+        });
+  }
+
+  public void testMultipleExportAssignments3() {
+    test(createCompilerOptions(),
+        new String[] {
+            "/** @constructor */ function Hello() {} " +
+                "module.exports.foo = Hello;" +
+                "/** @constructor */ function Bar() {} " +
+                "Bar.prototype.foobar = function() { alert('foobar'); };" +
+                "exports.foo = Bar;",
+            "var Foobar = require('./i0');" +
+                "var show = new Foobar.foo();" +
+                "show.foobar();"
+        },
+        new String[] {
+            "var module$i0 = {};" +
+                "function Hello$$module$i0(){} " +
+                "module$i0.foo = Hello$$module$i0;" +
+                "function Bar$$module$i0(){} " +
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
+                "module$i0.foo=Bar$$module$i0;",
+            "var module$i1 = {};" +
+                "var Foobar$$module$i1=module$i0;" +
+                "var show$$module$i1=new Foobar$$module$i1.foo();" +
+                "show$$module$i1.foobar();"
+        });
   }
 
   public void testCrossModuleSubclass1() {
@@ -115,7 +192,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "function Hello$$module$i0(){}" +
            "var module$i0=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "var SubHello$$module$i1=function(){};" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -140,7 +217,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "function Hello$$module$i0(){}" +
            "var module$i0=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){}" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -165,7 +242,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "function Hello$$module$i0(){}" +
            "var module$i0=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){ Hello$$module$i1.call(this); }" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
@@ -215,7 +292,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "function Hello$$module$i0(){}" +
            "var module$i0=Hello$$module$i0;",
            "var module$i1={};" +
-           "var Hello$$module$i1=module$i0;" +
+           "var Hello$$module$i1=Hello$$module$i0;" +
            "var util$$module$i1={inherits:function(x,y){}};" +
            "function SubHello$$module$i1(){ Hello$$module$i1.call(this); }" +
            "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"


### PR DESCRIPTION
To help get CommonJS to parity with ES6 modules, this changes the CommonJS module rewriting to add `@const` annotations if we can reasonably be certain that the export property was assigned exactly once.