### PR TITLE
Add "extraProvide" to allowed suppressions.

### DIFF
--- a/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java
+++ b/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java
@@ -184,7 +184,7 @@ public final class CheckJSDocStyle extends AbstractPostOrderCallback implements 
   private void checkSuppressionsOnNonFunction(NodeTraversal t, Node n, JSDocInfo jsDoc) {
     // Suppressions that are allowed to be in places other than functions and @fileoverview blocks.
     Set<String> specialSuppressions =
-        ImmutableSet.of("const", "duplicate", "extraRequire", "missingRequire");
+        ImmutableSet.of("const", "duplicate", "extraProvide", "extraRequire", "missingRequire");
 
     Set<String> suppressions = Sets.difference(jsDoc.getSuppressions(), specialSuppressions);
     if (!suppressions.isEmpty()) {

--- a/test/com/google/javascript/jscomp/lint/CheckJSDocStyleTest.java
+++ b/test/com/google/javascript/jscomp/lint/CheckJSDocStyleTest.java
@@ -97,6 +97,7 @@ public final class CheckJSDocStyleTest extends CompilerTestCase {
             "}"));
 
     testWarning("/** @suppress {uselessCode} */ goog.require('unused.Class');", INVALID_SUPPRESS);
+    testSame("/** @suppress {extraProvide} */ goog.provide('unused.Class');");
     testSame("/** @suppress {extraRequire} */ goog.require('unused.Class');");
     testSame("/** @const @suppress {duplicate} */ var google = {};");
     testSame("/** @suppress {const} */ var google = {};");


### PR DESCRIPTION
We still need to implement a proper lint check for "extraProvide", but allow this for now to unblock fixes to Closure Library.

Related to #1615.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1624)

<!-- Reviewable:end -->
