### PR TITLE
Move the CommandLineRunner exit code test to the end of the function

### DIFF
--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1884,7 +1884,6 @@ public final class CommandLineRunnerTest extends TestCase {
   private void test(String[] original, String[] compiled, DiagnosticType warning) {
     exitCodes.clear();
     Compiler compiler = compile(original);
-    assertThat(exitCodes).containsExactly(0);
 
     if (warning == null) {
       assertEquals("Expected no warnings or errors\n" +
@@ -1906,6 +1905,8 @@ public final class CommandLineRunnerTest extends TestCase {
           "\nResult: " + compiler.toSource(root) +
           "\n" + explanation, explanation);
     }
+
+    assertThat(exitCodes).containsExactly(0);
   }
 
   /**


### PR DESCRIPTION
Having the assertion at the beginning of the function was hiding more appropriate error messages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1576)
<!-- Reviewable:end -->
