### PR TITLE
Force rewriting of ES6 or CommonJS modules which are imported

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1318,6 +1318,40 @@ public class Compiler extends AbstractCompiler {
         processAMDAndCommonJSModules();
       }
 
+      if (options.lowerFromEs6() || options.transformAMDToCJSModules
+          || options.processCommonJSModules) {
+
+        // Build a map of module identifiers for any input which provides no namespace.
+        // These files could be imported modules which have no exports, but do have side effects.
+        Map<String, CompilerInput> inputModuleIdentifiers = new HashMap<>();
+        for (CompilerInput input : inputs) {
+          if (!input.getProvides().isEmpty())  {
+            continue;
+          }
+
+          DependencyOptions.ModuleIdentifier modInfo =
+              DependencyOptions.ModuleIdentifier.forFile(input.getSourceFile().getOriginalPath());
+
+          inputModuleIdentifiers.put(modInfo.getClosureNamespace(), input);
+        }
+
+        // Find out if any input attempted to import a module that had no exports.
+        // In this case we must force module rewriting to occur on the imported file
+        Map<String, CompilerInput> inputsToRewrite = new HashMap<>();
+        for (CompilerInput input : inputs) {
+          for (String require : input.getRequires()) {
+            if (inputModuleIdentifiers.containsKey(require)
+                && !inputsToRewrite.containsKey(require)) {
+              inputsToRewrite.put(require, inputModuleIdentifiers.get(require));
+            }
+          }
+        }
+
+        if (!inputsToRewrite.isEmpty()) {
+          processEs6Modules(new ArrayList<>(inputsToRewrite.values()), true);
+        }
+      }
+
       hoistExterns();
 
       // Check if the sources need to be re-ordered.
@@ -1474,14 +1508,18 @@ public class Compiler extends AbstractCompiler {
   }
 
   void processEs6Modules() {
+    processEs6Modules(inputs, false);
+  }
+
+  void processEs6Modules(List<CompilerInput> inputsToProcess, boolean forceRewrite) {
     ES6ModuleLoader loader = new ES6ModuleLoader(options.moduleRoots, inputs);
-    for (CompilerInput input : inputs) {
+    for (CompilerInput input : inputsToProcess) {
       input.setCompiler(this);
       Node root = input.getAstRoot(this);
       if (root == null) {
         continue;
       }
-      new ProcessEs6Modules(this, loader, true).processFile(root);
+      new ProcessEs6Modules(this, loader, true).processFile(root, forceRewrite);
     }
   }
 

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -305,9 +305,19 @@ public final class ProcessCommonJSModules implements CompilerPass {
       }
 
       String moduleName = ES6ModuleLoader.toModuleName(loadAddress);
-      Node moduleRef = IR.name(moduleName).srcref(require);
-      parent.replaceChild(require, moduleRef);
       Node script = getCurrentScriptNode(parent);
+
+      // When require("name") is used as a standalone statement (the result isn't used)
+      // it indicates that a module is being loaded for the side effects it produces.
+      // In this case the require statement should just be removed as the goog.require
+      // call inserted will import the module.
+      if (!NodeUtil.isExpressionResultUsed(require) && parent.isExprResult()
+          && NodeUtil.isStatementBlock(parent.getParent())) {
+        parent.getParent().removeChild(parent);
+      } else {
+        Node moduleRef = IR.name(moduleName).srcref(require);
+        parent.replaceChild(require, moduleRef);
+      }
       if (reportDependencies) {
         t.getInput().addRequire(moduleName);
       }

--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -50,11 +50,6 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
           "JSC_LHS_OF_GOOG_REQUIRE_MUST_BE_CONST",
           "The left side of a goog.require() must use ''const'' (not ''let'' or ''var'')");
 
-  static final DiagnosticType USELESS_USE_STRICT_DIRECTIVE =
-      DiagnosticType.warning(
-          "JSC_USELESS_USE_STRICT_DIRECTIVE",
-          "'use strict' is unnecessary in ES6 modules.");
-
   static final DiagnosticType NAMESPACE_IMPORT_CANNOT_USE_STAR =
       DiagnosticType.error(
           "JSC_NAMESPACE_IMPORT_CANNOT_USE_STAR",
@@ -88,6 +83,7 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
   private Set<String> alreadyRequired = new HashSet<>();
 
   private boolean isEs6Module;
+  private boolean forceRewrite;
 
   private boolean reportDependencies;
 
@@ -110,13 +106,18 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
     this.reportDependencies = reportDependencies;
   }
 
-  public void processFile(Node root) {
+  /**
+   * If a file contains an ES6 "import" or "export" statement, or the forceRewrite
+   * option is true, rewrite the source as a module.
+   */
+  public void processFile(Node root, boolean forceRewrite) {
     FindGoogProvideOrGoogModule finder = new FindGoogProvideOrGoogModule();
     NodeTraversal.traverseEs6(compiler, root, finder);
     if (finder.isFound()) {
       return;
     }
-    isEs6Module = false;
+    this.forceRewrite = forceRewrite;
+    isEs6Module = forceRewrite;
     NodeTraversal.traverseEs6(compiler, root, this);
   }
 
@@ -323,7 +324,7 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
       return;
     }
 
-    checkStrictModeDirective(t, script);
+    setStrictModeDirective(t, script);
 
     Preconditions.checkArgument(scriptNodeCount == 1,
         "ProcessEs6Modules supports only one invocation per "
@@ -376,7 +377,7 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
     // Rename vars to not conflict in global scope.
     NodeTraversal.traverseEs6(compiler, script, new RenameGlobalVars(moduleName));
 
-    if (!exportMap.isEmpty()) {
+    if (!exportMap.isEmpty() || forceRewrite) {
       // Add goog.provide call.
       Node googProvide = IR.exprResult(
           IR.call(NodeUtil.newQName(compiler, "goog.provide"),
@@ -401,11 +402,11 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
     compiler.reportCodeChange();
   }
 
-  private static void checkStrictModeDirective(NodeTraversal t, Node n) {
+  private static void setStrictModeDirective(NodeTraversal t, Node n) {
     Preconditions.checkState(n.isScript(), n);
     Set<String> directives = n.getDirectives();
     if (directives != null && directives.contains("use strict")) {
-      t.report(n, USELESS_USE_STRICT_DIRECTIVE);
+      return;
     } else {
       if (directives == null) {
         n.setDirectives(USE_STRICT_ONLY);

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1613,6 +1613,51 @@ public final class CommandLineRunnerTest extends TestCase {
         });
   }
 
+  public void testES6ImportOfFileWithoutImportsOrExports() {
+    args.add("--dependency_mode=NONE");
+    args.add("--language_in=ECMASCRIPT6");
+    setFilename(0, "foo.js");
+    setFilename(1, "app.js");
+    test(
+        new String[] {
+            CompilerTestCase.LINE_JOINER.join(
+                "function foo() { alert('foo'); }",
+                "foo();"),
+            "import './foo';"
+        },
+        new String[] {
+            CompilerTestCase.LINE_JOINER.join(
+                "/** @const */ var module$foo={};",
+                "function foo$$module$foo(){ alert('foo'); }",
+                "foo$$module$foo();"),
+            "'use strict';"
+        });
+  }
+
+  public void testCommonJSRequireOfFileWithoutExports() {
+    args.add("--process_common_js_modules");
+    args.add("--dependency_mode=NONE");
+    args.add("--language_in=ECMASCRIPT6");
+    setFilename(0, "foo.js");
+    setFilename(1, "app.js");
+    test(
+        new String[] {
+            CompilerTestCase.LINE_JOINER.join(
+                "function foo() { alert('foo'); }",
+                "foo();"),
+            "require('./foo');"
+        },
+        new String[] {
+            CompilerTestCase.LINE_JOINER.join(
+                "/** @const */ var module$foo={};",
+                "function foo$$module$foo(){ alert('foo'); }",
+                "foo$$module$foo();"),
+            CompilerTestCase.LINE_JOINER.join(
+                "'use strict';",
+                "/** @const */ var module$app={};")
+        });
+  }
+
   public void testFormattingSingleQuote() {
     testSame("var x = '';");
     assertThat(lastCompiler.toSource()).isEqualTo("var x=\"\";");

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -277,4 +277,14 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  }",
             "};"));
   }
+
+  public void testRequireResultUnused() {
+    setFilename("test");
+    testModules(
+        "require('./other');",
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "goog.require('module$other');")
+    );
+  }
 }

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -607,4 +607,10 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
     testModules("import * as Foo from 'goog:other.Foo';",
         ProcessEs6Modules.NAMESPACE_IMPORT_CANNOT_USE_STAR);
   }
+
+  public void testImportWithoutReferences() {
+    testModules(
+        "import 'other';",
+        "goog.require('module$other');");
+  }
 }


### PR DESCRIPTION
A file is considered a module if it is imported (whether it exports anything or not). This forces module rewriting to occur on files which are imported, but were otherwise unrecognized as a module.

This is accomplished by assuming that after module rewriting, any input that has no provide statements is a potential module. The normalized module identifier for each of these inputs is calculated. If any input attempts to require the normalized module name for one of these files, the file is treated as an ES6 module and rewriting is forced. Since the module didn't export anything, it doesn't matter which type of module it is rewritten as.

This PR also removes the `USELESS_USE_STRICT_DIRECTIVE` warning for ES6 modules. As a file can now be treated as a script or a module. This caused warnings when such code was imported. In addition, "use strict" directives are often inserted by IDE tools automatically and are already removed by the compiler.

Fixes #1220

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1476)
<!-- Reviewable:end -->
