### PR TITLE
Adding CompilerOption.reportOTIErrorsUnderNTI

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -348,7 +348,9 @@ public class Compiler extends AbstractCompiler {
     // But we do not want to see the warnings from OTI.
     if (options.getNewTypeInference()) {
       options.checkTypes = true;
-      options.setWarningLevel(DiagnosticGroups.OLD_CHECK_TYPES, CheckLevel.OFF);
+      if (!options.reportOTIErrorsUnderNTI) {
+        options.setWarningLevel(DiagnosticGroups.OLD_CHECK_TYPES, CheckLevel.OFF);
+      }
       options.setWarningLevel(
           DiagnosticGroup.forType(RhinoErrorReporter.TYPE_PARSE_ERROR),
           CheckLevel.WARNING);

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -134,6 +134,15 @@ public class CompilerOptions {
   boolean inferTypes;
 
   private boolean useNewTypeInference;
+  
+  /**
+   * Relevant only when {@link #useNewTypeInference} is true, where we normally disable OTI errors.
+   * If you want both NTI and OTI errors in this case, set to true.
+   * E.g. if using using a warnings guard to filter NTI or OTI warnings in new or legacy code,
+   * respectively.
+   * This will be removed when NTI entirely replaces OTI.
+   */
+  boolean reportOTIErrorsUnderNTI = false;
 
   /**
    * Configures the compiler to skip as many passes as possible.
@@ -1760,7 +1769,12 @@ public class CompilerOptions {
     this.useNewTypeInference = enable;
   }
 
-  /**
+  // Not dead code; used by the open-source users of the compiler.
+  public void setReportOTIErrorsUnderNTI(boolean enable) {
+    this.reportOTIErrorsUnderNTI = enable;
+  }
+
+/**
    * @return Whether assumeStrictThis is set.
    */
   public boolean assumeStrictThis() {

--- a/src/com/google/javascript/jscomp/TypedScopeCreator.java
+++ b/src/com/google/javascript/jscomp/TypedScopeCreator.java
@@ -212,7 +212,7 @@ final class TypedScopeCreator implements ScopeCreator {
   }
 
   private void report(JSError error) {
-    if (!this.runsAfterNTI) {
+    if (!this.runsAfterNTI || compiler.getOptions().reportOTIErrorsUnderNTI) {
       compiler.report(error);
     }
   }


### PR DESCRIPTION
This allows you to opt-in to OTI errors when NTI is enabled.

Fixes https://github.com/google/closure-compiler/issues/1525

To support compiling a large codebase with both NTI and OTI, using warnings guards to filter out by path NTI warnings in the old code, and OTI warnings in the new code.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1537)
<!-- Reviewable:end -->
