### PR TITLE
Preserve file order when using '--js <files>' with CommandlineRunner

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -757,7 +758,7 @@ public class CommandLineRunner extends
             mixedSources.remove(new FlagEntry<>(JsSourceType.JS, filename));
           }
         } else {
-          for (String filename : findJsFiles(Collections.singletonList(source.value))) {
+          for (String filename : findJsFiles(Collections.singletonList(source.value), true)) {
             if (!excludes.contains(filename)) {
               mixedSources.add(new FlagEntry<>(JsSourceType.JS, filename));
             }
@@ -1503,7 +1504,20 @@ public class CommandLineRunner extends
    * within the directory and sub-directories.
    */
   public static List<String> findJsFiles(Collection<String> patterns) throws IOException {
-    Set<String> allJsInputs = new TreeSet<>();
+    return findJsFiles(patterns, false);
+  }
+
+  /**
+   * Returns all the JavaScript files from the set of patterns.
+   *
+   * @param patterns A collection of filename patterns.
+   * @param sortAlphabetically Whether the output filenames should be in alphabetical order.
+   * @return The list of JS filenames found by expanding the patterns.
+   */
+  private static List<String> findJsFiles(Collection<String> patterns, boolean sortAlphabetically)
+      throws IOException {
+    Set<String> allJsInputs = sortAlphabetically
+        ? new TreeSet<String>() : new LinkedHashSet<String>();
     Set<String> excludes = new HashSet<>();
     for (String pattern : patterns) {
       if (!pattern.contains("*") && !pattern.startsWith("!")) {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1094,9 +1094,11 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testInputMultipleJsFilesWithOneJsFlag() throws IOException, FlagUsageException {
+    // Test that file order is preserved with --js test3.js test2.js test1.js
     FlagEntry<JsSourceType> jsFile1 = createJsFile("test1", "var a;");
     FlagEntry<JsSourceType> jsFile2 = createJsFile("test2", "var b;");
-    compileJsFiles("var a;var b;", jsFile1, jsFile2);
+    FlagEntry<JsSourceType> jsFile3 = createJsFile("test3", "var c;");
+    compileJsFiles("var c;var b;var a;", jsFile3, jsFile2, jsFile1);
   }
 
   public void testGlobJs1() throws IOException, FlagUsageException {


### PR DESCRIPTION
Use LinkedHashSet instead of TreeSet when we are dealing with cases
like '--js test3.js test2.js test1.js'.

For cases like '--js=*.js', keep using a TreeSet to preserve
alphabetical order by filename.

Fixes #1548.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1549)
<!-- Reviewable:end -->
