### PR TITLE
Added FileReader state constants

### DIFF
--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -508,16 +508,31 @@ FileReader.prototype.abort = function() {};
 FileReader.prototype.EMPTY = 0;
 
 /**
+ * @type {number}
+ */
+FileReader.EMPTY = 0;
+
+/**
  * @see http://www.w3.org/TR/FileAPI/#dfn-loading
  * @type {number}
  */
 FileReader.prototype.LOADING = 1;
 
 /**
+ * @type {number}
+ */
+FileReader.LOADING = 1;
+
+/**
  * @see http://www.w3.org/TR/FileAPI/#dfn-done
  * @type {number}
  */
 FileReader.prototype.DONE = 2;
+
+/**
+ * @type {number}
+ */
+FileReader.DONE = 2;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-readystate

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import com.google.javascript.jscomp.SourceMap.LocationMapping;
+import com.google.javascript.rhino.TokenStream;
 import com.google.protobuf.TextFormat;
 
 import org.kohsuke.args4j.Argument;
@@ -116,6 +117,9 @@ public class CommandLineRunner extends
 
   // UTF-8 BOM is 0xEF, 0xBB, 0xBF, of which character code is 65279.
   public static final int UTF8_BOM_CODE = 65279;
+
+  // Allowable module name characters that aren't valid in a JS identifier
+  private static final Pattern extraModuleNameChars = Pattern.compile("[-.]+");
 
   private static class GuardLevel {
     final String name;
@@ -1170,6 +1174,15 @@ public class CommandLineRunner extends
   protected void addWhitelistWarningsGuard(
       CompilerOptions options, File whitelistFile) {
     options.addWarningsGuard(WhitelistWarningsGuard.fromFile(whitelistFile));
+  }
+
+  @Override
+  protected void checkModuleName(String name)
+      throws FlagUsageException {
+    if (!TokenStream.isJSIdentifier(
+        extraModuleNameChars.matcher(name).replaceAll("_"))) {
+      throw new FlagUsageException("Invalid module name: '" + name + "'");
+    }
   }
 
   @Override

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1579,6 +1579,33 @@ public final class CommandLineRunnerTest extends TestCase {
         + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
   }
 
+  public void testOutputModuleNaming() throws FlagUsageException {
+    String inputString = "[{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
+    args.add("--json_streams=BOTH");
+    args.add("--module=foo--bar.baz:1");
+
+    CommandLineRunner runner = new CommandLineRunner(
+        args.toArray(new String[]{}),
+        new ByteArrayInputStream(inputString.getBytes()),
+        new PrintStream(outReader),
+        new PrintStream(errReader));
+
+    lastCompiler = runner.getCompiler();
+    try {
+      runner.doRun();
+    } catch (IOException e) {
+      e.printStackTrace();
+      fail("Unexpected exception " + e);
+    }
+    String output = new String(outReader.toByteArray(), UTF_8);
+    assertThat(output).isEqualTo("[{\"src\":\"alert(\\\"foo\\\");\\n\","
+        + "\"path\":\"./foo--bar.baz.js\",\"source_map\":\"{\\n\\\"version\\\":3,"
+        + "\\n\\\"file\\\":\\\"./foo--bar.baz.js\\\",\\n\\\"lineCount\\\":1,"
+        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAA,CAAM,KAAN;\\\","
+        + "\\n\\\"sources\\\":[\\\"foo.js\\\"],"
+        + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
+  }
+
   /* Helper functions */
 
   private void testSame(String original) {


### PR DESCRIPTION
FileReader state constants should be defined not only in prototype but in constructor object itself.