### PR TITLE
Fix support of ES6 shorthand object literals in ProcessCommonJSModules

### DIFF
--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -257,7 +257,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "function foo$$module$test() {}",
             "/** @const */ module$test = {",
             "  /** @const */ prop: 'value',",
-            "  /** @const */ foo",
+            "  /** @const */ foo: foo$$module$test",
             "};"));
 
     testModules(
@@ -276,5 +276,25 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "    console.log('bar');",
             "  }",
             "};"));
+
+    testModules(
+        LINE_JOINER.join(
+            "var a = require('other');",
+            "module.exports = {a: a};"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "goog.require('module$other');",
+            "var a$$module$test = module$other;",
+            "/** @const */ module$test = { /** @const */ a: a$$module$test };"));
+
+    testModules(
+        LINE_JOINER.join(
+            "var a = require('other');",
+            "module.exports = {a};"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "goog.require('module$other');",
+            "var a$$module$test = module$other;",
+            "/** @const */ module$test = { /** @const */ a: a$$module$test };"));
   }
 }


### PR DESCRIPTION
We need to rewrite {a} as {a: a$$module$foo}.

Fixes #1592.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1593)
<!-- Reviewable:end -->
