### PR TITLE
Add checkNegatedLeftOperandOfInOperator to CheckSuspiciousCode

### DIFF
--- a/src/com/google/javascript/jscomp/CheckSuspiciousCode.java
+++ b/src/com/google/javascript/jscomp/CheckSuspiciousCode.java
@@ -55,12 +55,18 @@ final class CheckSuspiciousCode extends AbstractPostOrderCallback {
           "JSC_SUSPICIOUS_INSTANCEOF_LEFT",
           "\"instanceof\" with left non-object operand is always false.");
 
+  static final DiagnosticType SUSPICIOUS_NEGATED_LEFT_OPERAND_OF_IN_OPERATOR =
+      DiagnosticType.warning(
+          "JSC_SUSPICIOUS_NEGATED_LEFT_OPERAND_OF_IN_OPERATOR",
+          "Suspicious negated left operand of 'in' operator.");
+
   @Override
   public void visit(NodeTraversal t, Node n, Node parent) {
     checkMissingSemicolon(t, n);
     checkNaN(t, n);
     checkInvalidIn(t, n);
     checkNonObjectInstanceOf(t, n);
+    checkNegatedLeftOperandOfInOperator(t, n);
   }
 
   private void checkMissingSemicolon(NodeTraversal t, Node n) {
@@ -136,5 +142,11 @@ final class CheckSuspiciousCode extends AbstractPostOrderCallback {
       return true;
     }
     return false;
+  }
+
+  private void checkNegatedLeftOperandOfInOperator(NodeTraversal t, Node n) {
+    if (n.isIn() && n.getFirstChild().isNot()) {
+      t.report(n.getFirstChild(), SUSPICIOUS_NEGATED_LEFT_OPERAND_OF_IN_OPERATOR);
+    }
   }
 }

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -450,6 +450,7 @@ public class DiagnosticGroups {
           CheckSuspiciousCode.SUSPICIOUS_COMPARISON_WITH_NAN,
           CheckSuspiciousCode.SUSPICIOUS_IN_OPERATOR,
           CheckSuspiciousCode.SUSPICIOUS_INSTANCEOF_LEFT_OPERAND,
+          CheckSuspiciousCode.SUSPICIOUS_NEGATED_LEFT_OPERAND_OF_IN_OPERATOR,
           TypeCheck.DETERMINISTIC_TEST);
 
   public static final DiagnosticGroup DEPRECATED_ANNOTATIONS =

--- a/test/com/google/javascript/jscomp/CheckSuspiciousCodeTest.java
+++ b/test/com/google/javascript/jscomp/CheckSuspiciousCodeTest.java
@@ -207,4 +207,11 @@ public final class CheckSuspiciousCodeTest extends Es6CompilerTestCase {
     testWarning(left + " instanceof " + right,
         CheckSuspiciousCode.SUSPICIOUS_INSTANCEOF_LEFT_OPERAND);
   }
+
+  public void testCheckNegatedLeftOperandOfInOperator() {
+    testSame("if (!(x in y)) {}");
+    testSame("if (('' + !x) in y) {}");
+    testWarning("if (!x in y) {}",
+        CheckSuspiciousCode.SUSPICIOUS_NEGATED_LEFT_OPERAND_OF_IN_OPERATOR);
+  }
 }


### PR DESCRIPTION
Check for negated left operand of the "in" operator
Eg:
```js
if (!a in b) {}
```
should almost always be
```js
if (!(a in b)) {}
```
or
```js
if (('' + !a) in b) {}
```
instead.

Negated left operand of the "in" operator usually indicates a programmer error.

Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-negated-in-lhs.js)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1571)
<!-- Reviewable:end -->
