### PR TITLE
Allow TypeScript syntax in arrow function parameters and return types

### DIFF
--- a/test/com/google/javascript/jscomp/Es6TypedToEs6ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6TypedToEs6ConverterTest.java
@@ -254,7 +254,7 @@ public final class Es6TypedToEs6ConverterTest extends CompilerTestCase {
 
   public void testGenericFunction() {
     test("function foo<T>() {}", "/** @template T */ function foo() {}");
-//     test("var x = <K, V>(p) => 3;", "var x = /** @template K, V */ (p) => 3");
+    test("var x = <K, V>(p) => 3;", "var x = /** @template K, V */ (p) => 3");
     test("class Foo { f<T>() {} }", "class Foo { /** @template T */ f() {} }");
     test("(function<T>() {})();", "(/** @template T */ function() {})();");
     test("function* foo<T>() {}", "/** @template T */ function* foo() {}");

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -227,6 +227,20 @@ public final class ParserTest extends BaseJSTypeTestCase {
     parse("foo:(function(){foo:2})");
   }
 
+  public void testConditional() {
+    parse("1 ? 2 ? 3 : 4 : 5;");
+
+    mode = LanguageMode.ECMASCRIPT6;
+    expectedFeatures = FeatureSet.ES6_IMPL;
+    Node hook = parse(LINE_JOINER.join(
+        "function f(cond) {",
+        "  return cond ?",
+        "      (v = 7, f = () => v) :",
+        "      n => 2 * n;",
+        "}")).getFirstChild().getLastChild().getFirstFirstChild();
+    assertNode(hook).hasType(Token.HOOK);
+  }
+
   public void testLinenoCharnoAssign1() throws Exception {
     Node assign = parse("a = b").getFirstFirstChild();
 

--- a/test/com/google/javascript/jscomp/parsing/TypeSyntaxTest.java
+++ b/test/com/google/javascript/jscomp/parsing/TypeSyntaxTest.java
@@ -152,7 +152,7 @@ public final class TypeSyntaxTest extends TestCase {
     parse("function foo({x}: any) {\n}");
   }
 
-  public void disabled_testFunctionParamDeclaration_arrow() {
+  public void testFunctionParamDeclaration_arrow() {
     Node fn = parse("(x: string) => 'hello' + x;").getFirstFirstChild();
     Node param = fn.getSecondChild().getFirstChild();
     assertDeclaredType("string type", stringType(), param);
@@ -172,7 +172,7 @@ public final class TypeSyntaxTest extends TestCase {
     assertDeclaredType("string type", stringType(), fn);
   }
 
-  public void disabled_testFunctionReturn_arrow() {
+  public void testFunctionReturn_arrow() {
     Node fn = parse("(): string => 'hello';").getFirstFirstChild();
     assertDeclaredType("string type", stringType(), fn);
   }
@@ -314,7 +314,7 @@ public final class TypeSyntaxTest extends TestCase {
     parse("var n: (p1: string, p2: number) => boolean;");
     parse("var n: () => () => number;");
     parse("var n: (p1: string) => {};");
-    // parse("(number): () => number => number;");
+    parse("(number): () => number => number;");
 
     Node ast = parse("var n: (p1: string, p2: number) => boolean[];");
     TypeDeclarationNode function = (TypeDeclarationNode)
@@ -510,7 +510,7 @@ public final class TypeSyntaxTest extends TestCase {
 
   public void testGenericFunction() {
     parse("function foo<T>() {\n}");
-    // parse("var x = <K, V>(p) => 3;");
+    parse("var x = <K, V>(p) => 3;");
     parse("class Foo {\n  f<T>() {\n  }\n}");
     parse("(function<T>() {\n})();");
     parse("function* foo<T>() {\n}");
@@ -522,11 +522,38 @@ public final class TypeSyntaxTest extends TestCase {
     expectErrors("Parse error. 'identifier' expected");
     parse("function foo<>() {\n}");
 
+    expectErrors("Parse error. invalid location for generics");
+    parse("var x = <T>(5 + 7);");
+
     // Typecasting, not supported yet.
-    expectErrors("Parse error. primary expression expected");
+    expectErrors("Parse error. invalid location for generics");
     parse("var x = <T>((p:T) => 3);");
 
     testNotEs6Typed("function foo<T>() {}", "generics");
+  }
+
+  public void testColonTypeInArrowFunction() {
+    parse("(x: string) => 'hello';");
+    parse("(x: number = 1) => 'hello';");
+    parse("(x: string): string => 'hello';");
+    parse("(x: string, y: number): string => 'hello';");
+    parse("1 ? (x: number) => '2' : (y: boolean) => 3 ? 4 : 5;");
+    parse("var x = (y: number, z = (w: number) => 1) => 2;");
+  }
+
+  public void testInvalidColonType() {
+    expectErrors("Parse error. invalid location for colon type expression");
+    parse("var x = 3 : number;");
+    expectErrors("Parse error. invalid location for colon type expression");
+    parse("var x = (3 : number);");
+    expectErrors("Parse error. invalid location for colon type expression");
+    parse("var x = (x : number);");
+    expectErrors("Parse error. invalid location for colon type expression");
+    parse("var x = ((y): number);");
+    expectErrors("Parse error. invalid location for colon type expression");
+    parse("var x = ((y: string, x: number): number);");
+    expectErrors("Parse error. invalid arrow function parameters");
+    parse("var x = 3 : number => 4;");
   }
 
   public void testImplements() {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1378)
<!-- Reviewable:end -->
