### PR TITLE
Add @SafeVarargs to methods that cause warnings

### DIFF
--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1944,7 +1944,8 @@ public final class CommandLineRunnerTest extends TestCase {
    * @param expectedOutput string representation of expected output.
    * @param entries entries of flags for zip and js files containing source to compile.
    */
-  private void compileFiles(String expectedOutput, FlagEntry<JsSourceType>... entries)
+  @SafeVarargs
+  private final void compileFiles(String expectedOutput, FlagEntry<JsSourceType>... entries)
       throws FlagUsageException {
     for (FlagEntry<JsSourceType> entry : entries) {
       args.add("--" + entry.flag.flagName + "=" + entry.value);
@@ -1957,7 +1958,8 @@ public final class CommandLineRunnerTest extends TestCase {
    * @param expectedOutput string representation of expected output.
    * @param entries entries of flags for js files containing source to compile.
    */
-  private void compileJsFiles(String expectedOutput, FlagEntry<JsSourceType>... entries)
+  @SafeVarargs
+  private final void compileJsFiles(String expectedOutput, FlagEntry<JsSourceType>... entries)
       throws FlagUsageException {
     args.add("--js");
     for (FlagEntry<JsSourceType> entry : entries) {


### PR DESCRIPTION
This removes multiple warnings about potentially unsafe operations
on varargs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1500)
<!-- Reviewable:end -->
