### PR TITLE
Add @SafeVarargs to methods that cause warnings (again)

### DIFF
--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1996,12 +1996,14 @@ public final class CommandLineRunnerTest extends TestCase {
     compileArgs(expectedOutput, null);
   }
 
+  @SafeVarargs
   private final void compileFilesError(
       DiagnosticType expectedError, FlagEntry<JsSourceType>... entries) {
     setupFlags(entries);
     compileArgs("", expectedError);
   }
 
+  @SafeVarargs
   private final void setupFlags(FlagEntry<JsSourceType>... entries) {
     for (FlagEntry<JsSourceType> entry : entries) {
       args.add("--" + entry.flag.flagName + "=" + entry.value);


### PR DESCRIPTION
This removes multiple warnings about potentially unsafe operations on varargs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1609)
<!-- Reviewable:end -->
