### PR TITLE
New lint check: CheckDuplicateCase

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -32,6 +32,7 @@ import com.google.javascript.jscomp.ExtractPrototypeMemberDeclarations.Pattern;
 import com.google.javascript.jscomp.NodeTraversal.Callback;
 import com.google.javascript.jscomp.PassFactory.HotSwapPassFactory;
 import com.google.javascript.jscomp.lint.CheckArguments;
+import com.google.javascript.jscomp.lint.CheckDuplicateCase;
 import com.google.javascript.jscomp.lint.CheckEmptyStatements;
 import com.google.javascript.jscomp.lint.CheckEnums;
 import com.google.javascript.jscomp.lint.CheckForInOverArray;
@@ -1540,6 +1541,7 @@ public final class DefaultPassConfig extends PassConfig {
     protected HotSwapCompilerPass create(AbstractCompiler compiler) {
       ImmutableList.Builder<Callback> callbacks = ImmutableList.<Callback>builder()
           .add(new CheckArguments(compiler))
+          .add(new CheckDuplicateCase(compiler))
           .add(new CheckEmptyStatements(compiler))
           .add(new CheckEnums(compiler))
           .add(new CheckInterfaces(compiler))

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.lint.CheckArguments;
+import com.google.javascript.jscomp.lint.CheckDuplicateCase;
 import com.google.javascript.jscomp.lint.CheckEmptyStatements;
 import com.google.javascript.jscomp.lint.CheckEnums;
 import com.google.javascript.jscomp.lint.CheckForInOverArray;
@@ -470,6 +471,7 @@ public class DiagnosticGroups {
   public static final DiagnosticGroup LINT_CHECKS =
       DiagnosticGroups.registerGroup("lintChecks", // undocumented
           CheckArguments.BAD_ARGUMENTS_USAGE,
+          CheckDuplicateCase.DUPLICATE_CASE,
           CheckEmptyStatements.USELESS_EMPTY_STATEMENT,
           CheckEnums.DUPLICATE_ENUM_VALUE,
           CheckEnums.COMPUTED_PROP_NAME_IN_ENUM,

--- a/src/com/google/javascript/jscomp/LintPassConfig.java
+++ b/src/com/google/javascript/jscomp/LintPassConfig.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.NodeTraversal.Callback;
 import com.google.javascript.jscomp.lint.CheckArguments;
+import com.google.javascript.jscomp.lint.CheckDuplicateCase;
 import com.google.javascript.jscomp.lint.CheckEmptyStatements;
 import com.google.javascript.jscomp.lint.CheckEnums;
 import com.google.javascript.jscomp.lint.CheckInterfaces;
@@ -107,6 +108,7 @@ class LintPassConfig extends PassConfig.PassConfigDelegate {
               compiler,
               ImmutableList.<Callback>of(
                   new CheckArguments(compiler),
+                  new CheckDuplicateCase(compiler),
                   new CheckEmptyStatements(compiler),
                   new CheckEnums(compiler),
                   new CheckInterfaces(compiler),

--- a/src/com/google/javascript/jscomp/lint/CheckDuplicateCase.java
+++ b/src/com/google/javascript/jscomp/lint/CheckDuplicateCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp.lint;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.DiagnosticType;
+import com.google.javascript.jscomp.HotSwapCompilerPass;
+import com.google.javascript.jscomp.NodeTraversal;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.rhino.Node;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Check for duplicate case labels in a switch statement
+ * Eg:
+ *   switch (foo) {
+ *     case 1:
+ *     case 1:
+ *   }
+ *
+ * This is normally an indication of a programmer error.
+ *
+ * Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-duplicate-case.js)
+ *
+ * TODO(moz): Move this into {@link CheckSuspiciousCode}.
+ */
+public final class CheckDuplicateCase extends AbstractPostOrderCallback
+    implements HotSwapCompilerPass {
+  public static final DiagnosticType DUPLICATE_CASE = DiagnosticType.warning(
+      "JSC_DUPLICATE_CASE", "Duplicate case in a switch statement.");
+
+  private final AbstractCompiler compiler;
+
+  public CheckDuplicateCase(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    NodeTraversal.traverseEs6(compiler, root, this);
+  }
+
+  @Override
+  public void hotSwapScript(Node scriptRoot, Node originalRoot) {
+    NodeTraversal.traverseEs6(compiler, scriptRoot, this);
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    if (n.isSwitch()) {
+      Set<String> cases = new HashSet<>();
+      for (Node curr = n.getSecondChild(); curr != null; curr = curr.getNext()) {
+        String source = compiler.toSource(curr.getFirstChild());
+        if (cases.contains(source)) {
+          t.report(curr, DUPLICATE_CASE);
+        } else {
+          cases.add(source);
+        }
+      }
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/lint/CheckDuplicateCaseTest.java
+++ b/test/com/google/javascript/jscomp/lint/CheckDuplicateCaseTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.lint;
+
+import static com.google.javascript.jscomp.lint.CheckDuplicateCase.DUPLICATE_CASE;
+
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.CompilerPass;
+import com.google.javascript.jscomp.Es6CompilerTestCase;
+
+/**
+ * Test case for {@link CheckDuplicateCase}.
+ */
+public final class CheckDuplicateCaseTest extends Es6CompilerTestCase {
+  @Override
+  public CompilerPass getProcessor(Compiler compiler) {
+    return new CheckDuplicateCase(compiler);
+  }
+
+  public void testCheckDuplicateCase_noWarning() {
+    testSame("switch (foo) { case 1: break; case 2: break; }");
+    testSame("switch (foo) { case 1: break; case '1': break; }");
+    testSame("switch (foo) { case bar: break; case 'bar': break; }");
+    testSame("switch (foo) { case 1: break; } switch (bar) { case 1: break; }");
+  }
+
+  public void testCheckDuplicateCase_warning() {
+    testWarning("switch (foo) { case 1: var a = 3; case 1: break; }", DUPLICATE_CASE);
+    testWarning("switch (foo) { case 1: break; case 2: break; case 1: break; }", DUPLICATE_CASE);
+    testWarning("switch (foo) { case '1': break; case '1': break; }", DUPLICATE_CASE);
+    testWarning("switch (foo) { case bar: break; case bar: break; }", DUPLICATE_CASE);
+    testWarning("switch (foo) { case i++: break; case i++: break; }", DUPLICATE_CASE);
+  }
+}


### PR DESCRIPTION
Check for duplicate case labels in a switch statement
Eg:
```javascript
switch (foo) {
  case 1:
  case 1:
}
```
This is normally an indication of a programmer error.

Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-duplicate-case.js)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1510)
<!-- Reviewable:end -->
