### PR TITLE
Add .checkstyle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ TESTS-TestSuites.xml
 junit*.properties
 target/
 *~
+.checkstyle
 .settings


### PR DESCRIPTION
We might enforce CheckStyle someday in the future, but let's ignore .checkstyle for now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1599)
<!-- Reviewable:end -->
