### PR TITLE
Run FlowSensitiveInlineVariables once before InlineFunctions

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -612,6 +612,13 @@ public final class DefaultPassConfig extends PassConfig {
 
     passes.add(createEmptyPass("beforeMainOptimizations"));
 
+    // Because FlowSensitiveInlineVariables does not operate on the global scope due to compilation
+    // time, we need to run it once before InlineFunctions so that we don't miss inlining
+    // opportunities when a function will be inlined into the global scope.
+    if (options.flowSensitiveInlineVariables) {
+      passes.add(flowSensitiveInlineVariables);
+    }
+
     passes.addAll(getMainOptimizationLoop());
 
     passes.add(createEmptyPass("beforeModuleMotion"));

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -1613,6 +1613,22 @@ public final class IntegrationTest extends IntegrationTestCase {
         "}");
   }
 
+  // Github issue #1540: https://github.com/google/closure-compiler/issues/1540
+  public void testFlowSensitiveInlineVariablesUnderAdvanced() {
+    CompilerOptions options = createCompilerOptions();
+    CompilationLevel level = CompilationLevel.ADVANCED_OPTIMIZATIONS;
+    level.setOptionsForCompilationLevel(options);
+    test(options,
+        LINE_JOINER.join(
+            "function f(x) {",
+            "  var a = x + 1;",
+            "  var b = x + 1;",
+            "  window.c = x > 5 ? a : b;",
+            "}",
+            "f(g);"),
+            "window.a = g + 1;");
+  }
+
   public void testCollapseAnonymousFunctions() {
     CompilerOptions options = createCompilerOptions();
     String code = "var f = function() {};";
@@ -2470,8 +2486,7 @@ public final class IntegrationTest extends IntegrationTestCase {
         + "  a = a + 'y';\n"
         + "  return a;\n"
         + "}",
-        // This should eventually get inlined completely.
-        "function f(a) { a += 'x'; return a += 'y'; }");
+        "function f(a) { return a += 'xy'; }");
   }
 
   public void testIssue1168() {


### PR DESCRIPTION
Because FlowSensitiveInlineVariables does not operate on the global
scope due to compilation time, we need to run it once before
InlineFunctions so that we don't miss inlining opportunities when a
function is inlined into the global scope.

Fixes #1540.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1541)
<!-- Reviewable:end -->
