### PR TITLE
CommonJS Module relocation feature

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -468,6 +468,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     options.tracer = config.tracerMode;
     options.setNewTypeInference(config.useNewTypeInference);
     options.instrumentationTemplateFile = config.instrumentationTemplateFile;
+    options.commonJSModuleRelocations = config.relocateCommonJSModule;
   }
 
   protected final A getCompiler() {
@@ -2424,6 +2425,17 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
      */
     CommandLineConfig setModuleRoots(List<String> jsModuleRoots) {
       this.moduleRoots = jsModuleRoots;
+      return this;
+    }
+
+    private Map<String, String> relocateCommonJSModule;
+
+    CommandLineConfig setRelocateCommonJSModule(Map<String, String> moduleRelocations) {
+      if (moduleRelocations == null) {
+        this.relocateCommonJSModule = new HashMap<>();
+      } else {
+        this.relocateCommonJSModule = moduleRelocations;
+      }
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -62,6 +62,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -421,6 +422,18 @@ public class CommandLineRunner extends
       usage = "Path prefix to be removed from CommonJS module names."
     )
     private List<String> commonJsPathPrefix = new ArrayList<>();
+
+    @Option(
+      name = "--relocate_common_js_module",
+      hidden = true,
+      usage = "Mapping for required CommonJS modules. You may specify " +
+          "multiple. This allows the compiler to map the path of the " +
+          "required module to the given mapping and to load the mapped " +
+          "module instead of the original module, e.g. " +
+          "--relocate_common_js_module=./lib/1.0.0/module.js=" +
+          "./lib/2.0.0/module.js"
+    )
+    private Map<String, String> comonJSModuleRelocations = new HashMap<>();
 
     @Option(
       name = "--js_module_root",
@@ -1077,6 +1090,10 @@ public class CommandLineRunner extends
           ImmutableList.of(ES6ModuleLoader.toModuleName(URI.create(flags.commonJsEntryModule)));
     }
 
+    if (!flags.processCommonJsModules && flags.comonJSModuleRelocations.size() != 0) {
+      reportError("Error - --relocate_common_js_module must be used together with --process_common_js_modules");
+    }
+
     if (flags.outputWrapperFile != null && !flags.outputWrapperFile.isEmpty()) {
       flags.outputWrapper = "";
       try {
@@ -1165,7 +1182,8 @@ public class CommandLineRunner extends
           .setTracerMode(flags.tracerMode)
           .setInstrumentationTemplateFile(flags.instrumentationFile)
           .setNewTypeInference(flags.useNewTypeInference)
-          .setJsonStreamMode(flags.jsonStreamMode);
+          .setJsonStreamMode(flags.jsonStreamMode)
+          .setRelocateCommonJSModule(flags.comonJSModuleRelocations);
     }
     errorStream = null;
   }

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1470,7 +1470,7 @@ public class Compiler extends AbstractCompiler {
   }
 
   void processEs6Modules() {
-    ES6ModuleLoader loader = new ES6ModuleLoader(options.moduleRoots, inputs);
+    ES6ModuleLoader loader = new ES6ModuleLoader(options.moduleRoots, inputs, options.commonJSModuleRelocations);
     for (CompilerInput input : inputs) {
       input.setCompiler(this);
       Node root = input.getAstRoot(this);
@@ -1493,7 +1493,7 @@ public class Compiler extends AbstractCompiler {
     // with multiple ways to express dependencies. Directly support JSModules
     // that are equivalent to a single file and which express their deps
     // directly in the source.
-    ES6ModuleLoader loader = new ES6ModuleLoader(options.moduleRoots, inputs);
+    ES6ModuleLoader loader = new ES6ModuleLoader(options.moduleRoots, inputs, options.commonJSModuleRelocations);
     for (CompilerInput input : inputs) {
       input.setCompiler(this);
       Node root = input.getAstRoot(this);

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -788,6 +788,8 @@ public class CompilerOptions {
   /** Runtime libraries to never inject. */
   Set<String> preventLibraryInjection = ImmutableSet.of();
 
+  Map<String, String> commonJSModuleRelocations = new HashMap<>();
+
 
   //--------------------------------
   // Output options

--- a/src/com/google/javascript/jscomp/ES6ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/ES6ModuleLoader.java
@@ -20,9 +20,11 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -34,7 +36,7 @@ import java.util.regex.Pattern;
  */
 public final class ES6ModuleLoader {
   /** According to the spec, the forward slash should be the delimiter on all platforms. */
-  static final String MODULE_SLASH = "/";
+  static final char MODULE_SLASH = '/';
   /** The default module root, the current directory. */
   public static final String DEFAULT_FILENAME_PREFIX = "." + MODULE_SLASH;
 
@@ -46,14 +48,22 @@ public final class ES6ModuleLoader {
   private final List<URI> moduleRootUris;
   /** The set of all known input module URIs (including trailing .js), after normalization. */
   private final Set<URI> moduleUris;
+  /**
+   * Contains a mapping of module paths. If such a module is required, the
+   * mapped file path is used.
+   */
+  private Map<URI, URI> commonJSModuleRelocations;
 
   /**
    * Creates an instance of the module loader which can be used to locate ES6 and CommonJS modules.
    *
    * @param moduleRoots The root directories to locate modules in.
    * @param inputs All inputs to the compilation process.
+   * @param commonJSModuleRelocations All CommonJS module mappings to be use
+   *        to locate required CommonJS modules.
    */
-  public ES6ModuleLoader(List<String> moduleRoots, Iterable<CompilerInput> inputs, Map<String, String> moduleRelocations) {
+  public ES6ModuleLoader(List<String> moduleRoots, Iterable<CompilerInput> inputs,
+	      Map<String, String> commonJSModuleRelocations) {
     this.moduleRootUris =
         Lists.transform(
             moduleRoots,
@@ -71,6 +81,19 @@ public final class ES6ModuleLoader {
             "Duplicate module URI after resolving: " + input.getName());
       }
     }
+
+    this.commonJSModuleRelocations = new HashMap<>();
+    if (commonJSModuleRelocations != null) {
+      for(Entry<String, String> mapping : commonJSModuleRelocations.entrySet()) {
+        // Normalize the original module name and normalize the mapped module
+        // name. The user must specify the path to both module names based on
+        // CWD, here we rebase it on the actual file which requires this
+        // module.
+        this.commonJSModuleRelocations.put(
+                normalizeAddress(createUri(mapping.getKey())),
+                normalizeAddress(createUri(mapping.getValue())));
+      }
+    }
   }
 
   /**
@@ -78,18 +101,67 @@ public final class ES6ModuleLoader {
    * @return The normalized module URI, or {@code null} if not found.
    */
   URI locateCommonJsModule(String requireName, CompilerInput context) {
+	URI loadAddress = null;
+    for (String possibleLoadUri : getAllModuleNamePossibilities(requireName)) {
+      String resolvedPossibleLoadUri =
+              resolveModuleName(possibleLoadUri, context).toString();
+      String mappedLoadUri =
+              relocateCommonJSModule(resolvedPossibleLoadUri, context);
+      if (resolvedPossibleLoadUri.equals(mappedLoadUri)) {
+        loadAddress = isModuleUri(mappedLoadUri);
+        if (loadAddress != null) {
+          return loadAddress;
+        }
+      } else {
+        for (String mappedUri : getAllModuleNamePossibilities(mappedLoadUri)) {
+          loadAddress = isModuleUri(mappedUri);
+          if (loadAddress != null) {
+            return loadAddress;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private String relocateCommonJSModule(String loadUri, CompilerInput referrer) {
+    if (loadUri == null || loadUri.length() == 0) {
+      return loadUri;
+    }
+    for (URI key : this.commonJSModuleRelocations.keySet()) {
+      String keyUri = key.toString();
+      // Replace the entire module path by the mapped value.
+      if (loadUri.equals(keyUri)) {
+        return this.commonJSModuleRelocations.get(key).toString();
+      }
+      // Prefix the entire module path by the mapped value.
+      if (keyUri.isEmpty()) {
+        return URI.create(this.commonJSModuleRelocations.get(key).toString() +
+                MODULE_SLASH + loadUri).normalize().toString();
+      }
+      // Replace the matched part of the original URI (only if it was a valid
+      // directory path and stopped at a separator) by the mapped value.
+      if (loadUri.startsWith(keyUri) &&
+              (loadUri.charAt(keyUri.length() - 1) == MODULE_SLASH &&
+               keyUri.endsWith(String.valueOf(MODULE_SLASH))) ||
+              (loadUri.length() > keyUri.length() &&
+               loadUri.charAt(keyUri.length()) == MODULE_SLASH &&
+               !keyUri.endsWith(String.valueOf(MODULE_SLASH)))) {
+        String prefix = this.commonJSModuleRelocations.get(key).toString();
+        String postfix = loadUri.substring(keyUri.length());
+        return URI.create(prefix + MODULE_SLASH + postfix)
+                .normalize().toString();
+      }
+    }
+    return loadUri;
+  }
+
+  private String[] getAllModuleNamePossibilities(String requireName) {
     // * the immediate name require'd
-    URI loadAddress = locate(requireName, context);
-    if (loadAddress == null) {
-      // * the require'd name + /index.js
-      loadAddress = locate(requireName + MODULE_SLASH + "index.js", context);
-    }
-    if (loadAddress == null) {
-      // * the require'd name with a potential trailing ".js"
-      loadAddress = locate(requireName + ".js", context);
-    }
-    
-    return loadAddress; // could be null.
+    // * the require'd name + /index.js
+    // * the require'd name with a potential trailing ".js"
+    return new String[]{requireName, requireName + MODULE_SLASH + "index.js",
+            requireName + ".js"};
   }
 
   /**
@@ -100,15 +172,28 @@ public final class ES6ModuleLoader {
     return locate(moduleName + ".js", context);
   }
 
-  private URI locate(String name, CompilerInput referrer) {
-    URI uri = createUri(name);
-    if (isRelativeIdentifier(name)) {
+  private URI resolveModuleName (String uri, CompilerInput referrer) {
+    URI result = createUri(uri);
+    if (isRelativeIdentifier(uri)) {
       URI referrerUri = normalizeInputAddress(referrer);
-      uri = referrerUri.resolve(uri);
+      result = referrerUri.resolve(uri);
     }
+	return result;
+  }
+
+  private URI locate(String name, CompilerInput referrer) {
+    URI uri = resolveModuleName(name, referrer);
     URI normalized = normalizeAddress(uri);
-    if (moduleUris.contains(normalized)) {
-      return normalized;
+    return isModuleUri(normalized);
+  }
+
+  private URI isModuleUri(String uri) {
+    return isModuleUri(URI.create(uri));
+  }
+
+  private URI isModuleUri(URI uri) {
+    if (moduleUris.contains(uri)) {
+      return uri;
     }
     return null;
   }
@@ -139,7 +224,7 @@ public final class ES6ModuleLoader {
   private static URI createUri(String input) {
     // Colons might cause URI.create() to fail
     String forwardSlashes =
-        input.replace(':', '-').replace("\\", MODULE_SLASH).replace(" ", "%20");
+        input.replace(':', '-').replace("\\", String.valueOf(MODULE_SLASH)).replace(" ", "%20");
     return URI.create(forwardSlashes).normalize();
   }
 
@@ -163,8 +248,8 @@ public final class ES6ModuleLoader {
   public static String toModuleName(URI filename) {
     String moduleName =
         stripJsExtension(filename.toString())
-            .replaceAll("^\\." + Pattern.quote(MODULE_SLASH), "")
-            .replace(MODULE_SLASH, "$")
+            .replaceAll("^\\." + Pattern.quote(String.valueOf(MODULE_SLASH)), "")
+            .replace(String.valueOf(MODULE_SLASH), "$")
             .replace('\\', '$')
             .replace('-', '_')
             .replace(':', '_')

--- a/src/com/google/javascript/jscomp/ES6ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/ES6ModuleLoader.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -52,7 +53,7 @@ public final class ES6ModuleLoader {
    * @param moduleRoots The root directories to locate modules in.
    * @param inputs All inputs to the compilation process.
    */
-  public ES6ModuleLoader(List<String> moduleRoots, Iterable<CompilerInput> inputs) {
+  public ES6ModuleLoader(List<String> moduleRoots, Iterable<CompilerInput> inputs, Map<String, String> moduleRelocations) {
     this.moduleRootUris =
         Lists.transform(
             moduleRoots,
@@ -87,6 +88,7 @@ public final class ES6ModuleLoader {
       // * the require'd name with a potential trailing ".js"
       loadAddress = locate(requireName + ".js", context);
     }
+    
     return loadAddress; // could be null.
   }
 

--- a/test/com/google/javascript/jscomp/ES6ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/ES6ModuleLoaderTest.java
@@ -32,14 +32,14 @@ public final class ES6ModuleLoaderTest extends TestCase {
 
   public void testWindowsAddresses() {
     ES6ModuleLoader loader =
-        new ES6ModuleLoader(ImmutableList.of("."), inputs("js\\a.js", "js\\b.js"));
+        new ES6ModuleLoader(ImmutableList.of("."), inputs("js\\a.js", "js\\b.js"), null);
     assertEquals("js/a.js", loader.normalizeInputAddress(input("js\\a.js")).toString());
     assertEquals("js/b.js", loader.locateEs6Module("./b", input("js\\a.js")).toString());
   }
 
   public void testLocateCommonJs() throws Exception {
     ES6ModuleLoader loader =
-        new ES6ModuleLoader(ImmutableList.of("."), inputs("A/index.js", "B/index.js", "app.js"));
+        new ES6ModuleLoader(ImmutableList.of("."), inputs("A/index.js", "B/index.js", "app.js"), null);
 
     CompilerInput inputA = input("A/index.js");
     CompilerInput inputB = input("B/index.js");
@@ -51,7 +51,7 @@ public final class ES6ModuleLoaderTest extends TestCase {
   }
 
   public void testNormalizeUris() throws Exception {
-    ES6ModuleLoader loader = new ES6ModuleLoader(ImmutableList.of("a", "b", "/c"), inputs());
+    ES6ModuleLoader loader = new ES6ModuleLoader(ImmutableList.of("a", "b", "/c"), inputs(), null);
     assertUri("a.js", loader.normalizeInputAddress(input("a/a.js")));
     assertUri("a.js", loader.normalizeInputAddress(input("a.js")));
     assertUri("some.js", loader.normalizeInputAddress(input("some.js")));
@@ -62,7 +62,7 @@ public final class ES6ModuleLoaderTest extends TestCase {
 
   public void testDuplicateUris() throws Exception {
     try {
-      new ES6ModuleLoader(ImmutableList.of("a", "b"), inputs("a/f.js", "b/f.js"));
+      new ES6ModuleLoader(ImmutableList.of("a", "b"), inputs("a/f.js", "b/f.js"), null);
       fail("Expected error");
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("Duplicate module URI"));
@@ -71,7 +71,7 @@ public final class ES6ModuleLoaderTest extends TestCase {
 
   public void testNotFound() throws Exception {
     ES6ModuleLoader loader =
-        new ES6ModuleLoader(ImmutableList.of("a", "b"), inputs("a/a.js", "b/b.js"));
+        new ES6ModuleLoader(ImmutableList.of("a", "b"), inputs("a/a.js", "b/b.js"), null);
     assertNull(
         "a.js' module root is stripped", loader.locateEs6Module("../a/a.js", input("b/b.js")));
   }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -47,7 +47,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         ProcessCommonJSModules processor =
             new ProcessCommonJSModules(
                 compiler,
-                new ES6ModuleLoader(ImmutableList.of("foo/bar/"), compiler.getInputsForTesting()),
+                new ES6ModuleLoader(ImmutableList.of("foo/bar/"), compiler.getInputsForTesting(), null),
                 false);
         processor.process(externs, testCodeScript);
       }


### PR DESCRIPTION
Adds the CLI argument --relocate_common_js_module which takes a path to a module and a mapped path to a replacement for this module. Multiple occurrences are allowed. For example the option --relocate_common_js_module=./proj/libs/1.0.0/=./proj/libs/2.0.0/ will map the require statement "require('./libs/1.0.0/someModule')" to the folder with the version 2.0.0 in the file ./proj/src/main.js.

This allows to compile different versions of a project focused on the referenced module versions without modifying the source code or the file system. (The relocated files must be passed to the compiler, e.g. via --js).

In addition this can be used as workaround for node.js modules that are stored in a node_modules folder and are referenced without a correct relative part.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1380)
<!-- Reviewable:end -->
