### PR TITLE
Add default languageOut = ECMASCRIPT3 to ant CompileTask

### DIFF
--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -101,7 +101,8 @@ public final class CompileTask
   private String sourceMapLocationMapping;
 
   public CompileTask() {
-    this.languageIn = CompilerOptions.LanguageMode.ECMASCRIPT3;
+    this.languageIn = CompilerOptions.LanguageMode.ECMASCRIPT6;
+    this.languageOut = CompilerOptions.LanguageMode.ECMASCRIPT3;
     this.warningLevel = WarningLevel.DEFAULT;
     this.debugOptions = false;
     this.compilationLevel = CompilationLevel.SIMPLE_OPTIMIZATIONS;


### PR DESCRIPTION
Also change the default languageIn to ECMASCRIPT6 to match the
compiler's current default setting.

Fixes #1579.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1580)
<!-- Reviewable:end -->
