### PR TITLE
Fix Maven build and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ options/arguments in your CUI application.</td>
 
   <tr>
     <td>Version</td>
-    <td>19.0, 20.0</td>
+    <td>20.0</td>
   </tr>
 
   <tr>

--- a/pom-main.xml
+++ b/pom-main.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>20.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -1092,56 +1091,6 @@ public final class CommandLineRunnerTest extends TestCase {
     compileFiles(
         "console.log(\"Hello World\");var a;window.alert(\"Hi Browser\");",
         zipFile1, jsFile1, zipFile2);
-  }
-
-  public void testGlobJs1() throws IOException, FlagUsageException {
-    FlagEntry<JsSourceType> jsFile1 = createJsFile("test1", "var a;");
-    FlagEntry<JsSourceType> jsFile2 = createJsFile("test2", "var b;");
-    // Move test2 to the same directory as test1, also make the filename of test2
-    // lexicographically larger than test1
-    new File(jsFile2.value).renameTo(new File(
-        new File(jsFile1.value).getParentFile() + File.separator + "utest2.js"));
-    String glob = new File(jsFile1.value).getParent() + File.separator + "**.js";
-    compileFiles(
-        "var a;var b;", new FlagEntry<>(JsSourceType.JS, glob));
-  }
-
-  public void testGlobJs2() throws IOException, FlagUsageException {
-    FlagEntry<JsSourceType> jsFile1 = createJsFile("test1", "var a;");
-    FlagEntry<JsSourceType> jsFile2 = createJsFile("test2", "var b;");
-    new File(jsFile2.value).renameTo(new File(
-        new File(jsFile1.value).getParentFile() + File.separator + "utest2.js"));
-    String glob = new File(jsFile1.value).getParent() + File.separator + "*test*.js";
-    compileFiles(
-        "var a;var b;", new FlagEntry<>(JsSourceType.JS, glob));
-  }
-
-  public void testGlobJs3() throws IOException, FlagUsageException {
-    FlagEntry<JsSourceType> jsFile1 = createJsFile("test1", "var a;");
-    FlagEntry<JsSourceType> jsFile2 = createJsFile("test2", "var b;");
-    new File(jsFile2.value).renameTo(new File(
-        new File(jsFile1.value).getParentFile() + File.separator + "test2.js"));
-    // Make sure test2.js is excluded from the inputs when the exclusion
-    // comes after the inclusion
-    String glob1 = new File(jsFile1.value).getParent() + File.separator + "**.js";
-    String glob2 = "!" + new File(jsFile1.value).getParent() + File.separator + "**test2.js";
-    compileFiles(
-        "var a;", new FlagEntry<>(JsSourceType.JS, glob1),
-        new FlagEntry<>(JsSourceType.JS, glob2));
-  }
-
-  public void testGlobJs4() throws IOException, FlagUsageException {
-    FlagEntry<JsSourceType> jsFile1 = createJsFile("test1", "var a;");
-    FlagEntry<JsSourceType> jsFile2 = createJsFile("test2", "var b;");
-    new File(jsFile2.value).renameTo(new File(
-        new File(jsFile1.value).getParentFile() + File.separator + "test2.js"));
-    // Make sure test2.js is excluded from the inputs when the exclusion
-    // comes before the inclusion
-    String glob1 = "!" + new File(jsFile1.value).getParent() + File.separator + "**test2.js";
-    String glob2 = new File(jsFile1.value).getParent() + File.separator + "**.js";
-    compileFiles(
-        "var a;", new FlagEntry<>(JsSourceType.JS, glob1),
-        new FlagEntry<>(JsSourceType.JS, glob2));
   }
 
   public void testGlobJs1() throws IOException, FlagUsageException {


### PR DESCRIPTION
"mvn test" is failing. We cannot use both Guava 19.0 and 20.0-SNAPSHOT after
https://github.com/google/guava/commit/1ef638f369964c1d1f56bd0ae588535c6abd99a4
See https://github.com/google/guava/issues/2380.

Fix by bumping Guava to 20.0-SNAPSHOT in pom-main.xml.

Remove reference to Guava 19 from README.md.

Remove conflicting import statement and duplicate testGlobJs*() methods
from CommandLineRunnerTest.java to fix the Maven build.