### PR TITLE
Re-add the setClosureEntryPoints method

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -301,6 +301,34 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     return null;
   }
 
+  /**
+   * Helper method to convert the manage closure dependecy options to the new
+   * DependencyMode enum value
+   */
+  static CompilerOptions.DependencyMode depModeFromClosureDepOptions(
+      boolean onlyClosureDependencies, boolean manageClosureDependencies) {
+    if (onlyClosureDependencies) {
+      return CompilerOptions.DependencyMode.STRICT;
+    } else if (manageClosureDependencies) {
+      return CompilerOptions.DependencyMode.LOOSE;
+    } else {
+      return CompilerOptions.DependencyMode.NONE;
+    }
+  }
+
+  /**
+   * Helper method to convert a list of closure entry points a list of the new
+   * ModuleIdentifier values
+   */
+  static List<DependencyOptions.ModuleIdentifier> entryPointsFromClosureEntryPoints(
+      List<String> closureEntryPoints) {
+    List<DependencyOptions.ModuleIdentifier> entryPoints = new ArrayList<>();
+    for(String closureEntryPoint : closureEntryPoints) {
+      entryPoints.add(DependencyOptions.ModuleIdentifier.forClosure(closureEntryPoint));
+    }
+    return entryPoints;
+  }
+
   protected abstract void addWhitelistWarningsGuard(
       CompilerOptions options, File whitelistFile);
 
@@ -2300,25 +2328,6 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     CommandLineConfig setEntryPoints(List<DependencyOptions.ModuleIdentifier> entryPoints) {
       Preconditions.checkNotNull(entryPoints);
       this.entryPoints = entryPoints;
-      return this;
-    }
-
-    /**
-     * Set closure entry points, which makes the compiler only include
-     * those files and sort them in dependency order.
-     *
-     * This method should eventually be replaced with setEntryPoints calls
-     */
-    CommandLineConfig setClosureEntryPoints(List<String> entryPoints) {
-      Preconditions.checkNotNull(entryPoints);
-
-      List<DependencyOptions.ModuleIdentifier> closureEntryPoints = new ArrayList<>();
-
-      for(String entryPoint : entryPoints) {
-        closureEntryPoints.add(DependencyOptions.ModuleIdentifier.forClosure(entryPoint));
-      }
-      this.entryPoints = closureEntryPoints;
-
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2294,12 +2294,27 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     private List<DependencyOptions.ModuleIdentifier> entryPoints = ImmutableList.of();
 
     /**
-     * Set closure entry points, which makes the compiler only include
+     * Set module entry points, which makes the compiler only include
      * those files and sort them in dependency order.
      */
     CommandLineConfig setEntryPoints(List<DependencyOptions.ModuleIdentifier> entryPoints) {
       Preconditions.checkNotNull(entryPoints);
       this.entryPoints = entryPoints;
+      return this;
+    }
+
+    /**
+     * Set closure entry points, which makes the compiler only include
+     * those files and sort them in dependency order.
+     *
+     * This method should eventually be replaced with setEntryPoints calls
+     */
+    CommandLineConfig setClosureEntryPoints(List<String> entryPoints) {
+      Preconditions.checkNotNull(entryPoints);
+
+      for(String entryPoint : entryPoints) {
+        this.entryPoints.add(DependencyOptions.ModuleIdentifier.forClosure(entryPoint));
+      }
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2312,9 +2312,13 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     CommandLineConfig setClosureEntryPoints(List<String> entryPoints) {
       Preconditions.checkNotNull(entryPoints);
 
+      List<DependencyOptions.ModuleIdentifier> closureEntryPoints = new ArrayList<>();
+
       for(String entryPoint : entryPoints) {
-        this.entryPoints.add(DependencyOptions.ModuleIdentifier.forClosure(entryPoint));
+        closureEntryPoints.add(DependencyOptions.ModuleIdentifier.forClosure(entryPoint));
       }
+      this.entryPoints = closureEntryPoints;
+
       return this;
     }
 


### PR DESCRIPTION
setClosureEntryPoints is deprecated, but used internally at Google. This re-adds the method to AbstractCommandLineRunner to aid in migration to the new setEntryPoints signature.