### PR TITLE
Fix class name not properly scoped to CLASS

### DIFF
--- a/src/com/google/javascript/jscomp/Es6SyntacticScopeCreator.java
+++ b/src/com/google/javascript/jscomp/Es6SyntacticScopeCreator.java
@@ -98,15 +98,28 @@ class Es6SyntacticScopeCreator implements ScopeCreator {
           declareLHS(scope, a);
         }
       }
-
       // Since we create a separate scope for body, stop scanning here
+
+    } else if (n.isClass()) {
+      if (scope.getParent() != null) {
+        inputId = NodeUtil.getInputId(n);
+      }
+
+      final Node classNameNode = n.getFirstChild();
+      // Bleed the class name into the scope, if it hasn't
+      // been declared in the outer scope.
+      if (!classNameNode.isEmpty()) {
+        if (NodeUtil.isClassExpression(n)) {
+          declareVar(classNameNode);
+        }
+      }
     } else if (n.isBlock() || n.isFor() || n.isForOf() || n.isSwitch()) {
       if (scope.getParent() != null) {
         inputId = NodeUtil.getInputId(n);
       }
       scanVars(n);
     } else {
-      // It's the global block
+      // n is the global SCRIPT node
       Preconditions.checkState(scope.getParent() == null);
       scanVars(n);
     }
@@ -262,8 +275,8 @@ class Es6SyntacticScopeCreator implements ScopeCreator {
   private boolean isNodeAtCurrentLexicalScope(Node n) {
     Node parent = n.getParent();
     Node grandparent = parent.getParent();
-    Preconditions.checkState(parent.isBlock() || parent.isFor()
-        || parent.isForOf() || parent.isScript() || parent.isLabel());
+    Preconditions.checkState(parent.isBlock() || parent.isFor() || parent.isForOf()
+        || parent.isScript() || parent.isLabel(), parent);
 
     if (parent.isSyntheticBlock()
         && grandparent != null && (grandparent.isCase() || grandparent.isDefaultCase())) {

--- a/src/com/google/javascript/jscomp/NodeTraversal.java
+++ b/src/com/google/javascript/jscomp/NodeTraversal.java
@@ -605,6 +605,8 @@ public class NodeTraversal {
 
     if (type == Token.FUNCTION) {
       traverseFunction(n, parent);
+    } else if (type == Token.CLASS) {
+      traverseClass(n, parent);
     } else if (useBlockScope && NodeUtil.createsBlockScope(n)) {
       traverseBlockScope(n);
     } else {
@@ -631,7 +633,7 @@ public class NodeTraversal {
         && NodeUtil.isFunctionExpression(n);
 
     if (!isFunctionExpression) {
-      // Functions declarations are in the scope containing the declaration.
+      // Function declarations are in the scope containing the declaration.
       traverseBranch(fnName, n);
     }
 
@@ -652,6 +654,39 @@ public class NodeTraversal {
 
     // Body
     // ES6 "arrow" function may not have a block as a body.
+    traverseBranch(body, n);
+
+    popScope();
+  }
+
+  /** Traverses a class. */
+  private void traverseClass(Node n, Node parent) {
+    Preconditions.checkState(n.getChildCount() == 3, n);
+    Preconditions.checkState(n.isClass());
+
+    final Node className = n.getFirstChild();
+    boolean isClassExpression = NodeUtil.isClassExpression(n);
+
+    if (!isClassExpression) {
+      // Class declarations are in the scope containing the declaration.
+      traverseBranch(className, n);
+    }
+
+    curNode = n;
+    pushScope(n);
+
+    if (isClassExpression) {
+      // Class expression names are only accessible within the class scope.
+      traverseBranch(className, n);
+    }
+
+    final Node extendsClause = className.getNext();
+    final Node body = extendsClause.getNext();
+
+    // Extends
+    traverseBranch(extendsClause, n);
+
+    // Body
     traverseBranch(body, n);
 
     popScope();
@@ -805,7 +840,7 @@ public class NodeTraversal {
   /**
    * Determines whether the hoist scope of the current traversal is global.
    */
-  boolean inGlobalHoistScope() {
+  public boolean inGlobalHoistScope() {
     return !getCfgRoot().isFunction();
   }
 

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -2274,6 +2274,7 @@ public final class NodeUtil {
       case Token.FOR:
       case Token.FOR_OF:
       case Token.SWITCH:
+      case Token.CLASS:
         return true;
     }
     return false;

--- a/src/com/google/javascript/jscomp/ReferenceCollectingCallback.java
+++ b/src/com/google/javascript/jscomp/ReferenceCollectingCallback.java
@@ -300,6 +300,7 @@ class ReferenceCollectingCallback implements ScopedCallback,
         case Token.TRY:
         case Token.WHILE:
         case Token.WITH:
+        case Token.CLASS:
           // NOTE: TRY has up to 3 child blocks:
           // TRY
           //   BLOCK

--- a/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java
+++ b/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java
@@ -227,7 +227,7 @@ public final class CheckJSDocStyle extends AbstractPostOrderCallback implements 
    * in the global scope, or a method on a class which is declared in the global scope.
    */
   private boolean isFunctionThatShouldHaveJsDoc(NodeTraversal t, Node function) {
-    if (!t.inGlobalScope()) {
+    if (!t.inGlobalScope() && (!t.getScopeRoot().isClass() || !t.inGlobalHoistScope())) {
       return false;
     }
     if (NodeUtil.isFunctionDeclaration(function)) {

--- a/test/com/google/javascript/jscomp/Es6VariableReferenceCheckTest.java
+++ b/test/com/google/javascript/jscomp/Es6VariableReferenceCheckTest.java
@@ -277,6 +277,10 @@ public final class Es6VariableReferenceCheckTest extends CompilerTestCase {
     assertNoWarning("class A { f() { return 1729; } }");
   }
 
+  public void testRedeclareClassName() {
+    assertNoWarning("var Clazz = class Foo {}; var Foo = 3;");
+  }
+
   public void testClassExtend() {
     assertNoWarning("class A {} class C extends A {} C = class extends A {}");
   }

--- a/test/com/google/javascript/jscomp/SyntacticScopeCreatorTest.java
+++ b/test/com/google/javascript/jscomp/SyntacticScopeCreatorTest.java
@@ -95,4 +95,14 @@ public final class SyntacticScopeCreatorTest extends TestCase {
     assertEquals(fooNode, fooScope.getRootNode());
     assertTrue(fooScope.isDeclared("x", false));
   }
+
+  public void testFunctionExpressionInForLoopInitializer() {
+    Node root = getRoot("for (function foo() {};;) {}");
+    Scope globalScope = scopeCreator.createScope(root, null);
+    assertFalse(globalScope.isDeclared("foo", false));
+
+    Node fNode = root.getFirstChild().getFirstChild();
+    Scope fScope = scopeCreator.createScope(fNode, globalScope);
+    assertTrue(fScope.isDeclared("foo", false));
+  }
 }

--- a/test/com/google/javascript/jscomp/VarCheckTest.java
+++ b/test/com/google/javascript/jscomp/VarCheckTest.java
@@ -173,6 +173,8 @@ public final class VarCheckTest extends Es6CompilerTestCase {
     testSameEs6("class x {}");
     testSameEs6("var x = class x {};");
     testSameEs6("var y = class x {};");
+    testSameEs6("var y = class x { foo() { return new x; } };");
+    testSameEs6("var y = class x extends class { constructor() { x; } } {};");
     testErrorEs6("var Foo = class extends Bar {};", VarCheck.UNDEFINED_VAR_ERROR);
   }
 

--- a/test/com/google/javascript/jscomp/VariableReferenceCheckTest.java
+++ b/test/com/google/javascript/jscomp/VariableReferenceCheckTest.java
@@ -95,6 +95,7 @@ public final class VariableReferenceCheckTest extends Es6CompilerTestCase {
 
   public void testUnreferencedBleedingFunction() {
     assertNoWarning("var x = function y() {}");
+    assertNoWarning("var x = function y() {}; var y = 1;");
   }
 
   public void testReferencedBleedingFunction() {


### PR DESCRIPTION
We need to treat CLASS as a root for a block scope possibly
containing just the "class name" declaration.

See "classScope" in:
http://www.ecma-international.org/ecma-262/6.0/index.html#sec-runtime-semantics-classdefinitionevaluation

Add a few unit tests regarding class names and function names.

Note that our transpilation doesn't support referring to the class name
in a method body yet. Eg:
```js
var Clazz = class Foo {
  bar() {
    return new Foo;
  }
};
```
is currently transpiled to:
```js
/**@constructor @struct */var Clazz = function() {
};
Clazz.prototype.bar = function() {
  return new Foo;
};
```
which does not work at runtime. This will be fixed later.

Part of the fix to #1546.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1551)
<!-- Reviewable:end -->
