### PR TITLE
New lint check: CheckRedundantBooleanCast

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -40,6 +40,7 @@ import com.google.javascript.jscomp.lint.CheckInterfaces;
 import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckNullableReturn;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
+import com.google.javascript.jscomp.lint.CheckRedundantBooleanCast;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
 import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 import com.google.javascript.jscomp.parsing.ParserRunner;
@@ -1547,6 +1548,7 @@ public final class DefaultPassConfig extends PassConfig {
           .add(new CheckInterfaces(compiler))
           .add(new CheckJSDocStyle(compiler))
           .add(new CheckPrototypeProperties(compiler))
+          .add(new CheckRedundantBooleanCast(compiler))
           .add(new CheckUnusedPrivateProperties(compiler))
           .add(new CheckUselessBlocks(compiler));
       return combineChecks(compiler, callbacks.build());

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -29,6 +29,7 @@ import com.google.javascript.jscomp.lint.CheckInterfaces;
 import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckNullableReturn;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
+import com.google.javascript.jscomp.lint.CheckRedundantBooleanCast;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
 import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 import com.google.javascript.jscomp.newtypes.JSTypeCreatorFromJSDoc;
@@ -490,6 +491,7 @@ public class DiagnosticGroups {
           CheckJSDocStyle.OPTIONAL_TYPE_NOT_USING_OPTIONAL_NAME,
           CheckJSDocStyle.WRONG_NUMBER_OF_PARAMS,
           CheckPrototypeProperties.ILLEGAL_PROTOTYPE_MEMBER,
+          CheckRedundantBooleanCast.REDUNDANT_BOOLEAN_CAST,
           CheckRequiresAndProvidesSorted.REQUIRES_NOT_SORTED,
           CheckRequiresAndProvidesSorted.PROVIDES_NOT_SORTED,
           CheckRequiresAndProvidesSorted.PROVIDES_AFTER_REQUIRES,

--- a/src/com/google/javascript/jscomp/LintPassConfig.java
+++ b/src/com/google/javascript/jscomp/LintPassConfig.java
@@ -24,6 +24,7 @@ import com.google.javascript.jscomp.lint.CheckEnums;
 import com.google.javascript.jscomp.lint.CheckInterfaces;
 import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
+import com.google.javascript.jscomp.lint.CheckRedundantBooleanCast;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
 import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 
@@ -113,6 +114,7 @@ class LintPassConfig extends PassConfig.PassConfigDelegate {
                   new CheckEnums(compiler),
                   new CheckInterfaces(compiler),
                   new CheckPrototypeProperties(compiler),
+                  new CheckRedundantBooleanCast(compiler),
                   new CheckUselessBlocks(compiler)));
         }
       };

--- a/src/com/google/javascript/jscomp/lint/CheckRedundantBooleanCast.java
+++ b/src/com/google/javascript/jscomp/lint/CheckRedundantBooleanCast.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp.lint;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.DiagnosticType;
+import com.google.javascript.jscomp.HotSwapCompilerPass;
+import com.google.javascript.jscomp.NodeTraversal;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.Token;
+
+/**
+ * Check for redundant casts to boolean via double negation or a Boolean call.
+ * Eg:
+ *   var foo = !!!bar;
+ *   var foo = Boolean(!!bar);
+ *   if (!!foo) {}
+ *   if (Boolean(foo)) {}
+ *
+ * Inspired by ESLint
+ *   (https://github.com/eslint/eslint/blob/master/lib/rules/no-extra-boolean-cast.js)
+ */
+public final class CheckRedundantBooleanCast extends AbstractPostOrderCallback
+    implements HotSwapCompilerPass {
+  public static final DiagnosticType REDUNDANT_BOOLEAN_CAST =
+      DiagnosticType.warning("JSC_REDUNDANT_BOOLEAN_CAST", "Redundant cast to boolean.");
+
+  private final AbstractCompiler compiler;
+
+  public CheckRedundantBooleanCast(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    NodeTraversal.traverseEs6(compiler, root, this);
+  }
+
+  @Override
+  public void hotSwapScript(Node scriptRoot, Node originalRoot) {
+    NodeTraversal.traverseEs6(compiler, scriptRoot, this);
+  }
+
+  private boolean isInBooleanContext(Node n, Node parent) {
+    switch (parent.getType()) {
+      case Token.IF:
+      case Token.WHILE:
+      case Token.HOOK:
+        return parent.getFirstChild().equals(n);
+      case Token.DO:
+      case Token.FOR:
+        return parent.getSecondChild().equals(n);
+      case Token.NOT:
+        return true;
+    }
+    return false;
+  }
+
+  private boolean isBooleanCall(Node n) {
+    return n.getFirstChild().isName() && n.getFirstChild().getString().equals("Boolean");
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    boolean shouldWarn = false;
+    if (n.isNot() && parent.isNot()) {
+      Node grandParent = parent.getParent();
+      if (isInBooleanContext(parent, grandParent)) {
+        shouldWarn = true;
+      } else if (grandParent.isCall() || grandParent.isNew()) {
+        shouldWarn = isBooleanCall(grandParent);
+      }
+    } else if (n.isCall()) {
+      shouldWarn = isBooleanCall(n) && isInBooleanContext(n, parent);
+    }
+    if (shouldWarn) {
+      t.report(n, REDUNDANT_BOOLEAN_CAST);
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/lint/CheckRedundantBooleanCastTest.java
+++ b/test/com/google/javascript/jscomp/lint/CheckRedundantBooleanCastTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.lint;
+
+import static com.google.javascript.jscomp.lint.CheckRedundantBooleanCast.REDUNDANT_BOOLEAN_CAST;
+
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.CompilerPass;
+import com.google.javascript.jscomp.Es6CompilerTestCase;
+
+/**
+ * Test case for {@link CheckRedundantBooleanCast}.
+ */
+public final class CheckRedundantBooleanCastTest extends Es6CompilerTestCase {
+  @Override
+  public CompilerPass getProcessor(Compiler compiler) {
+    return new CheckRedundantBooleanCast(compiler);
+  }
+
+  public void testCheckRedundantBooleanCast_noWarning() {
+    testSame("var x = !!y;");
+    testSame("var x = Boolean(y)");
+    testSame("function f() { return !!x; }");
+    testSame("var x = y ? !!z : !!w;");
+  }
+
+  public void testCheckRedundantBooleanCast_warning() {
+    testWarning("var x = !!!y;", REDUNDANT_BOOLEAN_CAST);
+    testWarning("var x = !!y ? 1 : 2;", REDUNDANT_BOOLEAN_CAST);
+    testWarning("var x = Boolean(y) ? 1 : 2;", REDUNDANT_BOOLEAN_CAST);
+    testWarning("var x = Boolean(!!y);", REDUNDANT_BOOLEAN_CAST);
+    testWarning("var x = new Boolean(!!y);", REDUNDANT_BOOLEAN_CAST);
+    testWarning("if (!!x) {}", REDUNDANT_BOOLEAN_CAST);
+    testWarning("if (Boolean(x)) {}", REDUNDANT_BOOLEAN_CAST);
+    testWarning("while (!!x) {}", REDUNDANT_BOOLEAN_CAST);
+    testWarning("while (Boolean(x)) {}", REDUNDANT_BOOLEAN_CAST);
+    testWarning("do {} while (!!x)", REDUNDANT_BOOLEAN_CAST);
+    testWarning("do {} while (Boolean(x))", REDUNDANT_BOOLEAN_CAST);
+    testWarning("for (; !!x; ) {}", REDUNDANT_BOOLEAN_CAST);
+    testWarning("for (; Boolean(x); ) {}", REDUNDANT_BOOLEAN_CAST);
+  }
+}


### PR DESCRIPTION
Check for redundant casts to boolean via double negation or a Boolean call.
Eg:
```js
var foo = !!!bar;
var foo = Boolean(!!bar);
if (!!foo) {}
if (Boolean(foo)) {}
```
Inspired by ESLint
  (https://github.com/eslint/eslint/blob/master/lib/rules/no-extra-boolean-cast.js)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1570)
<!-- Reviewable:end -->
