### PR TITLE
New pass WhitespaceWrapGoogModules in specialist "always pre-check" phase (fixes #611) [rebuilt]

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -682,6 +682,11 @@ public class Compiler extends AbstractCompiler {
     if (!precheck()) {
       return;
     }
+    
+    if (options.skipNonTranspilationPasses) {
+      // I.e. whitespace-only mode, which will not work with goog.module without:
+      whitespaceOnlyPasses();
+    }
 
     if (!options.skipNonTranspilationPasses || options.lowerFromEs6()) {
       check();
@@ -754,6 +759,17 @@ public class Compiler extends AbstractCompiler {
     return true;
   }
 
+  public void whitespaceOnlyPasses() {
+    Tracer t = newTracer("runWhitespaceOnlyPasses");
+    try {
+      for (PassFactory pf : getPassConfig().getWhitespaceOnlyPasses()) {
+        pf.create(this).process(externsRoot, jsRoot);
+      }
+    } finally {
+      stopTracer(t, "runWhitespaceOnlyPasses");
+    }
+  }
+  
   public void check() {
     runCustomPasses(CustomPassExecutionTime.BEFORE_CHECKS);
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -178,6 +178,13 @@ public final class DefaultPassConfig extends PassConfig {
       }
     }
   }
+  
+  @Override
+  protected List<PassFactory> getWhitespaceOnlyPasses() {
+    List<PassFactory> passes = new ArrayList<>();
+    passes.add(whitespaceWrapGoogModules);
+    return passes;
+  }
 
   @Override
   protected List<PassFactory> getChecks() {
@@ -2602,4 +2609,14 @@ public final class DefaultPassConfig extends PassConfig {
       return new RewriteBindThis(compiler);
     }
   };
+
+  /** Rewrites goog.module in whitespace only mode */
+  private final HotSwapPassFactory whitespaceWrapGoogModules =
+      new HotSwapPassFactory("whitespaceWrapGoogModules", true) {
+    @Override
+    protected HotSwapCompilerPass create(AbstractCompiler compiler) {
+      return new WhitespaceWrapGoogModules(compiler);
+    }
+  };
+
 }

--- a/src/com/google/javascript/jscomp/PassConfig.java
+++ b/src/com/google/javascript/jscomp/PassConfig.java
@@ -23,6 +23,7 @@ import com.google.javascript.jscomp.graph.LinkedDirectedGraph;
 import com.google.javascript.rhino.Node;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -98,6 +99,15 @@ public abstract class PassConfig {
    */
   TypedScope getTopScope() {
     return topScope;
+  }
+
+  /**
+   * Gets additional checking passes that are run always, even in "whitespace only" mode.
+   * For very specific cases where processing is required even in a mode which is intended 
+   * not to have any processing - specifically introduced to support goog.module() usage.
+   */
+  protected List<PassFactory> getWhitespaceOnlyPasses() {
+    return Collections.emptyList();
   }
 
   /**
@@ -242,6 +252,10 @@ public abstract class PassConfig {
     PassConfigDelegate(PassConfig delegate) {
       super(delegate.options);
       this.delegate = delegate;
+    }
+    
+    @Override protected List<PassFactory> getWhitespaceOnlyPasses() {
+      return delegate.getWhitespaceOnlyPasses();
     }
 
     @Override protected List<PassFactory> getChecks() {

--- a/src/com/google/javascript/jscomp/WhitespaceWrapGoogModules.java
+++ b/src/com/google/javascript/jscomp/WhitespaceWrapGoogModules.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp;
+
+import com.google.common.base.Preconditions;
+import com.google.javascript.rhino.IR;
+import com.google.javascript.rhino.Node;
+
+/**
+ * Replicates the effect of ClosureBundler in whitespace-only mode and wraps goog.modules
+ * in goog.loadModule calls. See comment block below.
+ */
+public class WhitespaceWrapGoogModules implements HotSwapCompilerPass {
+
+  private final AbstractCompiler compiler;
+
+  WhitespaceWrapGoogModules(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    for (Node c = root.getFirstChild(); c != null; c = c.getNext()) {
+      Preconditions.checkState(c.isScript());
+      hotSwapScript(c, null);
+    }
+  }
+
+  @Override
+  public void hotSwapScript(Node scriptRoot, Node originalRoot) {
+    if (!NodeUtil.isModuleFile(scriptRoot)) return;
+
+    // As per ClosureBundler:
+    /*
+      // add the prefix on the first line so the line numbers aren't affected.
+      out.append(
+          "goog.loadModule(function(exports) {"
+          + "'use strict';");
+      append(out, Mode.NORMAL, contents);
+      out.append(
+          "\n" // terminate any trailing single line comment.
+          + ";" // terminate any trailing expression.
+          + "return exports;});\n");
+      appendSourceUrl(out, Mode.NORMAL);
+     */
+
+    Node block = IR.block();
+    block.addChildToBack(IR.exprResult(IR.string("use strict"))); // needs to be explicit, to match ClosureBundler
+
+    Node loadMod = IR.exprResult(IR.call(
+        IR.getprop(IR.name("goog"), IR.string("loadModule")),
+        IR.function(IR.name(""), IR.paramList(IR.name("exports")), block)))
+        .srcrefTree(scriptRoot);
+
+    if (scriptRoot.hasChildren()) {
+      block.addChildrenToBack(scriptRoot.removeChildren());
+    }
+    block.addChildToBack(IR.returnNode(IR.name("exports")).srcrefTree(scriptRoot));
+    
+    scriptRoot.addChildToBack(loadMod);
+    compiler.reportCodeChange();
+  }
+
+}

--- a/test/com/google/javascript/jscomp/WhitespaceWrapGoogModulesTest.java
+++ b/test/com/google/javascript/jscomp/WhitespaceWrapGoogModulesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp;
+
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+
+public class WhitespaceWrapGoogModulesTest extends CompilerTestCase {
+
+  private LanguageMode languageOut;
+
+  @Override
+  public void setUp() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    languageOut = LanguageMode.ECMASCRIPT6;
+    disableTypeCheck();
+    
+    enableCompareAsTree(false); 
+    // otherwise "use strict" in the expected output moves,
+    // from where it should be (deliberately to match ClosureBundler),
+    // to the top of the AST and breaks the comparison.
+  }
+  
+  @Override
+  protected CompilerPass getProcessor(Compiler compiler) {
+    return new WhitespaceWrapGoogModules(compiler);
+  }
+
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    options.setLanguageOut(languageOut);
+    return options;
+  }
+
+  public void testGoogModuleRewrite() {
+    test(
+        LINE_JOINER.join(
+            "goog.module('test');",
+            "var f = 5;",
+            "exports = f;"),
+        "goog.loadModule(function(exports){"+
+            "\"use strict\";"+
+            "goog.module(\"test\");"+
+            "var f=5;"+
+            "exports=f;"+
+            "return exports"+
+        "})");
+  }
+}


### PR DESCRIPTION
Replacement for PR https://github.com/google/closure-compiler/pull/1123 which fixes Git history.  See original PR for discussion including @blickly last comment:

> ... So looks like this is safe to merge even if people are relying on the two-step workflow. ...

I'd broken my previous branch by doing some merge in the past which was causing tons of conflicts when I rebased, so I started again with a clean branch from today's google/master, and cherry-picked all my non-merge commits (no conflicts or compilation errors resulted).

This constitutes exactly the same changes we were consulting on in the previous PR, but freshly applied to master. I haven't added or removed any changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1365)
<!-- Reviewable:end -->
