### PR TITLE
Simplify !IArrayLike|!Array to !IArrayLike in ES6 Array polyfills

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/array.js
+++ b/src/com/google/javascript/jscomp/js/es6/array.js
@@ -96,7 +96,7 @@ $jscomp.array.findInternal_ = function(array, callback, thisArg) {
  * relies on the compiler to check the validity of inputs rather
  * than producing spec-compliant TypeErrors.
  *
- * @param {!IArrayLike<INPUT>|!Iterator<INPUT>|!Iterable<INPUT>|!Array<INPUT>}
+ * @param {!IArrayLike<INPUT>|!Iterator<INPUT>|!Iterable<INPUT>}
  *     arrayLike An array-like or iterable.
  * @param {(function(this: THIS, INPUT): OUTPUT)=} opt_mapFn
  *     Function to call on each argument.


### PR DESCRIPTION
After 9d52fed2c7da2a9e3807477c852c60b56edd2497, Array implements
IArrayLike, so the union type can be simplified.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1530)
<!-- Reviewable:end -->
