### PR TITLE
Be more strict in es3.js extern

### DIFF
--- a/externs/es3.js
+++ b/externs/es3.js
@@ -1730,7 +1730,7 @@ String.prototype.localeCompare = function(compareString, locales, options) {};
  * expression.
  *
  * @this {String|string}
- * @param {*} regexp
+ * @param {RegExp|string} regexp
  * @return {Array<string>} This should really return an Array with a few
  *     special properties, but we do not have a good way to model this in
  *     our type system. Also see Regexp.prototype.exec.
@@ -1792,7 +1792,7 @@ String.prototype.small = function() {};
 
 /**
  * @this {String|string}
- * @param {*=} opt_separator
+ * @param {(RegExp|string)=} opt_separator
  * @param {number=} opt_limit
  * @return {!Array<string>}
  * @nosideeffects
@@ -1906,8 +1906,8 @@ String.prototype.length;
 
 /**
  * @constructor
- * @param {*=} opt_pattern
- * @param {*=} opt_flags
+ * @param {(RegExp|string)=} opt_pattern
+ * @param {string=} opt_flags
  * @return {!RegExp}
  * @nosideeffects
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
@@ -1915,8 +1915,8 @@ String.prototype.length;
 function RegExp(opt_pattern, opt_flags) {}
 
 /**
- * @param {*} pattern
- * @param {*=} opt_flags
+ * @param {string} pattern
+ * @param {string=} opt_flags
  * @return {void}
  * @modifies {this}
  * @deprecated
@@ -1926,7 +1926,7 @@ function RegExp(opt_pattern, opt_flags) {}
 RegExp.prototype.compile = function(pattern, opt_flags) {};
 
 /**
- * @param {*} str The string to search.
+ * @param {string} str The string to search.
  * @return {Array<string>} This should really return an Array with a few
  *     special properties, but we do not have a good way to model this in
  *     our type system. Also see String.prototype.match.
@@ -1936,7 +1936,7 @@ RegExp.prototype.compile = function(pattern, opt_flags) {};
 RegExp.prototype.exec = function(str) {};
 
 /**
- * @param {*} str The string to search.
+ * @param {string} str The string to search.
  * @return {boolean} Whether the string was matched.
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
  */


### PR DESCRIPTION
Is there some internal reason for `{*}` annotations or am I missing something?

When I compare `String.prototype.match` and `String.prototype.search` methods. I would say that `regexp` param should be the same type for both but it isn't.

And I expect this code to throw some warning:

``` javascript
var r = new RegExp();
r.test([]);
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1438)

<!-- Reviewable:end -->
