### PR TITLE
Rename "--checks-only" to "--checks_only"

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -348,9 +348,10 @@ public class CommandLineRunner extends
     private String compilationLevel = "SIMPLE";
     private CompilationLevel compilationLevelParsed = null;
 
-    @Option(name = "--checks-only",
+    @Option(name = "--checks_only",
+        aliases = {"--checks-only"},
         handler = BooleanOptionHandler.class,
-        usage = "Don't generate output. Run checks, but no compiler passes.")
+        usage = "Don't generate output. Run checks, but no optimization passes.")
     private boolean checksOnly = false;
 
     @Option(name = "--use_types_for_optimization",

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1380,20 +1380,20 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testChecksOnlySkipsOptimizations() {
-    args.add("--checks-only");
+    args.add("--checks_only");
     test("var foo = 1 + 1;",
       "var foo = 1 + 1;");
   }
 
   public void testChecksOnlyWithParseError() {
     args.add("--compilation_level=WHITESPACE_ONLY");
-    args.add("--checks-only");
+    args.add("--checks_only");
     test("val foo = 1;",
       RhinoErrorReporter.PARSE_ERROR);
   }
 
   public void testChecksOnlyWithWarning() {
-    args.add("--checks-only");
+    args.add("--checks_only");
     args.add("--warning_level=VERBOSE");
     test("/** @deprecated */function foo() {}; foo();",
       CheckAccessControls.DEPRECATED_NAME);


### PR DESCRIPTION
The hyphen is inconsistent with all other compiler flags. Keep "--checks-only" as an alias to avoid breakage for now.

Also fix the help message to say "optimization passes" instead of "compiler passes".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1610)
<!-- Reviewable:end -->
