### PR TITLE
Fix scanner for Unicode point escape with curly braces

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
@@ -651,15 +651,32 @@ public class Scanner {
     valueBuilder.append(ch);
 
     boolean containsUnicodeEscape = ch == '\\';
+    boolean bracedUnicodeEscape = false;
+    int unicodeEscapeLen = containsUnicodeEscape ? 1 : 0;
 
     ch = peekChar();
     while (isIdentifierPart(ch)
         || ch == '\\'
-        || (ch == '{' && containsUnicodeEscape)
-        || (ch == '}' && containsUnicodeEscape)) {
+        || (ch == '{' && unicodeEscapeLen == 2)
+        || (ch == '}' && bracedUnicodeEscape)) {
       if (ch == '\\') {
         containsUnicodeEscape = true;
       }
+      // Update length of current Unicode escape.
+      if (ch == '\\' || unicodeEscapeLen > 0) {
+        unicodeEscapeLen ++;
+      }
+      // Enter Unicode point escape.
+      if (ch == '{') {
+        bracedUnicodeEscape = true;
+      }
+      // Exit Unicode escape
+      if (ch == '}' || (unicodeEscapeLen >= 6 && !bracedUnicodeEscape)) {
+        bracedUnicodeEscape = false;
+        unicodeEscapeLen = 0;
+      }
+
+      // Add character to token
       valueBuilder.append(nextChar());
       ch = peekChar();
     }

--- a/test/com/google/javascript/jscomp/parsing/NewParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/NewParserTest.java
@@ -2197,14 +2197,21 @@ public final class NewParserTest extends BaseJSTypeTestCase {
 
   public void testUnicodeInIdentifiers() {
     parse("var \\u00fb");
+    parse("var \\u00fbtest\\u00fb");
     parse("Js\\u00C7ompiler");
     parse("Js\\u0043ompiler");
+    parse("if(true){foo=\\u03b5}");
+    parse("if(true){foo=\\u03b5}else bar()");
   }
 
   public void testUnicodePointEscapeInIdentifiers() {
     parse("var \\u{0043}");
+    parse("var \\u{0043}test\\u{0043}");
+    parse("var \\u0043test\\u{0043}");
+    parse("var \\u{0043}test\\u0043");
     parse("Js\\u{0043}ompiler");
     parse("Js\\u{765}ompiler");
+    parse("var \\u0043;{43}");
   }
 
   public void testUnicodePointEscapeStringLiterals() {
@@ -2217,7 +2224,13 @@ public final class NewParserTest extends BaseJSTypeTestCase {
 
   public void testInvalidUnicodePointEscapeInIdentifiers() {
     parseError("var \\u{defg", "Invalid escape sequence");
+    parseError("var \\u{03b5", "Invalid escape sequence");
+    parseError("var \\u43{43}", "Invalid escape sequence");
     parseError("var \\u{defgRestOfIdentifier", "Invalid escape sequence");
+    parseError("var \\u03b5}", "primary expression expected");
+    parseError("var \\u{03b5}}}", "primary expression expected");
+    parseError("var \\u{03b5}{}", "Semi-colon expected");
+    parseError("var \\u0043{43}", "Semi-colon expected");
     parseError("var \\u{DEFG}", "Invalid escape sequence");
     parseError("Js\\u{}ompiler", "Invalid escape sequence");
     // Legal unicode but invalid in identifier


### PR DESCRIPTION
Right curly braces "}" was unconditionally parsed as the same token if there is a Unicode escape string before it. For example, in the following JS code:

`if(foo){foo=\u03b5}else bar()`

"\u03b5}" was parsed as a single token. In this pull request, my code checks if there is already a left curly brace "{" in this token (and if this token contains Unicode escape string) before appending "}".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1488)
<!-- Reviewable:end -->
