### PR TITLE
[NTI] Improve handling of instanceof

### DIFF
--- a/src/com/google/javascript/jscomp/NewTypeInference.java
+++ b/src/com/google/javascript/jscomp/NewTypeInference.java
@@ -1607,7 +1607,14 @@ final class NewTypeInference implements CompilerPass {
       objPair = analyzeExprFwd(obj, inEnv, JSType.UNKNOWN, instanceSpecType);
       ctorPair = analyzeExprFwd(ctor, objPair.env, commonTypes.topFunction());
     }
-    ctorPair.type = JSType.BOOLEAN;
+    if (instanceSpecType.isBottom()
+        || (specializedType.isFalseOrFalsy() && objType.equals(instanceSpecType))) {
+      ctorPair.type = JSType.FALSE_TYPE;
+    } else if (specializedType.isTrueOrTruthy() && objType.equals(instanceSpecType)) {
+      ctorPair.type = JSType.TRUE_TYPE;
+    } else {
+      ctorPair.type = JSType.BOOLEAN;
+    }
     return ctorPair;
   }
 

--- a/test/com/google/javascript/jscomp/NewTypeInferenceES5OrLowerTest.java
+++ b/test/com/google/javascript/jscomp/NewTypeInferenceES5OrLowerTest.java
@@ -3359,6 +3359,15 @@ public final class NewTypeInferenceES5OrLowerTest extends NewTypeInferenceTestBa
         "function f(x, y) {",
         "  if (y instanceof x) {}",
         "}"));
+
+    typeCheck(LINE_JOINER.join(
+        "/** @constructor */ function Foo() {}",
+        "/** @constructor */ function Bar() {}",
+        "function f(/** Foo|Bar */ x, /** Foo|Bar */ y) {",
+        "  if (!(x instanceof Foo) && ((x instanceof Foo) || (y instanceof Foo))) {",
+        "    var /** Foo */ foo = y;",
+        "  }",
+        "}"));
   }
 
   public void testFunctionsExtendFunction() {


### PR DESCRIPTION
If we know for sure that `x` is not of type `Foo`, we can infer that
`x instanceof Foo` is of `FALSE_TYPE`. On the other hand, if we know
for sure that `x` is of type `Foo` already, we can infer that
`x instanceof Foo` is of `TRUE_TYPE`.

Part of the fix to #1589.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1590)
<!-- Reviewable:end -->
