### PR TITLE
Refine types for Object.getOwnPropertySymbols and Object.setPrototypeOf.

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -1449,13 +1449,20 @@ Array.prototype.find = function(predicate, opt_this) {};
 Array.prototype.findIndex = function(predicate, opt_this) {};
 
 
-/** @return {!Array<symbol>} */
-Object.getOwnPropertySymbols;
+/**
+ * @param {!Object} obj
+ * @return {!Array<symbol>}
+ * @see http://www.ecma-international.org/ecma-262/6.0/#sec-object.getownpropertysymbols
+ */
+Object.getOwnPropertySymbols = function(obj) {};
 
 
-/** @return {void} */
-Object.setPrototypeOf;
-
+/**
+ * @param {!Object} obj
+ * @return {!Object}
+ * @see http://www.ecma-international.org/ecma-262/6.0/#sec-object.setprototypeof
+ */
+Object.setPrototypeOf = function(obj) {};
 
 
 /**


### PR DESCRIPTION
Added correct type annotations for Object.getOwnPropertySymbols and Object.setPrototypeOf according to ES6 specs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1612)
<!-- Reviewable:end -->
