### PR TITLE
Remove XMLHttpRequest.prototype.mozResponseArrayBuffer

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2402,6 +2402,9 @@ XMLHttpRequest.prototype.response;
  * Implemented as a draft spec in Firefox 4 as the way to get a requested array
  * buffer from an XMLHttpRequest.
  * @see https://developer.mozilla.org/En/Using_XMLHttpRequest#Receiving_binary_data_using_JavaScript_typed_arrays
+ * 
+ * This property is not used anymore and should be removed.
+ * @see https://github.com/google/closure-compiler/pull/1389
  */
 XMLHttpRequest.prototype.mozResponseArrayBuffer;
 


### PR DESCRIPTION
This property was introduced in Firefox 4 (Gecko 2.0) and it was removed in Firefox 6 (Gecko 6.0). It has been removed from the [documentation] (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest) almost [4 years ago] (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest$compare?to=2362&from=2361).