### PR TITLE
Add the check for missing @return JSDoc to CheckJSDocStyle.

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -483,6 +483,7 @@ public class DiagnosticGroups {
           CheckInterfaces.INTERFACE_SHOULD_NOT_TAKE_ARGS,
           CheckJSDocStyle.MISSING_PARAMETER_JSDOC,
           CheckJSDocStyle.MISSING_JSDOC,
+          CheckJSDocStyle.MISSING_RETURN_JSDOC,
           CheckJSDocStyle.EXTERNS_FILES_SHOULD_BE_ANNOTATED,
           CheckJSDocStyle.INCORRECT_PARAM_NAME,
           CheckJSDocStyle.INVALID_SUPPRESS,

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -2170,7 +2170,7 @@ public final class NodeUtil {
   /**
    * Determines whether the given node is a FOR, DO, WHILE, WITH, or IF node.
    */
-  static boolean isControlStructure(Node n) {
+  public static boolean isControlStructure(Node n) {
     switch (n.getType()) {
       case Token.FOR:
       case Token.FOR_OF:
@@ -2243,7 +2243,7 @@ public final class NodeUtil {
   /**
    * @return Whether the node is of a type that contain other statements.
    */
-  static boolean isStatementBlock(Node n) {
+  public static boolean isStatementBlock(Node n) {
     return n.isScript() || n.isBlock();
   }
 

--- a/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java
+++ b/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java
@@ -25,6 +25,7 @@ import com.google.javascript.jscomp.DiagnosticType;
 import com.google.javascript.jscomp.ExportTestFunctions;
 import com.google.javascript.jscomp.NodeTraversal;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPreOrderCallback;
 import com.google.javascript.jscomp.NodeUtil;
 import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.JSDocInfo.Visibility;
@@ -62,6 +63,10 @@ public final class CheckJSDocStyle extends AbstractPostOrderCallback implements 
   public static final DiagnosticType MIXED_PARAM_JSDOC_STYLES =
       DiagnosticType.warning("JSC_MIXED_PARAM_JSDOC_STYLES",
       "Functions may not use both @param annotations and inline JSDoc");
+
+  public static final DiagnosticType MISSING_RETURN_JSDOC =
+      DiagnosticType.warning("JSC_MISSING_RETURN_JSDOC",
+          "Function with non-trivial return must have @return JSDoc or inline return JSDoc.");
 
   public static final DiagnosticType MUST_BE_PRIVATE =
       DiagnosticType.warning("JSC_MUST_BE_PRIVATE", "Property {0} must be marked @private");
@@ -196,11 +201,14 @@ public final class CheckJSDocStyle extends AbstractPostOrderCallback implements 
 
     if (jsDoc == null && !hasAnyInlineJsDoc(function)) {
       checkMissingJsDoc(t, function);
-    } else if (t.inGlobalScope()
-        || hasAnyInlineJsDoc(function)
-        || !jsDoc.getParameterNames().isEmpty()
-        || jsDoc.hasReturnType()) {
-      checkParams(t, function, jsDoc);
+    } else {
+      if (t.inGlobalScope()
+          || hasAnyInlineJsDoc(function)
+          || !jsDoc.getParameterNames().isEmpty()
+          || jsDoc.hasReturnType()) {
+        checkParams(t, function, jsDoc);
+      }
+      checkReturn(t, function, jsDoc);
     }
 
     if (parent.isMemberFunctionDef()
@@ -355,6 +363,39 @@ public final class CheckJSDocStyle extends AbstractPostOrderCallback implements 
       }
     }
     return false;
+  }
+
+  private void checkReturn(NodeTraversal t, Node function, JSDocInfo jsDoc) {
+    if (jsDoc != null && (jsDoc.hasReturnType() || jsDoc.isOverride() || jsDoc.isConstructor())) {
+      return;
+    }
+    if (function.getFirstChild().getJSDocInfo() != null) {
+      return;
+    }
+
+    FindNonTrivialReturn finder = new FindNonTrivialReturn();
+    NodeTraversal.traverseEs6(compiler, function.getLastChild(), finder);
+    if (finder.found) {
+      t.report(function, MISSING_RETURN_JSDOC);
+    }
+  }
+
+  private static class FindNonTrivialReturn extends AbstractPreOrderCallback {
+    private boolean found;
+
+    @Override
+    public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
+      // Shallow traversal, since we don't need to inspect within functions or expressions.
+      if (!found && (parent == null || NodeUtil.isControlStructure(parent)
+         || NodeUtil.isStatementBlock(parent))) {
+        if (n.isReturn() && n.hasChildren()) {
+          found = true;
+          return false;
+        }
+        return true;
+      }
+      return false;
+    }
   }
 
   private static class ExternsCallback implements NodeTraversal.Callback {

--- a/test/com/google/javascript/jscomp/lint/CheckJSDocStyleTest.java
+++ b/test/com/google/javascript/jscomp/lint/CheckJSDocStyleTest.java
@@ -21,6 +21,7 @@ import static com.google.javascript.jscomp.lint.CheckJSDocStyle.INCORRECT_PARAM_
 import static com.google.javascript.jscomp.lint.CheckJSDocStyle.INVALID_SUPPRESS;
 import static com.google.javascript.jscomp.lint.CheckJSDocStyle.MISSING_JSDOC;
 import static com.google.javascript.jscomp.lint.CheckJSDocStyle.MISSING_PARAMETER_JSDOC;
+import static com.google.javascript.jscomp.lint.CheckJSDocStyle.MISSING_RETURN_JSDOC;
 import static com.google.javascript.jscomp.lint.CheckJSDocStyle.MIXED_PARAM_JSDOC_STYLES;
 import static com.google.javascript.jscomp.lint.CheckJSDocStyle.MUST_BE_PRIVATE;
 import static com.google.javascript.jscomp.lint.CheckJSDocStyle.MUST_HAVE_TRAILING_UNDERSCORE;
@@ -519,6 +520,31 @@ public final class CheckJSDocStyleTest extends CompilerTestCase {
             "function getDistanceFromZero({x, y}) {}"));
 
     testSame("function getDistanceFromZero(/** {x: number, y: number} */ {x, y}) {}");
+  }
+
+  public void testMissingReturn_noWarning() {
+    testSame("/** @param {number} x */ function f(x) {}");
+    testSame("/** @param {number} x */ function f(x) { function bar() { return x; } }");
+    testSame("/** @param {number} x */ function f(x) { return; }");
+    testSame("/** @param {number} x @return {number} */ function f(x) { return x; }");
+    testSame("/** @param {number} x */ function /** number */ f(x) { return x; }");
+    testSame("/** @param {number} x @constructor */ function f(x) { return x; }");
+    testSame("/** @inheritDoc */ function f(x) { return x; }");
+    testSame("/** @override */ function f(x) { return x; }");
+  }
+
+  public void testMissingReturn() {
+    testWarning("/** @param {number} x */ function f(x) { return x; }", MISSING_RETURN_JSDOC);
+    testWarning(LINE_JOINER.join(
+        "/** @param {number} x */",
+        "function f(x) {",
+        "  /** @param {number} x */",
+        "  function bar(x) {",
+        "    return x;",
+        "  }",
+        "}"), MISSING_RETURN_JSDOC);
+    testWarning(
+        "/** @param {number} x */ function f(x) { if (true) { return x; } }", MISSING_RETURN_JSDOC);
   }
 
   public void testExternsAnnotation() {


### PR DESCRIPTION
For any function with a non-trivial return statement (i.e. not "return;"), if the function has JSDoc or inline JSDoc and doesn't have either a @return JSDoc or an inline return JSDoc, we give a warning.

Note that we don't warn on functions that are annotated with @constructor, @inheritDoc, or @override.

Fixes #844.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1623)
<!-- Reviewable:end -->
