### PR TITLE
Allow file based modules as entry points

### DIFF
--- a/src/com/google/javascript/jscomp/JSModuleGraph.java
+++ b/src/com/google/javascript/jscomp/JSModuleGraph.java
@@ -453,7 +453,12 @@ public final class JSModuleGraph {
         CompilerInput entryPointInput = null;
         try {
           if (entryPoint.getClosureNamespace().equals(entryPoint.getModuleName())) {
-            entryPointInput = sorter.getInputProviding(entryPoint.getClosureNamespace());
+            entryPointInput = sorter.maybeGetInputProviding(entryPoint.getClosureNamespace());
+            // Check to see if we can find the entry point as an ES6 and CommonJS module
+            // ES6 and CommonJS entry points may not provide any symbols
+            if (entryPointInput == null) {
+              entryPointInput = sorter.getInputProviding(entryPoint.getName());
+            }
           } else {
             JSModule module = modulesByName.get(entryPoint.getModuleName());
             if (module == null) {

--- a/src/com/google/javascript/jscomp/deps/Es6SortedDependencies.java
+++ b/src/com/google/javascript/jscomp/deps/Es6SortedDependencies.java
@@ -21,12 +21,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 
+import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +55,7 @@ public final class Es6SortedDependencies<INPUT extends DependencyInfo>
   private final List<INPUT> userOrderedInputs = new ArrayList<>();
   private final List<INPUT> importOrderedInputs = new ArrayList<>();
   private final Set<INPUT> completedInputs = new HashSet<>();
-  private final List<INPUT> nonExportingInputs = new ArrayList<>();
+  private final Map<String, INPUT> nonExportingInputs = new LinkedHashMap<>();
   private final Map<String, INPUT> exportingInputBySymbolName = new HashMap<>();
   // Maps an input A to the inputs it depends on, ie, inputs that provide stuff that A requires.
   private final Multimap<INPUT, INPUT> importedInputByImportingInput = LinkedHashMultimap.create();
@@ -92,15 +94,17 @@ public final class Es6SortedDependencies<INPUT extends DependencyInfo>
 
   @Override
   public INPUT getInputProviding(String symbolName) throws MissingProvideException {
-    if (exportingInputBySymbolName.containsKey(symbolName)) {
-      return exportingInputBySymbolName.get(symbolName);
+    INPUT input = maybeGetInputProviding(symbolName);
+    if (input != null) {
+      return input;
     }
+
     throw new MissingProvideException(symbolName);
   }
 
   @Override
   public List<INPUT> getInputsWithoutProvides() {
-    return Collections.unmodifiableList(nonExportingInputs);
+    return ImmutableList.copyOf(nonExportingInputs.values());
   }
 
   @Override
@@ -115,7 +119,38 @@ public final class Es6SortedDependencies<INPUT extends DependencyInfo>
 
   @Override
   public INPUT maybeGetInputProviding(String symbol) {
-    return exportingInputBySymbolName.get(symbol);
+    if (exportingInputBySymbolName.containsKey(symbol)) {
+      return exportingInputBySymbolName.get(symbol);
+    }
+
+    return nonExportingInputs.get(toModuleName(URI.create(symbol)));
+  }
+
+  /**
+   * Turns a filename into a JS identifier that is used for moduleNames in
+   * rewritten code. Removes leading ./, replaces / with $, removes trailing .js
+   * and replaces - with _. All moduleNames get a "module$" prefix.
+   *
+   * @see com.google.javascript.jscomp.ES6ModuleLoader
+   *
+   * TODO(ChadKillingsworth): Switch to using the ModuleIdentifier class once
+   * it no longer causes circular dependencies in Google builds.
+   */
+  private static String toModuleName(URI filename) {
+    String moduleName = filename.toString();
+    if (moduleName.endsWith(".js")) {
+      moduleName = moduleName.substring(0, moduleName.length() - 3);
+    }
+
+    moduleName =
+        moduleName.replaceAll("^\\./", "")
+            .replace("/", "$")
+            .replace('\\', '$')
+            .replace('-', '_')
+            .replace(':', '_')
+            .replace('.', '_')
+            .replace("%20", "_");
+    return "module$" + moduleName;
   }
 
   private void orderInput(INPUT input) {
@@ -136,7 +171,7 @@ public final class Es6SortedDependencies<INPUT extends DependencyInfo>
     // Index.
     for (INPUT userOrderedInput : userOrderedInputs) {
       if (userOrderedInput.getProvides().isEmpty()) {
-        nonExportingInputs.add(userOrderedInput);
+        nonExportingInputs.put(toModuleName(URI.create(userOrderedInput.getName())), userOrderedInput);
       }
       for (String providedSymbolName : userOrderedInput.getProvides()) {
         exportingInputBySymbolName.put(providedSymbolName, userOrderedInput);

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -794,6 +794,33 @@ public final class CompilerTest extends TestCase {
     assertTrue(ast.isEquivalentTo(newInput.getAstRoot(compiler)));
   }
 
+  public void testEs6ModuleEntryPoint() throws Exception {
+    List<SourceFile> inputs = ImmutableList.of(
+        SourceFile.fromCode(
+            "/index.js", "import foo from './foo'; foo('hello');"),
+        SourceFile.fromCode("/foo.js",
+            "export default (foo) => { alert(foo); }"));
+
+    List<ModuleIdentifier> entryPoints = ImmutableList.of(
+        ModuleIdentifier.forFile("/index"));
+
+    CompilerOptions options = createNewFlagBasedOptions();
+    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT6);
+    options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
+    options.dependencyOptions.setDependencyPruning(true);
+    options.dependencyOptions.setDependencySorting(true);
+    options.dependencyOptions.setEntryPoints(entryPoints);
+
+    List<SourceFile> externs =
+        AbstractCommandLineRunner.getBuiltinExterns(options.getEnvironment());
+
+    Compiler compiler = new Compiler();
+    compiler.compile(externs, inputs, options);
+
+    Result result = compiler.getResult();
+    assertThat(result.errors).isEmpty();
+  }
+
   public void testGetEmptyResult() {
     Result result = new Compiler().getResult();
     assertThat(result.errors).isEmpty();


### PR DESCRIPTION
ES6 module rewriting only issues `goog.provide` statements when an `export` keyword is encountered. It is common for an ES6 module entry point to only `import` statements. This PR supports using file based modules as entry points.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1573)
<!-- Reviewable:end -->
