### PR TITLE
Don't rename @define's in ProcessEs6Modules

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -501,6 +501,11 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
 
         Var var = t.getScope().getVar(name);
         if (var != null && var.isGlobal()) {
+          JSDocInfo varInfo = NodeUtil.getBestJSDocInfo(var.getNameNode());
+          // Assume @define's are truly global and don't mangle them.
+          if (varInfo != null && varInfo.isDefine()) {
+            return;
+          }
           // Avoid polluting the global namespace.
           String newName = name + "$$" + suffix;
           if (isShorthandObjLitKey) {

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -623,4 +623,14 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "} = module$other.f({foo: foo$$module$testcode});",
             "use(a$$module$testcode, b$$module$testcode);"));
   }
+
+  public void testDefine() {
+    testModules(
+        LINE_JOINER.join(
+            "import name from 'other';",
+            "/** @define {boolean} */ var FOO = true; use(FOO);"),
+        LINE_JOINER.join(
+            "goog.require('module$other');",
+            "/** @define {boolean} */ var FOO = true; use(FOO);"));
+  }
 }


### PR DESCRIPTION
Treat @define's as truly global definitions and don't mangle the names.

Fixes #1601.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1602)

<!-- Reviewable:end -->
