### PR TITLE
Add "indeterminate" attribute to HTMLInputElement extern

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -1275,6 +1275,12 @@ HTMLInputElement.prototype.dirname;
 /** @type {FileList} */
 HTMLInputElement.prototype.files;
 
+/**
+ * @type {boolean}
+ * @see https://www.w3.org/TR/html5/forms.html#dom-input-indeterminate
+ */
+HTMLInputElement.prototype.indeterminate;
+
 /** @type {string} */
 HTMLInputElement.prototype.list;
 


### PR DESCRIPTION
HTML5 defines an indeterminate attribute for checkboxes.

Patch from @xavi.

Closes #154.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1535)
<!-- Reviewable:end -->
