### PR TITLE
TypedCodeGenerator temp fix for crash when printing Closure Library

### DIFF
--- a/src/com/google/javascript/jscomp/TypedCodeGenerator.java
+++ b/src/com/google/javascript/jscomp/TypedCodeGenerator.java
@@ -118,6 +118,14 @@ class TypedCodeGenerator extends CodeGenerator {
     //     NAME param1
     //     NAME param2
     if (fnNode != null) {
+      if (!fnNode.isFunction()) {
+        // Temporarily ignore failures when using TypedCodeGenerator with ClosureLibrary, e.g.: 
+        // goog.removeHashCode = goog.removeUid;   (base.js)
+        // goog.now = goog.TRUSTED_SITE && Date.now || function() {...   (goog.base)
+        // this.boundTick_ = goog.bind(this.tick_, this);   (timer.js)
+        // goog.math.Vec2.prototype.scale = (goog.math.Coordinate.prototype.scale);   (vec2.js)
+        return ""; // don't annotate
+      }
       Node paramNode = NodeUtil.getFunctionParameters(fnNode).getFirstChild();
 
       // Param types


### PR DESCRIPTION
Temporary fix and demonstrative unit test for ```TypedCodeGenerator.getFunctionAnnotation()``` Preconditions failure in ```NodeUtil.getFunctionParameters(fnNode)``` when code printing e.g.
``` javascript
goog.removeHashCode = goog.removeUid;
```
from ```base.js``` in Closure Library.

See 4 examples in code below.

I suspect there is some other proper fix that may be apparent to whoever introduced this problem, but this highlights the problem and works around it by printing without type annotations for these cases. I appreciate this PR probably won't be accepted in full but may be in part, so I've submitted as a PR rather than an issue.

This used to work in around June-September 2015 and was noticed to fail in Jan 2016.