### PR TITLE
Make setOutputEncoding() accept String instead of Charset

### DIFF
--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -275,8 +275,8 @@ public final class CompileTask
   /**
    * Set output file encoding
    */
-  public void setOutputEncoding(Charset outputEncoding) {
-    this.outputEncoding = outputEncoding;
+  public void setOutputEncoding(String outputEncoding) {
+    this.outputEncoding = Charset.forName(outputEncoding);
   }
 
   /**


### PR DESCRIPTION
Restore parameter type of setOutputEncoding() to String to work with Ant-configuration

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1564)
<!-- Reviewable:end -->
