### PR TITLE
Add the "trailingUnderscore" DiagnosticGroup

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -102,10 +102,10 @@ public class DiagnosticGroups {
       + "misplacedTypeAnnotation, missingGetCssName, missingProperties, "
       + "missingProvide, missingRequire, missingReturn, msgDescriptions, "
       + "newCheckTypes, nonStandardJsDocs, reportUnknownTypes, "
-      + "suspiciousCode, strictModuleDepCheck, typeInvalidation, "
-      + "undefinedNames, undefinedVars, unknownDefines, unnecessaryCasts, "
+      + "suspiciousCode, strictModuleDepCheck, trailingUnderscore, typeInvalidation, "
+      + "undefinedNames, undefinedVars, underscore, unknownDefines, unnecessaryCasts, "
       + "unusedLocalVariables, unusedPrivateMembers, uselessCode, "
-      + "useOfGoogBase, underscore, visibility";
+      + "useOfGoogBase, visibility";
 
   public static final DiagnosticGroup GLOBAL_THIS =
       DiagnosticGroups.registerGroup("globalThis",
@@ -120,6 +120,12 @@ public class DiagnosticGroups {
           CheckAccessControls.DEPRECATED_CLASS,
           CheckAccessControls.DEPRECATED_CLASS_REASON);
 
+  public static final DiagnosticGroup TRAILING_UNDERSCORE =
+      DiagnosticGroups.registerGroup("trailingUnderscore",  // undocumented
+          CheckJSDocStyle.MUST_BE_PRIVATE,
+          CheckJSDocStyle.MUST_HAVE_TRAILING_UNDERSCORE);
+
+  @Deprecated
   public static final DiagnosticGroup UNDERSCORE =
       DiagnosticGroups.registerGroup("underscore",  // undocumented
           CheckJSDocStyle.MUST_BE_PRIVATE,


### PR DESCRIPTION
This makes the name more descriptive.

Mark "underscore" as deprecated for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1621)
<!-- Reviewable:end -->
