### PR TITLE
Added missing HTMLFieldSetElement properties

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -3426,3 +3426,53 @@ HTMLTemplateElement.prototype.content;
  * @see http://www.w3.org/TR/html-imports/#interface-import
  */
 HTMLLinkElement.prototype.import;
+
+
+/**
+ * @return {boolean}
+ * @see https://www.w3.org/TR/html5/forms.html#dom-fieldset-elements
+ */
+HTMLFieldSetElement.prototype.checkValidity = function() {};
+
+/**
+ * @type {HTMLCollection}
+ * @see https://www.w3.org/TR/html5/forms.html#dom-fieldset-elements
+ */
+HTMLFieldSetElement.prototype.elements;
+
+/**
+ * @type {string}
+ * @see https://www.w3.org/TR/html5/forms.html#the-fieldset-element
+ */
+HTMLFieldSetElement.prototype.name;
+
+/**
+ * @param {string} message
+ * @see https://www.w3.org/TR/html5/forms.html#dom-fieldset-elements
+ */
+HTMLFieldSetElement.prototype.setCustomValidity = function(message) {};
+
+/**
+ * @type {string}
+ * @see https://www.w3.org/TR/html5/forms.html#dom-fieldset-type
+ */
+HTMLFieldSetElement.prototype.type;
+
+/**
+ * @type {string}
+ * @see https://www.w3.org/TR/html5/forms.html#the-fieldset-element
+ */
+HTMLFieldSetElement.prototype.validationMessage;
+
+/**
+ * @type {ValidityState}
+ * @see https://www.w3.org/TR/html5/forms.html#the-fieldset-element
+ */
+HTMLFieldSetElement.prototype.validity;
+
+/**
+ * @type {boolean}
+ * @see https://www.w3.org/TR/html5/forms.html#the-fieldset-element
+ */
+HTMLFieldSetElement.prototype.willValidate;
+


### PR DESCRIPTION
[This commit](https://github.com/google/closure-compiler/commit/f98608a07dc43fb3e950a730ca59906179386ffb) added `disabled` property for `HTMLFieldSetElement` but this property is not in [DOM2 specification](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-7365882). I've moved it into `html5.js` extern and added other missing properties according to the [HTML5 specification](https://www.w3.org/TR/html5/forms.html#the-fieldset-element).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1467)
<!-- Reviewable:end -->
