### PR TITLE
Rewrite the logic for folding comparisons in PeepholeFoldConstants

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeFoldConstants.java
+++ b/src/com/google/javascript/jscomp/PeepholeFoldConstants.java
@@ -942,7 +942,6 @@ class PeepholeFoldConstants extends AbstractPeepholeOptimization {
   /**
    * Try to fold comparison nodes, e.g ==
    */
-  @SuppressWarnings("fallthrough")
   private Node tryFoldComparison(Node n, Node left, Node right) {
     TernaryValue result = evaluateComparison(n.getType(), left, right, shouldUseTypes);
     if (result == TernaryValue.UNKNOWN) {
@@ -956,222 +955,186 @@ class PeepholeFoldConstants extends AbstractPeepholeOptimization {
     return newNode;
   }
 
+  /** http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-relational-comparison */
+  private static TernaryValue tryAbstractRelationalComparison(Node left, Node right,
+      boolean useTypes, boolean willNegate) {
+    // First, try to evaluate based on the general type.
+    ValueType leftValueType = NodeUtil.getKnownValueType(left);
+    ValueType rightValueType = NodeUtil.getKnownValueType(right);
+    if (leftValueType != ValueType.UNDETERMINED && rightValueType != ValueType.UNDETERMINED) {
+      if (leftValueType == ValueType.STRING && rightValueType == ValueType.STRING) {
+        String lv = NodeUtil.getStringValue(left);
+        String rv = NodeUtil.getStringValue(right);
+        if (lv != null && rv != null) {
+          // In JS, browsers parse \v differently. So do not compare strings if one contains \v.
+          if (lv.indexOf('\u000B') != -1 || rv.indexOf('\u000B') != -1) {
+            return TernaryValue.UNKNOWN;
+          } else {
+            return TernaryValue.forBoolean(lv.compareTo(rv) < 0);
+          }
+        } else if (left.isTypeOf() && right.isTypeOf()
+            && left.getFirstChild().isName() && right.getFirstChild().isName()
+            && left.getFirstChild().getString().equals(right.getFirstChild().getString())) {
+          // Special case: `typeof a < typeof a` is always false.
+          return TernaryValue.FALSE;
+        }
+      }
+    }
+    // Then, try to evaluate based on the value of the node. Try comparing as numbers.
+    Double lv = NodeUtil.getNumberValue(left, useTypes);
+    Double rv = NodeUtil.getNumberValue(right, useTypes);
+    if (lv == null || rv == null) {
+      // Special case: `x < x` is always false.
+      //
+      // TODO(moz): If we knew the named value wouldn't be NaN, it would be nice to handle
+      // LE and GE. We should use type information if available here.
+      if (!willNegate && left.isName() && right.isName()) {
+        if (left.getString().equals(right.getString())) {
+          return TernaryValue.FALSE;
+        }
+      }
+      return TernaryValue.UNKNOWN;
+    }
+    if (Double.isNaN(lv) || Double.isNaN(rv)) {
+      return TernaryValue.forBoolean(willNegate);
+    } else {
+      return TernaryValue.forBoolean(lv.doubleValue() < rv.doubleValue());
+    }
+  }
+
+  /** http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-equality-comparison */
+  private static TernaryValue tryAbstractEqualityComparison(Node left, Node right,
+      boolean useTypes) {
+    // Evaluate based on the general type.
+    ValueType leftValueType = NodeUtil.getKnownValueType(left);
+    ValueType rightValueType = NodeUtil.getKnownValueType(right);
+    if (leftValueType != ValueType.UNDETERMINED && rightValueType != ValueType.UNDETERMINED) {
+      // Delegate to strict equality comparison for values of the same type.
+      if (leftValueType == rightValueType) {
+        return tryStrictEqualityComparison(left, right, useTypes);
+      }
+      if ((leftValueType == ValueType.NULL && rightValueType == ValueType.VOID)
+          || (leftValueType == ValueType.VOID && rightValueType == ValueType.NULL)) {
+        return TernaryValue.TRUE;
+      }
+      if ((leftValueType == ValueType.NUMBER && rightValueType == ValueType.STRING)
+          || rightValueType == ValueType.BOOLEAN) {
+        Double rv = NodeUtil.getNumberValue(right, useTypes);
+        return rv == null
+            ? TernaryValue.UNKNOWN
+            : tryAbstractEqualityComparison(left, IR.number(rv), useTypes);
+      }
+      if ((leftValueType == ValueType.STRING && rightValueType == ValueType.NUMBER)
+          || leftValueType == ValueType.BOOLEAN) {
+        Double lv = NodeUtil.getNumberValue(left, useTypes);
+        return lv == null
+            ? TernaryValue.UNKNOWN
+            : tryAbstractEqualityComparison(IR.number(lv), right, useTypes);
+      }
+      if ((leftValueType == ValueType.STRING || leftValueType == ValueType.NUMBER)
+          && rightValueType == ValueType.OBJECT) {
+        return TernaryValue.UNKNOWN;
+      }
+      if (leftValueType == ValueType.OBJECT
+          && (rightValueType == ValueType.STRING || rightValueType == ValueType.NUMBER)) {
+        return TernaryValue.UNKNOWN;
+      }
+      return TernaryValue.FALSE;
+    }
+    // In general, the rest of the cases cannot be folded.
+    return TernaryValue.UNKNOWN;
+  }
+
+  /** http://www.ecma-international.org/ecma-262/6.0/#sec-strict-equality-comparison */
+  private static TernaryValue tryStrictEqualityComparison(Node left, Node right, boolean useTypes) {
+    // First, try to evaluate based on the general type.
+    ValueType leftValueType = NodeUtil.getKnownValueType(left);
+    ValueType rightValueType = NodeUtil.getKnownValueType(right);
+    if (leftValueType != ValueType.UNDETERMINED && rightValueType != ValueType.UNDETERMINED) {
+      // Strict equality can only be true for values of the same type.
+      if (leftValueType != rightValueType) {
+        return TernaryValue.FALSE;
+      }
+      switch (leftValueType) {
+        case VOID:
+        case NULL:
+          return TernaryValue.TRUE;
+        case NUMBER: {
+          if (NodeUtil.isNaN(left)) {
+            return TernaryValue.FALSE;
+          }
+          if (NodeUtil.isNaN(right)) {
+            return TernaryValue.FALSE;
+          }
+          Double lv = NodeUtil.getNumberValue(left, useTypes);
+          Double rv = NodeUtil.getNumberValue(right, useTypes);
+          if (lv != null && rv != null) {
+            return TernaryValue.forBoolean(lv.doubleValue() == rv.doubleValue());
+          }
+          break;
+        }
+        case STRING: {
+          String lv = NodeUtil.getStringValue(left);
+          String rv = NodeUtil.getStringValue(right);
+          if (lv != null && rv != null) {
+            // In JS, browsers parse \v differently. So do not consider strings
+            // equal if one contains \v.
+            if (lv.indexOf('\u000B') != -1 || rv.indexOf('\u000B') != -1) {
+              return TernaryValue.UNKNOWN;
+            } else {
+              return lv.equals(rv) ? TernaryValue.TRUE : TernaryValue.FALSE;
+            }
+          } else if (left.isTypeOf() && right.isTypeOf()
+              && left.getFirstChild().isName() && right.getFirstChild().isName()
+              && left.getFirstChild().getString().equals(right.getFirstChild().getString())) {
+            // Special case, typeof a == typeof a is always true.
+            return TernaryValue.TRUE;
+          }
+          break;
+        }
+        case BOOLEAN: {
+          TernaryValue lv = NodeUtil.getPureBooleanValue(left);
+          TernaryValue rv = NodeUtil.getPureBooleanValue(right);
+          return lv.and(rv).or(lv.not().and(rv.not()));
+        }
+        default: // Symbol and Object cannot be folded in the general case.
+          return TernaryValue.UNKNOWN;
+      }
+    }
+
+    // Then, try to evaluate based on the value of the node. There's only one special case:
+    // Any strict equality comparison against NaN returns false.
+    if (NodeUtil.isNaN(left) || NodeUtil.isNaN(right)) {
+      return TernaryValue.FALSE;
+    }
+    return TernaryValue.UNKNOWN;
+  }
+
   static TernaryValue evaluateComparison(int op, Node left, Node right, boolean useTypes) {
     // Don't try to minimize side-effects here.
     if (NodeUtil.mayHaveSideEffects(left) || NodeUtil.mayHaveSideEffects(right)) {
       return TernaryValue.UNKNOWN;
     }
 
-    // First try to evaluate based on the general type.
-    ValueType leftValueType = NodeUtil.getKnownValueType(left);
-    ValueType rightValueType = NodeUtil.getKnownValueType(right);
-    if (leftValueType != ValueType.UNDETERMINED && rightValueType != ValueType.UNDETERMINED) {
-      // For strict equality are can only be equal for values of same type.
-      if (op == Token.SHEQ || op == Token.SHNE) {
-        if (leftValueType != rightValueType) {
-          return TernaryValue.forBoolean(op != Token.SHEQ);
-        } else if (rightValueType == ValueType.NULL || rightValueType == ValueType.VOID) {
-          return TernaryValue.forBoolean(op == Token.SHEQ);
-        }
-      }
-
-      // For equality, null and undefined are only equal to themselves
-      if (op == Token.EQ || op == Token.NE) {
-        switch (leftValueType) {
-          case OBJECT:
-          case NUMBER:
-          case BOOLEAN:
-          case STRING:
-            // OBJECT is never equal to NULL or VOID
-            if (rightValueType == ValueType.NULL || rightValueType == ValueType.VOID) {
-              return TernaryValue.forBoolean(op != Token.EQ);
-            }
-            break;
-          case NULL:
-          case VOID:
-            if (rightValueType == ValueType.NULL || rightValueType == ValueType.VOID) {
-              return TernaryValue.forBoolean(op == Token.EQ);
-            } else {
-              return TernaryValue.forBoolean(op != Token.EQ);
-            }
-          default:
-            throw new IllegalStateException("unexpected");
-        }
-      }
-    }
-
-    // Even if we don't know both the left and the right some operations always evaluate the
-    // same way if undefined is on one side.
-    if (leftValueType == ValueType.VOID || rightValueType == ValueType.VOID) {
-      switch (op) {
-        case Token.GE:
-        case Token.LE:
-        case Token.GT:
-        case Token.LT:
-          return TernaryValue.FALSE;
-      }
-    }
-
-    // TODO: fold NaN operations.
-
-    // Evaluate based on the value of the node.
-    int lhType = getNormalizedNodeType(left);
-    int rhType = getNormalizedNodeType(right);
-    switch (lhType) {
-      case Token.NULL:
-        // handle null <,>,<=,>=
-      case Token.TRUE:
-      case Token.FALSE:
-        boolean rhIsBooleanLike =
-            rhType == Token.TRUE || rhType == Token.FALSE || rhType == Token.NULL;
-        switch (op) {
-          case Token.SHEQ:
-          case Token.EQ:
-            return rhIsBooleanLike
-                ? TernaryValue.forBoolean(lhType == rhType) : TernaryValue.UNKNOWN;
-
-          case Token.SHNE:
-          case Token.NE:
-            return rhIsBooleanLike
-                ? TernaryValue.forBoolean(lhType != rhType) : TernaryValue.UNKNOWN;
-
-          case Token.GE:
-          case Token.LE:
-          case Token.GT:
-          case Token.LT:
-            return compareAsNumbers(op, left, right, useTypes);
-        }
-        return TernaryValue.UNKNOWN;
-
-      case Token.THIS:
-        if (right.isThis()) {
-          switch (op) {
-            case Token.SHEQ:
-            case Token.EQ:
-              return TernaryValue.TRUE;
-
-            case Token.SHNE:
-            case Token.NE:
-              return TernaryValue.FALSE;
-          }
-        }
-
-        // We can only handle == and != here.
-        // GT, LT, GE, LE depend on the type of "this" and how it will
-        // be converted to number.  The results are different depending on
-        // whether it is a string, NaN or other number value.
-        return TernaryValue.UNKNOWN;
-
-      case Token.STRING:
-        if (right.isString()) {
-          // Only eval if they are the same type
-          switch (op) {
-            case Token.SHEQ:
-            case Token.EQ:
-              return areStringsEqual(left.getString(), right.getString());
-
-            case Token.SHNE:
-            case Token.NE:
-              return areStringsEqual(left.getString(), right.getString()).not();
-          }
-        }
-        return TernaryValue.UNKNOWN;
-
-      case Token.NUMBER:
-        if (right.isNumber()) {
-          return compareAsNumbers(op, left, right, useTypes);
-        }
-        return TernaryValue.UNKNOWN; // Only eval if they are the same type
-
-      case Token.NAME:
-        if (right.isName()) {
-          if (left.getString().equals(right.getString())) {
-            // Only eval if they are the same type and the same name.
-            switch (op) {
-                // If we knew the named value wouldn't be NaN, it would be nice
-                // to handle EQ,NE,LE,GE,SHEQ, and SHNE.
-              case Token.LT:
-              case Token.GT:
-                return TernaryValue.FALSE;
-            }
-          }
-        }
-        return TernaryValue.UNKNOWN;
-
-      default:
-        return TernaryValue.UNKNOWN;
-    }
-  }
-
-  /** Returns whether two JS strings are equal. */
-  private static TernaryValue areStringsEqual(String a, String b) {
-    // In JS, browsers parse \v differently. So do not consider strings
-    // equal if one contains \v.
-    if (a.indexOf('\u000B') != -1 || b.indexOf('\u000B') != -1) {
-      return TernaryValue.UNKNOWN;
-    } else {
-      return a.equals(b) ? TernaryValue.TRUE : TernaryValue.FALSE;
-    }
-  }
-
-  /**
-   * @return Translate NOT expressions into TRUE or FALSE when possible.
-   */
-  private static int getNormalizedNodeType(Node n) {
-    int type = n.getType();
-    if (type == Token.NOT) {
-      TernaryValue value = NodeUtil.getPureBooleanValue(n);
-      switch (value) {
-        case TRUE:
-          return Token.TRUE;
-        case FALSE:
-          return Token.FALSE;
-        case UNKNOWN:
-          return type;
-      }
-    }
-    return type;
-  }
-
-  /**
-   * The result of the comparison, or UNKNOWN if the
-   * result could not be determined.
-   */
-  private static TernaryValue compareAsNumbers(int op, Node left, Node right, boolean useTypes) {
-    Double leftValue = NodeUtil.getNumberValue(left, useTypes);
-    if (leftValue == null) {
-      return TernaryValue.UNKNOWN;
-    }
-    Double rightValue = NodeUtil.getNumberValue(right, useTypes);
-    if (rightValue == null) {
-      return TernaryValue.UNKNOWN;
-    }
-
-    double lv = leftValue;
-    double rv = rightValue;
-
     switch (op) {
-      case Token.SHEQ:
       case Token.EQ:
-        Preconditions.checkState(
-            left.isNumber() && right.isNumber());
-        return TernaryValue.forBoolean(lv == rv);
-      case Token.SHNE:
+        return tryAbstractEqualityComparison(left, right, useTypes);
       case Token.NE:
-        Preconditions.checkState(
-            left.isNumber() && right.isNumber());
-        return TernaryValue.forBoolean(lv != rv);
-      case Token.LE:
-        return TernaryValue.forBoolean(lv <= rv);
+        return tryAbstractEqualityComparison(left, right, useTypes).not();
+      case Token.SHEQ:
+        return tryStrictEqualityComparison(left, right, useTypes);
+      case Token.SHNE:
+        return tryStrictEqualityComparison(left, right, useTypes).not();
       case Token.LT:
-        return TernaryValue.forBoolean(lv <  rv);
-      case Token.GE:
-        return TernaryValue.forBoolean(lv >= rv);
+        return tryAbstractRelationalComparison(left, right, useTypes, false);
       case Token.GT:
-        return TernaryValue.forBoolean(lv >  rv);
-      default:
-        return TernaryValue.UNKNOWN;  // don't handle that op
+        return tryAbstractRelationalComparison(right, left, useTypes, false);
+      case Token.LE:
+        return tryAbstractRelationalComparison(right, left, useTypes, true).not();
+      case Token.GE:
+        return tryAbstractRelationalComparison(left, right, useTypes, true).not();
     }
+    throw new IllegalStateException("Unexpected operator for comparison");
   }
 
   /**

--- a/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java
@@ -207,6 +207,7 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
     fold("null === undefined", "false");
     fold("null === null", "true");
     fold("null === void 0", "false");
+    foldSame("null === x");
 
     foldSame("null == this");
     foldSame("null == x");
@@ -233,9 +234,12 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
     fold("null >= null", "true");
     fold("null <= null", "true");
 
-    foldSame("0 < null"); // foldable
+    fold("0 < null", "false");
+    fold("0 > null", "false");
+    fold("0 >= null", "true");
     fold("true > null", "true");
-    foldSame("'hi' >= null"); // foldable
+    fold("'hi' < null", "false");
+    fold("'hi' >= null", "false");
     fold("null <= null", "true");
 
     fold("null < 0", "false");
@@ -290,6 +294,130 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
 
     foldSame("this == null");
     foldSame("x == null");
+  }
+
+  public void testBooleanBooleanComparison() {
+    foldSame("!x == !x");
+    foldSame("!x < !x"); // foldable
+    foldSame("!x !== !x"); // Maybe foldable given type information
+  }
+
+  public void testBooleanNumberComparison() {
+    foldSame("!x == +x");
+    foldSame("!x <= +x");
+    fold("!x !== +x", "true");
+  }
+
+  public void testNumberBooleanComparison() {
+    foldSame("+x == !x");
+    foldSame("+x <= !x");
+    fold("+x === !x", "false");
+  }
+
+  public void testBooleanStringComparison() {
+    foldSame("!x == '' + x");
+    foldSame("!x <= '' + x");
+    fold("!x !== '' + x", "true");
+  }
+
+  public void testStringBooleanComparison() {
+    foldSame("'' + x == !x");
+    foldSame("'' + x <= !x");
+    fold("'' + x === !x", "false");
+  }
+
+  public void testNumberNumberComparison() {
+    fold("1 > 1", "false");
+    fold("2 == 3", "false");
+    fold("3.6 === 3.6", "true");
+    foldSame("+x > +x"); // foldable
+    foldSame("+x == +x"); // Maybe foldable given type information
+    foldSame("+x === +x"); // Maybe foldable given type information
+  }
+
+  public void testStringStringComparison() {
+    fold("'a' < 'b'", "true");
+    fold("'a' <= 'b'", "true");
+    fold("'a' > 'b'", "false");
+    fold("'a' >= 'b'", "false");
+    fold("+'a' < +'b'", "false");
+    foldSame("typeof a < 'a'");
+    foldSame("'a' >= typeof a");
+    fold("typeof a < typeof a", "false");
+    fold("typeof a >= typeof a", "true");
+    fold("typeof 3 > typeof 4", "false");
+    fold("typeof function() {} < typeof function() {}", "false");
+    fold("'a' == 'a'", "true");
+    fold("'b' != 'a'", "true");
+    foldSame("'undefined' == typeof a");
+    foldSame("typeof a != 'number'");
+    foldSame("'undefined' == typeof a");
+    foldSame("'undefined' == typeof a");
+    fold("typeof a == typeof a", "true");
+    fold("'a' === 'a'", "true");
+    fold("'b' !== 'a'", "true");
+    fold("typeof a === typeof a", "true");
+    fold("typeof a !== typeof a", "false");
+    foldSame("'' + x <= '' + x");
+    foldSame("'' + x != '' + x");
+    foldSame("'' + x === '' + x");
+  }
+
+  public void testNumberStringComparison() {
+    fold("1 < '2'", "true");
+    fold("2 > '1'", "true");
+    fold("123 > '34'", "true");
+    fold("NaN >= 'NaN'", "false");
+    fold("1 == '2'", "false");
+    fold("1 != '1'", "false");
+    fold("NaN == 'NaN'", "false");
+    fold("1 === '1'", "false");
+    fold("1 !== '1'", "true");
+    foldSame("+x > '' + x");
+    foldSame("+x == '' + x");
+    fold("+x !== '' + x", "true");
+  }
+
+  public void testStringNumberComparison() {
+    fold("'1' < 2", "true");
+    fold("'2' > 1", "true");
+    fold("'123' > 34", "true");
+    fold("'NaN' < NaN", "false");
+    fold("'1' == 2", "false");
+    fold("'1' != 1", "false");
+    fold("'NaN' == NaN", "false");
+    fold("'1' === 1", "false");
+    fold("'1' !== 1", "true");
+    foldSame("'' + x < +x");
+    foldSame("'' + x == +x");
+    fold("'' + x === +x", "false");
+  }
+
+  public void testNaNComparison() {
+    fold("NaN < NaN", "false");
+    fold("NaN >= NaN", "false");
+    fold("NaN == NaN", "false");
+    fold("NaN === NaN", "false");
+
+    fold("NaN < null", "false");
+    fold("null >= NaN", "false");
+    fold("NaN == null", "false");
+    fold("null != NaN", "true");
+    fold("null === NaN", "false");
+
+    fold("NaN < undefined", "false");
+    fold("undefined >= NaN", "false");
+    fold("NaN == undefined", "false");
+    fold("undefined != NaN", "true");
+    fold("undefined === NaN", "false");
+
+    foldSame("NaN < x");
+    foldSame("x >= NaN");
+    foldSame("NaN == x");
+    foldSame("x != NaN");
+    fold("NaN === x", "false");
+    fold("x !== NaN", "true");
+    foldSame("NaN == foo()");
   }
 
   public void testObjectComparison1() {
@@ -668,7 +796,7 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
     fold("x = 3 < 3", "x = false");
     fold("x = 10 > 1.0", "x = true");
     fold("x = 10 > 10.25", "x = false");
-    fold("x = y == y", "x = y==y");
+    fold("x = y == y", "x = y==y"); // Maybe foldable given type information
     fold("x = y < y", "x = false");
     fold("x = y > y", "x = false");
     fold("x = 1 <= 1", "x = true");
@@ -968,14 +1096,14 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
   }
 
   public void testFoldLiteralNames() {
-    foldSame("NaN == NaN");
-    foldSame("Infinity == Infinity");
-    foldSame("Infinity == NaN");
+    fold("NaN == NaN", "false");
+    fold("Infinity == Infinity", "true");
+    fold("Infinity == NaN", "false");
     fold("undefined == NaN", "false");
     fold("undefined == Infinity", "false");
 
-    foldSame("Infinity >= Infinity");
-    foldSame("NaN >= NaN");
+    fold("Infinity >= Infinity", "true");
+    fold("NaN >= NaN", "false");
   }
 
   public void testFoldLiteralsTypeMismatches() {
@@ -1267,8 +1395,7 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
             if (a.equals("NaN") ||
                 a.equals("Infinity") ||
                 a.equals("-Infinity")) {
-              foldSame(join(a, op, b));
-              foldSame(join(a, inverse, b));
+              fold(join(a, op, b), a.equals("NaN") ? "false" : "true");
             } else {
               assertSameResults(join(a, op, b), "true");
               assertSameResults(join(a, inverse, b), "false");
@@ -1303,8 +1430,7 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
           String op = operators.get(iOp);
 
           // Test commutativity.
-          // TODO(nicksantos): Eventually, all cases should be collapsed.
-          assertSameResultsOrUncollapsed(join(a, op, b), join(b, op, a));
+          assertSameResults(join(a, op, b), join(b, op, a));
         }
       }
     }
@@ -1316,16 +1442,6 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
 
   private static String join(String operandA, String op, String operandB) {
     return operandA + " " + op + " " + operandB;
-  }
-
-  private void assertSameResultsOrUncollapsed(String exprA, String exprB) {
-    String resultA = process(exprA);
-    if (resultA.equals(print(exprA))) {
-      foldSame(exprA);
-      foldSame(exprB);
-    } else {
-      assertSameResults(exprA, exprB);
-    }
   }
 
   private void assertSameResults(String exprA, String exprB) {
@@ -1344,10 +1460,6 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
 
   private String process(String js) {
     return printHelper(js, true);
-  }
-
-  private String print(String js) {
-    return printHelper(js, false);
   }
 
   private String printHelper(String js, boolean runProcessor) {

--- a/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
@@ -433,7 +433,7 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
         "  break;\n" +
         "}",
         "");
-    foldSame("switch (0) {\n" +
+    fold("switch (0) {\n" +
         "case NaN:\n" +
         "  foobar();\n" +
         "  break;\n" +
@@ -443,7 +443,8 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
         "case 2:\n" +
         "  bar();\n" +
         "  break;\n" +
-        "}");
+        "}",
+        "foo();");
     foldSame("switch ('\\v') {\n" +
         "case '\\u000B':\n" +
         "  foo();\n" +


### PR DESCRIPTION
evaluateComparison() is now based on the three Abstract Operations
defined in the ES6 Specs: Abstract Relational Comparison [1],
Abstract Equality Comparison [2] and Strict Equality Comparison [3].

This fixes a handful of foldable cases that were not folded previously:

Cases like `0 < null` and `'hi' < null` are now folded.

String-string comparisons and string-number comparisions
like `'a' < 'b'` and `1 < '2'` are now folded.

Cases involving `NaN` are now folded.

As a bonus, a test case in testOptimizeSwitch() in
PeepholeRemoveDeadCodeTest now folds.

[1] http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-relational-comparison
[2] http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-equality-comparison
[3] http://www.ecma-international.org/ecma-262/6.0/#sec-strict-equality-comparison

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1591)
<!-- Reviewable:end -->
