### PR TITLE
Turn on compareJsDoc in InferJSDocInfoTest

### DIFF
--- a/src/com/google/javascript/rhino/JSDocInfoBuilder.java
+++ b/src/com/google/javascript/rhino/JSDocInfoBuilder.java
@@ -272,8 +272,7 @@ public final class JSDocInfoBuilder {
           lineno, charno + name.length());
       currentMarker.setName(position);
 
-      SourcePosition<Node> nodePos =
-          new JSDocInfo.NamePosition();
+      JSDocInfo.NamePosition nodePos = new JSDocInfo.NamePosition();
       Node node = Node.newString(Token.NAME, name, lineno, charno);
       node.setLength(name.length());
       node.setStaticSourceFile(file);

--- a/test/com/google/javascript/jscomp/InferJSDocInfoTest.java
+++ b/test/com/google/javascript/jscomp/InferJSDocInfoTest.java
@@ -49,16 +49,6 @@ public final class InferJSDocInfoTest extends CompilerTestCase {
   private TypedScope globalScope;
 
   @Override
-  public void setUp() {
-    compareJsDoc = false;
-  }
-
-  @Override
-  public int getNumRepetitions() {
-    return 1;
-  }
-
-  @Override
   protected CompilerOptions getOptions() {
     CompilerOptions options = super.getOptions();
     options.setIdeMode(true);


### PR DESCRIPTION
This requires fixing JSDocInfo.areEquivalent().

Part of #1396.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1511)
<!-- Reviewable:end -->
