### PR TITLE
Restore the JsDoc that seems to have been deleted accidentally

### DIFF
--- a/externs/browser/chrome.js
+++ b/externs/browser/chrome.js
@@ -472,6 +472,13 @@ chrome.runtime.sendMessage = function(
     opt_callback) {};
 
 
+/**
+ * Returns an object representing current load times. Note that the properties
+ * on the object do not change and the function must be called again to get
+ * up-to-date data.
+ *
+ * @return {!ChromeLoadTimes}
+ */
 chrome.loadTimes = function() {};
 
 


### PR DESCRIPTION
42a9a109461c63eb67226c44d7e9703906a8be3b seems to have deleted the
JsDoc accidentally, restore it but leave out the internal-only link.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1559)
<!-- Reviewable:end -->
