### PR TITLE
Change several C-style array declarations to Java-style ones.

### DIFF
--- a/src/com/google/javascript/jscomp/ConformanceRules.java
+++ b/src/com/google/javascript/jscomp/ConformanceRules.java
@@ -1018,7 +1018,7 @@ public final class ConformanceRules {
     private Constructor<?> getRuleConstructor(Class<Rule> cls)
         throws InvalidRequirementSpec {
       for (Constructor<?> ctor : cls.getConstructors()) {
-        Class<?> paramClasses[] = ctor.getParameterTypes();
+        Class<?>[] paramClasses = ctor.getParameterTypes();
         if (paramClasses.length == 2) {
           TypeToken<?> param1 = TypeToken.of(paramClasses[0]);
           TypeToken<?> param2 = TypeToken.of(paramClasses[1]);

--- a/src/com/google/javascript/jscomp/GatherRawExports.java
+++ b/src/com/google/javascript/jscomp/GatherRawExports.java
@@ -39,7 +39,7 @@ class GatherRawExports extends AbstractPostOrderCallback
   // collapse properties, so the two entries here protect goog.global in the
   // two common cases "collapse properties and renaming on" or both off
   // but not the case where only property renaming is on.
-  private static final String GLOBAL_THIS_NAMES[] = {
+  private static final String[] GLOBAL_THIS_NAMES = {
     "window", "top", "goog$global", "goog.global" };
 
   private final Set<String> exportedVariables = new HashSet<>();

--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -482,7 +482,7 @@ public final class CompileTask
     }
 
     if (!Strings.isNullOrEmpty(sourceMapLocationMapping)) {
-      String tokens[] = sourceMapLocationMapping.split("\\|", -1);
+      String[] tokens = sourceMapLocationMapping.split("\\|", -1);
       LocationMapping lm = new LocationMapping(tokens[0], tokens[1]);
       options.setSourceMapLocationMappings(Arrays.asList(lm));
     }


### PR DESCRIPTION
According to https://google.github.io/styleguide/javaguide.html#s4.8.3.2-array-declarations, C-style array declarations aren't allowed.

There are still a couple of C-style array declarations left. Two in src/com/google/javascript/jscomp/gwt/super/java/util/BitSet.java and one in src/com/google/javascript/jscomp/parsing/parser/util/format/SimpleFormat.java, but since the former is being backported to GWT 2.8 and the latter needs a thorough style cleanup anyway, I'm not fixing them now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1604)
<!-- Reviewable:end -->
