### PR TITLE
Suppress missing require from externs (reworked)

### DIFF
--- a/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
+++ b/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
@@ -329,23 +329,22 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
     Node extendClass = classNode.getSecondChild();
     
     // If the superclass is something other than a qualified name, ignore it.
-    if (extendClass.isQualifiedName()) {
-      // Grab the root superclass namespace.
-      Node root = NodeUtil.getRootOfQualifiedName(extendClass);
-      
-      // It should always be a name. Extending this.something or 
-      // super.something is unlikely.
-      // We only consider programmer-defined superclasses that are
-      // global variables, or are defined on global variables.
-      if (root.isName()) {
-        String rootName = root.getString();
-        Var var = t.getScope().getVar(rootName);
-        if (var != null && (var.isLocal() || var.isExtern())) {
-          // "require" not needed for these
-        } else {
-          usages.put(extendClass.getQualifiedName(), extendClass);
-        }
-      }
+    if (!extendClass.isQualifiedName()) return;
+    
+    Node root = NodeUtil.getRootOfQualifiedName(extendClass);
+	  
+	// It should always be a name. Extending this.something or 
+    // super.something is unlikely.
+    // We only consider programmer-defined superclasses that are
+    // global variables, or are defined on global variables.
+    if (root.isName()) {
+	  String rootName = root.getString();
+	  Var var = t.getScope().getVar(rootName);
+	  if (var != null && (var.isLocal() || var.isExtern())) {
+		// "require" not needed for these
+	  } else {
+		usages.put(extendClass.getQualifiedName(), extendClass);
+	  }
     }
   }
 

--- a/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
+++ b/src/com/google/javascript/jscomp/CheckRequiresForConstructors.java
@@ -166,7 +166,7 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
         visitNewNode(t, n);
         break;
       case Token.CLASS:
-        visitClassNode(n);
+        visitClassNode(t, n);
         break;
       case Token.IMPORT:
       case Token.EXPORT:
@@ -320,14 +320,32 @@ class CheckRequiresForConstructors implements HotSwapCompilerPass, NodeTraversal
     }
   }
 
-  private void visitClassNode(Node classNode) {
+  private void visitClassNode(NodeTraversal t, Node classNode) {
     String name = NodeUtil.getName(classNode);
     if (name != null) {
       constructors.add(name);
     }
+    
     Node extendClass = classNode.getSecondChild();
+    
+    // If the superclass is something other than a qualified name, ignore it.
     if (extendClass.isQualifiedName()) {
-      usages.put(extendClass.getQualifiedName(), extendClass);
+      // Grab the root superclass namespace.
+      Node root = NodeUtil.getRootOfQualifiedName(extendClass);
+      
+      // It should always be a name. Extending this.something or 
+      // super.something is unlikely.
+      // We only consider programmer-defined superclasses that are
+      // global variables, or are defined on global variables.
+      if (root.isName()) {
+        String rootName = root.getString();
+        Var var = t.getScope().getVar(rootName);
+        if (var != null && (var.isLocal() || var.isExtern())) {
+          // "require" not needed for these
+        } else {
+          usages.put(extendClass.getQualifiedName(), extendClass);
+        }
+      }
     }
   }
 

--- a/test/com/google/javascript/jscomp/MissingRequireTest.java
+++ b/test/com/google/javascript/jscomp/MissingRequireTest.java
@@ -22,6 +22,8 @@ import static com.google.javascript.jscomp.CheckRequiresForConstructors.MISSING_
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 
+import java.util.List;
+
 /**
  * Tests for the "missing requires" check in {@link CheckRequiresForConstructors}.
  *
@@ -140,7 +142,31 @@ public final class MissingRequireTest extends Es6CompilerTestCase {
     String warning = "'goog.foo.Bar.Inner' used but not goog.require'd";
     test(js, js, null, MISSING_REQUIRE_WARNING, warning);
   }
-
+  
+  public void testFailEs6ClassExtendsSomethingWithoutNS() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    String js = "var goog = {}; class SubClass extends SomethingWithoutNS {}";
+    String warning = "'SomethingWithoutNS' used but not goog.require'd";
+    test(js, js, null, MISSING_REQUIRE_WARNING, warning);
+  }
+  
+  public void testEs6ClassExtendsSomethingInExterns() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    String js = "var goog = {}; class SubClass extends SomethingInExterns {}";
+    List<SourceFile> externs = ImmutableList.of(SourceFile.fromCode("externs", 
+        "/** @constructor */ var SomethingInExterns;")); 
+    test(externs, js, js, null, null, null);
+  }
+  
+  public void testEs6ClassExtendsSomethingInExternsWithNS() {
+    setAcceptedLanguage(LanguageMode.ECMASCRIPT6);
+    String js = "var goog = {}; class SubClass extends MyExterns.SomethingInExterns {}";
+    List<SourceFile> externs = ImmutableList.of(SourceFile.fromCode("externs", 
+        "var MyExterns;\n"
+        + "/** @constructor */ MyExterns.SomethingInExterns;")); 
+    test(externs, js, js, null, null, null);
+  }
+  
   public void testFailWithNestedNewNodes() {
     String[] js =
         new String[] {"var goog = {}; goog.require('goog.foo.Bar'); "


### PR DESCRIPTION
This is to fix the case where you have React defined globally in externs:
``` javascript
// Externs:

var React = {};

/**
 * @constructor
 * @param {Object} props
 */
React.Component = function(props) {};

// Main code:

class X extends React.Component {
}
```
Without this PR you get the following warning, which is incorrect since externs don't need to be required as they are global:
```
'React.Component' used but not goog.require'd
```

This is a rework of PR https://github.com/google/closure-compiler/pull/1192 which follows the behaviour of the rest of the class more closely. The check now happens before adding to usages, in visitClassNode, rather than in visitScriptNode, as per @MatrixFrog comment https://github.com/google/closure-compiler/pull/1192#issuecomment-146266314