### PR TITLE
Allow "=" in the "this" and "new" type of functional types

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -2153,9 +2153,14 @@ public final class JsDocInfoParser {
           if (match(JsDocToken.COLON)) {
             next();
             skipEOLs();
+            Node type = parseContextTypeExpression(next());
+            if (match(JsDocToken.EQUALS)) {
+              next();
+              skipEOLs();
+              type = wrapNode(Token.EQUALS, type);
+            }
             Node contextType = wrapNode(
-                isThis ? Token.THIS : Token.NEW,
-                parseContextTypeExpression(next()));
+                isThis ? Token.THIS : Token.NEW, type);
             if (contextType == null) {
               return null;
             }

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -463,6 +463,11 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
     testParseType("function()", "function (): ?");
   }
 
+  public void testParseFunctionalType8() throws Exception {
+    // "undefined" is ignored by JSTypeRegistry
+    testParseType("function(this:(Foo|undefined))", "function (this:Foo): ?");
+  }
+
   public void testParseFunctionalType9() throws Exception {
     testParseType(
         "function(this:Array,!Date,...(boolean?))",
@@ -511,6 +516,21 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
     testParseType(
         "function(...?): void",
         "function (...?): undefined");
+  }
+
+  public void testParseFunctionalType20() throws Exception {
+    // "=" is ignored by JSTypeRegistry
+    testParseType("function(this:Foo=)", "function (this:Foo): ?");
+  }
+
+  public void testParseFunctionalTypeError21() throws Exception {
+    // "undefined" is ignored by JSTypeRegistry
+    testParseType("function (new:(Foo|undefined))}", "function (new:Foo): ?");
+  }
+
+  public void testParseFunctionalTypeError22() throws Exception {
+    // "=" is ignored by JSTypeRegistry
+    testParseType("function (new:Foo=)}", "function (new:Foo): ?");
   }
 
   public void testStructuralConstructor() throws Exception {
@@ -625,7 +645,7 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
         "Bad type annotation. type not recognized due to syntax error");
   }
 
-  public void testParseFunctionalType8() throws Exception {
+  public void testParseFunctionalTypeError15() throws Exception {
     parse("@type {function(this:Array,...[boolean])} */",
         "Bad type annotation. type not recognized due to syntax error");
   }


### PR DESCRIPTION
Eg:
```js
/** @type {function(this:Foo=)} */
```
Note that JSTypeRegistry, which is used by OTI, will ignore the optionality and resolve this to "function(this:Foo)". NTI won't ignore it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1575)
<!-- Reviewable:end -->
