### PR TITLE
Ensure the source map file property references the full module name

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1327,7 +1327,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
           }
           writeModuleOutput(writer, m);
           if (options.sourceMapOutputPath != null) {
-            compiler.getSourceMap().appendTo(mapFileOut, m.getName());
+            compiler.getSourceMap().appendTo(mapFileOut, getModuleOutputFileName(m));
           }
         }
 


### PR DESCRIPTION
I fixed most of these instances when I added the `--json_streams` flag, however one case slipped by. When using `--module` flags, the source map `file` property did not reference the full module file name (it was missing the `.js` extension).

This property is used by 3rd party tools such as [Mozilla's JS Source Map Library](https://github.com/mozilla/source-map).