### PR TITLE
Use type information if available when folding constants.

### DIFF
--- a/src/com/google/javascript/jscomp/CompilationLevel.java
+++ b/src/com/google/javascript/jscomp/CompilationLevel.java
@@ -187,10 +187,9 @@ public enum CompilationLevel {
         options.disambiguateProperties = true;
         options.ambiguateProperties = true;
         options.inlineProperties = true;
+        options.useTypesForOptimization = true;
         break;
       case SIMPLE_OPTIMIZATIONS:
-        // TODO(johnlenz): enable peephole type based optimization.
-        break;
       case WHITESPACE_ONLY:
         break;
     }

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -475,6 +475,9 @@ public class CompilerOptions {
   /** Chains calls to functions that return this. */
   boolean chainCalls;
 
+  /** Use type information to enable additional optimization opportunities. */
+  boolean useTypesForOptimization;
+
   //--------------------------------
   // Renaming
   //--------------------------------

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -1343,7 +1343,7 @@ public final class DefaultPassConfig extends PassConfig {
             new PeepholeSubstituteAlternateSyntax(late),
             new PeepholeReplaceKnownMethods(late),
             new PeepholeRemoveDeadCode(),
-            new PeepholeFoldConstants(late),
+            new PeepholeFoldConstants(late, options.useTypesForOptimization),
             new PeepholeCollectPropertyAssignments());
     }
   };
@@ -1360,7 +1360,7 @@ public final class DefaultPassConfig extends PassConfig {
             new PeepholeMinimizeConditions(late),
             new PeepholeSubstituteAlternateSyntax(late),
             new PeepholeReplaceKnownMethods(late),
-            new PeepholeFoldConstants(late),
+            new PeepholeFoldConstants(late, options.useTypesForOptimization),
             new ReorderConstantExpression());
     }
   };

--- a/src/com/google/javascript/jscomp/ExpandJqueryAliases.java
+++ b/src/com/google/javascript/jscomp/ExpandJqueryAliases.java
@@ -85,7 +85,7 @@ class ExpandJqueryAliases extends AbstractPostOrderCallback
         new PeepholeSubstituteAlternateSyntax(late),
         new PeepholeReplaceKnownMethods(late),
         new PeepholeRemoveDeadCode(),
-        new PeepholeFoldConstants(late),
+        new PeepholeFoldConstants(late, compiler.getOptions().useTypesForOptimization),
         new PeepholeCollectPropertyAssignments());
   }
 

--- a/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java
+++ b/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java
@@ -326,8 +326,9 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
         for (cur = cond.getNext(); cur != null; cur = next) {
           next = cur.getNext();
           caseLabel = cur.getFirstChild();
+          // TODO(moz): Use type information if allowed.
           caseMatches = PeepholeFoldConstants.evaluateComparison(
-              Token.SHEQ, cond, caseLabel);
+              Token.SHEQ, cond, caseLabel, false);
           if (caseMatches == TernaryValue.TRUE) {
             break;
           } else if (caseMatches == TernaryValue.UNKNOWN) {

--- a/test/com/google/javascript/jscomp/CreateSyntheticBlocksTest.java
+++ b/test/com/google/javascript/jscomp/CreateSyntheticBlocksTest.java
@@ -48,7 +48,7 @@ public final class CreateSyntheticBlocksTest extends Es6CompilerTestCase {
         new PeepholeOptimizationsPass(compiler,
             new PeepholeRemoveDeadCode(),
             new PeepholeMinimizeConditions(true),
-            new PeepholeFoldConstants(true))
+            new PeepholeFoldConstants(true, false))
             .process(externs, js);
         new MinimizeExitPoints(compiler).process(externs, js);
 

--- a/test/com/google/javascript/jscomp/MultiPassTest.java
+++ b/test/com/google/javascript/jscomp/MultiPassTest.java
@@ -185,7 +185,7 @@ public final class MultiPassTest extends CompilerTestCase {
                 new PeepholeSubstituteAlternateSyntax(late),
                 new PeepholeReplaceKnownMethods(late),
                 new PeepholeRemoveDeadCode(),
-                new PeepholeFoldConstants(late),
+                new PeepholeFoldConstants(late, false),
                 new PeepholeCollectPropertyAssignments());
           }
         });

--- a/test/com/google/javascript/jscomp/PeepholeIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeIntegrationTest.java
@@ -36,7 +36,7 @@ public class PeepholeIntegrationTest extends CompilerTestCase {
         new PeepholeMinimizeConditions(late),
         new PeepholeSubstituteAlternateSyntax(late),
         new PeepholeRemoveDeadCode(),
-        new PeepholeFoldConstants(late)
+        new PeepholeFoldConstants(late, false)
       );
 
     return peepholePass;


### PR DESCRIPTION
This is only enabled if `--use_types_for_optimization` is passed via the command line or if `CompilerOptions.useTypesForOptimization` is set to true.
    
Modify NodeUtil.maybeString() and NodeUtil.getNumberValue() to use type information if available and allowed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1553)
<!-- Reviewable:end -->
