### PR TITLE
Add .js files to the Eclipse classpath.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="**/gwt/**|**/debugger/**" including="**/*.java|**/*.properties" kind="src" path="src"/>
+	<classpathentry excluding="**/debugger/**|**/gwt/**" including="**/*.java|**/*.js|**/*.properties" kind="src" path="src"/>
 	<classpathentry including="**/*.java" kind="src" path="gen"/>
 	<classpathentry including="**/*.java" kind="src" output="build/test-classes" path="test"/>
 	<classpathentry kind="lib" path="lib/ant.jar"/>


### PR DESCRIPTION
This allows running some unit tests from Eclipse (the ones loading base.js).