### PR TITLE
Be less aggressive with default parameters in VariableReferenceCheck

### DIFF
--- a/test/com/google/javascript/jscomp/Es6VariableReferenceCheckTest.java
+++ b/test/com/google/javascript/jscomp/Es6VariableReferenceCheckTest.java
@@ -327,15 +327,20 @@ public final class Es6VariableReferenceCheckTest extends CompilerTestCase {
    * basic checks.
    */
   public void testDefaultParam() {
-    assertEarlyReferenceError("function f(x=a) {}");
     assertEarlyReferenceError("function f(x=a) { let a; }");
+    assertEarlyReferenceError(LINE_JOINER.join(
+        "function f(x=a) { let a; }",
+        "function g(x=1) { var a; }"));
     assertEarlyReferenceError("function f(x=a) { var a; }");
     assertEarlyReferenceError("function f(x=a()) { function a() {} }");
     assertEarlyReferenceError("function f(x=[a]) { var a; }");
     assertEarlyReferenceError("function f(x=y, y=2) {}");
+    assertNoWarning("function f(x=a) {}");
     assertNoWarning("function f(x=a) {} var a;");
     assertNoWarning("let b; function f(x=b) { var b; }");
     assertNoWarning("function f(y = () => x, x = 5) { return y(); }");
+    assertNoWarning("function f(x = new foo.bar()) {}");
+    assertNoWarning("var foo = {}; foo.bar = class {}; function f(x = new foo.bar()) {}");
   }
 
   public void testDestructuring() {

--- a/test/com/google/javascript/jscomp/VarCheckTest.java
+++ b/test/com/google/javascript/jscomp/VarCheckTest.java
@@ -280,6 +280,18 @@ public final class VarCheckTest extends Es6CompilerTestCase {
     testSame("function fn(a){ var a = 2; }");
     testError("function fn(){ var b = a; }", VarCheck.UNDEFINED_VAR_ERROR);
 
+    // Default parameters
+    testErrorEs6(
+        "function fn(a = b) { function g(a = 3) { var b; } }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x=a) { let a; }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x=a) { { let a; } }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x=b) { function a(x=1) { var b; } }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x=a) { var a; }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x=a()) { function a() {} }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x=[a]) { var a; }", VarCheck.UNDEFINED_VAR_ERROR);
+    testErrorEs6("function f(x = new foo.bar()) {}", VarCheck.UNDEFINED_VAR_ERROR);
+    testSameEs6("var foo = {}; foo.bar = class {}; function f(x = new foo.bar()) {}");
+
     testSameEs6("function fn(a = 2){ var b = a; }");
     testSameEs6("function fn(a = 2){ var a = 3; }");
     testSameEs6("function fn({a, b}){ var c = a; }");


### PR DESCRIPTION
Be less aggressive with default parameters in VariableReferenceCheck

When checking default parameters, only report early reference error
if the name refers to a variable defined in the function body scope.

This will prevent reporting early reference error on variables
possibly defined in the outer scope.

Add test cases about undefined variables in default parameters to
VarCheckTest.

Fixes #1397

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1398)
<!-- Reviewable:end -->
