### PR TITLE
Update w3c_audio.js

### DIFF
--- a/externs/browser/w3c_audio.js
+++ b/externs/browser/w3c_audio.js
@@ -51,8 +51,9 @@ AudioContext.prototype.createBuffer =
 
 /**
  * @param {ArrayBuffer} audioData
- * @param {function(AudioBuffer)} successCallback
+ * @param {function(AudioBuffer)=} successCallback
  * @param {function(?)=} errorCallback
+ * @return {!Promise<AudioBuffer>}
  */
 AudioContext.prototype.decodeAudioData =
     function(audioData, successCallback, errorCallback) {};


### PR DESCRIPTION
I have updated the `AudioContext.decodeAudioData` function signature to reflect [the addition of a returned Promise](https://code.google.com/p/chromium/issues/detail?id=420107) and optional success callback. The change has landed in Chrome 49.