### PR TITLE
Cap jvm memory usage in pom-main.xml to prevent Travis from killing it

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -209,6 +209,7 @@
         <configuration>
           <!-- <parallel>classes</parallel>
           <threadCount>4</threadCount> -->
+          <argLine>-Xmx1G</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Pass -Xmx1G to maven-surefire-plugin.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1501)
<!-- Reviewable:end -->
