### PR TITLE
Allow code to @export a list of tokens.

### DIFF
--- a/test/com/google/javascript/jscomp/GenerateExportsTest.java
+++ b/test/com/google/javascript/jscomp/GenerateExportsTest.java
@@ -299,4 +299,21 @@ public final class GenerateExportsTest extends Es6CompilerTestCase {
     testSame(code);
     testExternChanges(code, "Object.prototype.foo;");
   }
+
+  public void testExportSymbolsArray() {
+    allowExternsChanges(true);
+    String code = "/** @export */ ['a', 'b'];";
+    testSame(code);
+    testExternChanges(code, "Object.prototype.a; Object.prototype.b;");
+  }
+
+  public void testExportSymbolsArray_onlyStringLiterals() {
+    String code = "/** @export */ ['a', 'b' + 'c'];";
+    testError(code, FindExportableNodes.EXPORT_NOT_STRING_LITERAL);
+  }
+
+  public void testExportSymbolsArray_pureExpression() {
+    String code = "(/** @export */ ['a', 'c']).length;";
+    testError(code, FindExportableNodes.EXPORT_ARRAY_LITERAL_NOT_EXPRESSION);
+  }
 }


### PR DESCRIPTION
E.g.: `/** @export */ ['a', 'b'];`

This is useful for applications that use a reflection based templating language
to tell JSCompiler which tokens are ever used in a template expression. The
intention is to e.g. generate a list of tokens from Angular templates as part of
the compilation process of an app.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1433)
<!-- Reviewable:end -->
