### PR TITLE
New lint check: CheckUselessBlocks

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -39,6 +39,7 @@ import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckNullableReturn;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
+import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 import com.google.javascript.jscomp.parsing.ParserRunner;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
@@ -1542,7 +1543,8 @@ public final class DefaultPassConfig extends PassConfig {
           .add(new CheckInterfaces(compiler))
           .add(new CheckJSDocStyle(compiler))
           .add(new CheckPrototypeProperties(compiler))
-          .add(new CheckUnusedPrivateProperties(compiler));
+          .add(new CheckUnusedPrivateProperties(compiler))
+          .add(new CheckUselessBlocks(compiler));
       return combineChecks(compiler, callbacks.build());
     }
   };

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -28,6 +28,7 @@ import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckNullableReturn;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
+import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 import com.google.javascript.jscomp.newtypes.JSTypeCreatorFromJSDoc;
 
 import java.util.HashMap;
@@ -491,6 +492,7 @@ public class DiagnosticGroups {
           CheckRequiresAndProvidesSorted.MULTIPLE_MODULES_IN_FILE,
           CheckRequiresAndProvidesSorted.MODULE_AND_PROVIDES,
           CheckUnusedPrivateProperties.UNUSED_PRIVATE_PROPERTY,
+          CheckUselessBlocks.USELESS_BLOCK,
           Es6RewriteArrowFunction.THIS_REFERENCE_IN_ARROWFUNC_OF_OBJLIT,
           RhinoErrorReporter.JSDOC_MISSING_BRACES_WARNING,
           RhinoErrorReporter.JSDOC_MISSING_TYPE_WARNING,

--- a/src/com/google/javascript/jscomp/LintPassConfig.java
+++ b/src/com/google/javascript/jscomp/LintPassConfig.java
@@ -23,6 +23,7 @@ import com.google.javascript.jscomp.lint.CheckInterfaces;
 import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
+import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 
 import java.util.List;
 
@@ -107,7 +108,8 @@ class LintPassConfig extends PassConfig.PassConfigDelegate {
                   new CheckArguments(compiler),
                   new CheckEnums(compiler),
                   new CheckInterfaces(compiler),
-                  new CheckPrototypeProperties(compiler)));
+                  new CheckPrototypeProperties(compiler),
+                  new CheckUselessBlocks(compiler)));
         }
       };
 

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -2417,7 +2417,7 @@ public final class NodeUtil {
   /**
    * see {@link #isClassDeclaration}
    */
-  static boolean isClassDeclaration(Node n) {
+  public static boolean isClassDeclaration(Node n) {
     return n.isClass() && isDeclarationParent(n.getParent());
   }
 

--- a/src/com/google/javascript/jscomp/lint/CheckUselessBlocks.java
+++ b/src/com/google/javascript/jscomp/lint/CheckUselessBlocks.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp.lint;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.DiagnosticType;
+import com.google.javascript.jscomp.HotSwapCompilerPass;
+import com.google.javascript.jscomp.NodeTraversal;
+import com.google.javascript.jscomp.NodeTraversal.Callback;
+import com.google.javascript.jscomp.NodeUtil;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.Token;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Check for useless blocks. A block is considered useful if it is part of a
+ * control structure like if / else / while / switch / etc. or if it contains
+ * any block-scoped variables (let, const, class, or function declarations).
+ * Otherwise there is no reason to use it so it is likely a mistake. This would
+ * catch the classic error:
+ *
+ * return
+ *     {foo: 'bar'};
+ *
+ * or more contrived cases like:
+ *
+ * if (denied) {
+ *   showAccessDenied();
+ * } {
+ *   grantAccess();
+ * }
+ *
+ * Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-lone-blocks.js)
+ */
+public final class CheckUselessBlocks implements Callback, HotSwapCompilerPass {
+  public static final DiagnosticType USELESS_BLOCK = DiagnosticType.warning(
+      "JSC_USELESS_BLOCK", "Useless block.");
+
+  private final AbstractCompiler compiler;
+  private Deque<Node> loneBlocks;
+
+  public CheckUselessBlocks(AbstractCompiler compiler) {
+    this.compiler = compiler;
+    this.loneBlocks = new ArrayDeque<>();
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    NodeTraversal.traverseEs6(compiler, root, this);
+  }
+
+  @Override
+  public void hotSwapScript(Node scriptRoot, Node originalRoot) {
+    NodeTraversal.traverseEs6(compiler, scriptRoot, this);
+  }
+
+  /**
+   * A lone block is a non-synthetic, not-added BLOCK that is a direct child of
+   * another non-synthetic, not-added BLOCK or a SCRIPT node.
+   */
+  private boolean isLoneBlock(Node n) {
+    Node parent = n.getParent();
+    if (parent != null && (parent.isScript()
+        || (parent.isBlock() && !parent.isSyntheticBlock() && !parent.isAddedBlock()))) {
+      return n.isBlock() && !n.isSyntheticBlock() && !n.isAddedBlock();
+    }
+    return false;
+  }
+
+  /**
+   * Remove the enclosing block of a block-scoped declaration from the loneBlocks stack.
+  */
+  private void allowLoneBlock(Node parent) {
+    if (loneBlocks.isEmpty()) {
+      return;
+    }
+
+    if (loneBlocks.peek() == parent) {
+      loneBlocks.pop();
+    }
+  }
+
+  @Override
+  public final boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
+    switch (n.getType()) {
+      case Token.BLOCK:
+        if (isLoneBlock(n)) {
+          loneBlocks.push(n);
+        }
+        break;
+      case Token.LET:
+      case Token.CONST:
+        allowLoneBlock(parent);
+        break;
+      case Token.CLASS:
+        if (NodeUtil.isClassDeclaration(n)) {
+          allowLoneBlock(parent);
+        }
+        break;
+      case Token.FUNCTION:
+        if (NodeUtil.isFunctionDeclaration(n)) {
+          allowLoneBlock(parent);
+        }
+        break;
+    }
+    return true;
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    if (n.isBlock() && !loneBlocks.isEmpty() && loneBlocks.peek() == n) {
+      loneBlocks.pop();
+      t.report(n, USELESS_BLOCK);
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/lint/CheckUselessBlocksTest.java
+++ b/test/com/google/javascript/jscomp/lint/CheckUselessBlocksTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.lint;
+
+import static com.google.javascript.jscomp.lint.CheckUselessBlocks.USELESS_BLOCK;
+
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.CompilerPass;
+import com.google.javascript.jscomp.Es6CompilerTestCase;
+
+/**
+ * Test case for {@link CheckUselessBlocks}.
+ */
+public final class CheckUselessBlocksTest extends Es6CompilerTestCase {
+  @Override
+  public CompilerPass getProcessor(Compiler compiler) {
+    return new CheckUselessBlocks(compiler);
+  }
+
+  public void testCheckUselessBlocks_noWarning() {
+    testSame("while (foo) { bar(); }");
+    testSame("if (true) { var x = 1; }");
+    testSame("if (foo) { if (bar) { baz(); } }");
+    testSame("function bar() { baz(); }");
+    testSame("function f() { switch (x) { case 1: { return 5; } } }");
+    // TODO(moz): For block-scoped function declaration, we should technically
+    // warn if we are in non-strict mode and the language mode is ES5 or below.
+    testSame("{ function foo() {} }");
+    testSameEs6("let x = 1;");
+    testSameEs6("{ let x = 1; }");
+    testSameEs6("if (true) { let x = 1; }");
+    testSameEs6("{ const y = 1; }");
+    testSameEs6("{ class Foo {} }");
+  }
+
+  public void testCheckUselessBlocks_warning() {
+    testWarning("{}", USELESS_BLOCK);
+    testWarning("{ var f = function() {}; }", USELESS_BLOCK);
+    testWarning("{ var x = 1; }", USELESS_BLOCK);
+    testWarning(LINE_JOINER.join(
+        "function f() {",
+        "  return",
+        "    {foo: 'bar'};",
+        "}"), USELESS_BLOCK);
+    testWarning(LINE_JOINER.join(
+        "if (foo) {",
+        "  bar();",
+        "  {",
+        "    baz();",
+        "  }",
+        "}"), USELESS_BLOCK);
+    testWarning(LINE_JOINER.join(
+        "if (foo) {",
+        "  bar();",
+        "} {",
+        "  baz();",
+        "}"), USELESS_BLOCK);
+    testWarning("function bar() { { baz(); } }", USELESS_BLOCK);
+    testWarningEs6("{ let x = function() {}; {} }", USELESS_BLOCK);
+    testWarningEs6("{ let x = function() { {} }; }", USELESS_BLOCK);
+    testWarningEs6("{ var f = class {}; }", USELESS_BLOCK);
+  }
+}


### PR DESCRIPTION
Check for useless blocks. A block is considered useful if it is part of a
control structure like if / else / while / switch / etc. or if it contains
any block-scoped variables (let, const, class, or function declarations).
Otherwise there is no reason to use it so it is likely a mistake. This would
catch the classic error:

```javascript
return
  {foo: 'bar'};
```

or more contrived cases like:

```javascript
if (denied) {
  showAccessDenied();
} {
  grantAccess();
}
```

Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-lone-blocks.js)

Fixes #1458.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1499)
<!-- Reviewable:end -->