### PR TITLE
Only re-write a file as a CommonJS module if it exports a symbol

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -81,11 +81,8 @@ public final class ProcessCommonJSModules implements CompilerPass {
   public void process(Node externs, Node root) {
     FindGoogProvideOrGoogModule finder = new FindGoogProvideOrGoogModule();
     NodeTraversal.traverseEs6(compiler, root, finder);
-    if (finder.found) {
-      return;
-    }
     NodeTraversal
-        .traverseEs6(compiler, root, new ProcessCommonJsModulesCallback());
+        .traverseEs6(compiler, root, new ProcessCommonJsModulesCallback(!finder.found));
   }
 
   String inputToModuleName(CompilerInput input) {
@@ -183,6 +180,11 @@ public final class ProcessCommonJSModules implements CompilerPass {
     private List<Node> moduleExportRefs = new ArrayList<>();
     private List<Node> exportRefs = new ArrayList<>();
     Multiset<String> propertyExportRefCount = HashMultiset.create();
+    private final boolean allowFullRewrite;
+
+    public ProcessCommonJsModulesCallback(boolean allowFullRewrite) {
+      this.allowFullRewrite = allowFullRewrite;
+    }
 
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
@@ -217,7 +219,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
       // will be rewritten to:
       //
       // if (typeof module == "object" && module.exports) {...}
-      if (n.isIf()) {
+      if (allowFullRewrite && n.isIf()) {
         FindModuleExportStatements commonjsFinder = new FindModuleExportStatements();
         Node condition = n.getFirstChild();
         NodeTraversal.traverseEs6(compiler, condition, commonjsFinder);
@@ -239,7 +241,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
         visitScript(t, n);
       }
 
-      if (n.isGetProp() &&
+      if (allowFullRewrite &&  n.isGetProp() &&
           "module.exports".equals(n.getQualifiedName())) {
         Var v = t.getScope().getVar(MODULE);
         // only rewrite "module.exports" if "module" is a free variable,
@@ -251,7 +253,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
         }
       }
 
-      if (n.isName() && EXPORTS.equals(n.getString())) {
+      if (allowFullRewrite && n.isName() && EXPORTS.equals(n.getString())) {
         Var v = t.getScope().getVar(n.getString());
         if (v == null || v.isGlobal()) {
           exportRefs.add(n);
@@ -329,9 +331,18 @@ public final class ProcessCommonJSModules implements CompilerPass {
 
       String moduleName = inputToModuleName(t.getInput());
 
-      // Rename vars to not conflict in global scope.
-      NodeTraversal.traverseEs6(compiler, script, new SuffixVarsCallback(
-          moduleName));
+      boolean hasExports = !(moduleExportRefs.isEmpty() && exportRefs.isEmpty());
+
+      // Rename vars to not conflict in global scope - but only if the script exports something.
+      // If there are no exports, we still need to rewrite type annotations which
+      // are module paths
+      NodeTraversal.traverseEs6(compiler, script,
+          new SuffixVarsCallback(moduleName, hasExports));
+
+      // If the script has no exports, we don't want to output a goog.provide statement
+      if (!hasExports) {
+        return;
+      }
 
       // Replace all refs to module.exports and exports
       processExports(script, moduleName);
@@ -577,9 +588,11 @@ public final class ProcessCommonJSModules implements CompilerPass {
    */
   private class SuffixVarsCallback extends AbstractPostOrderCallback {
     private final String suffix;
+    private final boolean fullRewrite;
 
-    SuffixVarsCallback(String suffix) {
+    SuffixVarsCallback(String suffix, boolean fullRewrite) {
       this.suffix = suffix;
+      this.fullRewrite = fullRewrite;
     }
 
     @Override
@@ -592,7 +605,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
       }
 
       boolean isShorthandObjLitKey = n.isStringKey() && !n.hasChildren();
-      if (n.isName() || isShorthandObjLitKey) {
+      if (fullRewrite && n.isName() || isShorthandObjLitKey) {
         String name = n.getString();
         if (suffix.equals(name)) {
           // TODO(moz): Investigate whether we need to return early in this unlikely situation.
@@ -649,7 +662,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
           String globalModuleName = ES6ModuleLoader.toModuleName(loadAddress);
           typeNode.setString(
               localTypeName == null ? globalModuleName : globalModuleName + localTypeName);
-        } else {
+        } else if (fullRewrite) {
           int endIndex = name.indexOf('.');
           if (endIndex == -1) {
             endIndex = name.length();

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1538,43 +1538,48 @@ public final class CommandLineRunnerTest extends TestCase {
     setFilename(3, "app.js");
     test(
         new String[] {
-          "/** @provideGoog */\n"
-              + "/** @const */ var goog = goog || {};\n"
-              + "var COMPILED = false;\n"
-              + "goog.provide = function (arg) {};\n"
-              + "goog.require = function (arg) {};",
+          CompilerTestCase.LINE_JOINER.join(
+              "/** @provideGoog */",
+              "/** @const */ var goog = goog || {};",
+              "var COMPILED = false;",
+              "goog.provide = function (arg) {};",
+              "goog.require = function (arg) {};"),
           "goog.provide('goog.array');",
-          "goog.require('goog.array');"
-              + "function Baz() {}"
-              + "Baz.prototype = {"
-              + "  baz: function() {"
-              + "    return goog.array.last(['asdf','asd','baz']);"
-              + "  },"
-              + "  bar: function () {"
-              + "    return 4 + 4;"
-              + "  }"
-              + "};"
-              + "module.exports = Baz;",
-          "var Baz = require('./Baz');"
-              + "var baz = new Baz();"
-              + "console.log(baz.baz());"
-              + "console.log(baz.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "goog.require('goog.array');",
+              "function Baz() {}",
+              "Baz.prototype = {",
+              "  baz: function() {",
+              "    return goog.array.last(['asdf','asd','baz']);",
+              "  },",
+              "  bar: function () {",
+              "    return 4 + 4;",
+              "  }",
+              "};",
+              "module.exports = Baz;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "var Baz = require('./Baz');",
+              "var baz = new Baz();",
+              "console.log(baz.baz());",
+              "console.log(baz.bar());")
         },
         new String[] {
-          "var goog=goog||{},COMPILED=!1;"
-              + "goog.provide=function(a){};goog.require=function(a){};",
+          CompilerTestCase.LINE_JOINER.join(
+              "var goog=goog||{},COMPILED=!1;",
+              "goog.provide=function(a){};goog.require=function(a){};"),
           "goog.array={};",
-          "function Baz$$module$Baz(){}"
-              + "Baz$$module$Baz.prototype={"
-              + "  baz:function(){return goog.array.last(['asdf','asd','baz'])},"
-              + "  bar:function(){return 8}"
-              + "};"
-              + "var module$Baz=Baz$$module$Baz;",
-          "var module$app={},"
-              + "    Baz$$module$app=Baz$$module$Baz,"
-              + "    baz$$module$app=new Baz$$module$app;"
-              + "console.log(baz$$module$app.baz());"
-              + "console.log(baz$$module$app.bar())"
+          CompilerTestCase.LINE_JOINER.join(
+              "function Baz$$module$Baz(){}",
+              "Baz$$module$Baz.prototype={",
+              "  baz:function(){return goog.array.last(['asdf','asd','baz'])},",
+              "  bar:function(){return 8}",
+              "};",
+              "var module$Baz=Baz$$module$Baz;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "var Baz = Baz$$module$Baz,",
+              "    baz = new Baz();",
+              "console.log(baz.baz());",
+              "console.log(baz.bar());")
         });
   }
 
@@ -1594,43 +1599,48 @@ public final class CommandLineRunnerTest extends TestCase {
 
     test(
         new String[] {
-          "/** @provideGoog */"
-              + "/** @const */ var goog = goog || {};"
-              + "var COMPILED = false;"
-              + "goog.provide = function (arg) {};"
-              + "goog.require = function (arg) {};",
+          CompilerTestCase.LINE_JOINER.join(
+              "/** @provideGoog */",
+              "/** @const */ var goog = goog || {};",
+              "var COMPILED = false;",
+              "goog.provide = function (arg) {};",
+              "goog.require = function (arg) {};"),
           "goog.provide('goog.array');",
-          "goog.require('goog.array');"
-              + "function Baz() {}"
-              + "Baz.prototype = {"
-              + "  baz: function() {"
-              + "    return goog.array.last(['asdf','asd','baz']);"
-              + "  },"
-              + "  bar: function () {"
-              + "    return 4 + 4;"
-              + "  }"
-              + "};"
-              + "module.exports = Baz;",
-          "var Baz = require('./Baz');"
-              + "var baz = new Baz();"
-              + "console.log(baz.baz());"
-              + "console.log(baz.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "goog.require('goog.array');",
+              "function Baz() {}",
+              "Baz.prototype = {",
+              "  baz: function() {",
+              "    return goog.array.last(['asdf','asd','baz']);",
+              "  },",
+              "  bar: function () {",
+              "    return 4 + 4;",
+              "  }",
+              "};",
+              "module.exports = Baz;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "var Baz = require('./Baz');",
+              "var baz = new Baz();",
+              "console.log(baz.baz());",
+              "console.log(baz.bar());")
         },
         new String[] {
-          "var goog=goog||{},COMPILED=!1;"
-              + "goog.provide=function(a){};goog.require=function(a){};",
+          CompilerTestCase.LINE_JOINER.join(
+          "var goog=goog||{},COMPILED=!1;",
+              "goog.provide=function(a){};goog.require=function(a){};"),
           "goog.array={};",
-          "function Baz$$module$Baz(){}"
-              + "Baz$$module$Baz.prototype={"
-              + "baz:function(){return goog.array.last([\"asdf\",\"asd\",\"baz\"])},"
-              + "bar:function(){return 8}"
-              + "};"
-              + "var module$Baz=Baz$$module$Baz;",
-          "var module$app={},"
-              + "Baz$$module$app=Baz$$module$Baz,"
-              + "baz$$module$app=new Baz$$module$app;"
-              + "console.log(baz$$module$app.baz());"
-              + "console.log(baz$$module$app.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "function Baz$$module$Baz(){}",
+              "Baz$$module$Baz.prototype={",
+              "baz:function(){return goog.array.last([\"asdf\",\"asd\",\"baz\"])},",
+              "bar:function(){return 8}",
+              "};",
+              "var module$Baz=Baz$$module$Baz;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "var Baz = Baz$$module$Baz,",
+              "    baz = new Baz();",
+              "console.log(baz.baz());",
+              "console.log(baz.bar());")
         });
   }
 
@@ -1643,20 +1653,25 @@ public final class CommandLineRunnerTest extends TestCase {
     setFilename(1, "app.js");
     test(
         new String[] {
-          "export default class Foo {" + "  bar() { console.log('bar'); }" + "}",
-          "var FooBar = require('./foo');"
-              + "var baz = new FooBar.default();"
-              + "console.log(baz.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "export default class Foo {",
+              "  bar() { console.log('bar'); }",
+              "}"),
+          CompilerTestCase.LINE_JOINER.join(
+             "var FooBar = require('./foo');",
+             "var baz = new FooBar.default();",
+             "console.log(baz.bar());")
         },
         new String[] {
-          "var module$foo={},"
-              + "Foo$$module$foo=function(){};"
-              + "Foo$$module$foo.prototype.bar=function(){console.log(\"bar\")};"
-              + "module$foo.default=Foo$$module$foo;",
-          "var module$app={},"
-              + "FooBar$$module$app=module$foo,"
-              + "baz$$module$app=new FooBar$$module$app.default();"
-              + "console.log(baz$$module$app.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "var module$foo={},",
+              "Foo$$module$foo=function(){};",
+              "Foo$$module$foo.prototype.bar=function(){console.log(\"bar\")};",
+              "module$foo.default=Foo$$module$foo;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "var FooBar = module$foo,",
+              "    baz = new FooBar.default();",
+              "console.log(baz.bar());")
         });
   }
 
@@ -1669,18 +1684,23 @@ public final class CommandLineRunnerTest extends TestCase {
     setFilename(1, "app.js");
     test(
         new String[] {
-          "/** @constructor */ function Foo () {}"
-              + "Foo.prototype.bar = function() { console.log('bar'); };"
-              + "module.exports = Foo;",
-          "import * as FooBar from './foo';" + "var baz = new FooBar();" + "console.log(baz.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "/** @constructor */ function Foo () {}",
+              "Foo.prototype.bar = function() { console.log('bar'); };",
+              "module.exports = Foo;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "import * as FooBar from './foo';",
+              "var baz = new FooBar();",
+              "console.log(baz.bar());")
         },
         new String[] {
-          "function Foo$$module$foo(){}"
-              + "Foo$$module$foo.prototype.bar=function(){console.log(\"bar\")};"
-              + "var module$foo=Foo$$module$foo;",
-          "var module$app={},"
-              + "baz$$module$app$$module$app=new Foo$$module$foo();"
-              + "console.log(baz$$module$app$$module$app.bar());"
+          CompilerTestCase.LINE_JOINER.join(
+              "function Foo$$module$foo(){}",
+              "Foo$$module$foo.prototype.bar=function(){console.log(\"bar\")};",
+              "var module$foo=Foo$$module$foo;"),
+          CompilerTestCase.LINE_JOINER.join(
+              "var baz$$module$app = new Foo$$module$foo();",
+              "console.log(baz$$module$app.bar());")
         });
   }
 

--- a/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
@@ -37,9 +37,8 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
            "function Hello$$module$i0(){}" +
            "var module$i0 = Hello$$module$i0;",
 
-           "var module$i1 = {};" +
-           "var Hello$$module$i1 = Hello$$module$i0;" +
-           "var hello$$module$i1 = new Hello$$module$i1();"
+           "var Hello = Hello$$module$i0;" +
+           "var hello = new Hello();"
          });
   }
 
@@ -74,15 +73,16 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
          new String[] {
            "/** @constructor */ function Hello() {} " +
            "module.exports = Hello;",
+
            "var Hello = require('./i0');" +
            "/** @type {!Hello} */ var hello = new Hello();"
          },
          new String[] {
            "function Hello$$module$i0(){}" +
            "var module$i0 = Hello$$module$i0;",
-           "var module$i1 = {};" +
-           "var Hello$$module$i1 = Hello$$module$i0;" +
-           "var hello$$module$i1 = new Hello$$module$i1();"
+
+           "var Hello = Hello$$module$i0;" +
+           "var hello = new Hello();"
          });
   }
 
@@ -91,6 +91,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
          new String[] {
            "/** @constructor */ function Hello() {} " +
            "module.exports = Hello;",
+
            "var Hello = require('./i0');" +
            "/** @type {!Hello} */ var hello = 1;"
          },
@@ -100,227 +101,254 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
   public void testMultipleExportAssignments1() {
     test(createCompilerOptions(),
         new String[] {
-            "/** @constructor */ function Hello() {} " +
-                "module.exports = Hello;" +
-                "/** @constructor */ function Bar() {} " +
-                "Bar.prototype.foobar = function() { alert('foobar'); };" +
-                "module.exports = Bar;",
-            "var Foobar = require('./i0');" +
-                "var show = new Foobar();" +
-                "show.foobar();"
+            LINE_JOINER.join(
+                "/** @constructor */ function Hello() {} ",
+                "module.exports = Hello;",
+                "/** @constructor */ function Bar() {} ",
+                "Bar.prototype.foobar = function() { alert('foobar'); };",
+                "module.exports = Bar;"),
+            LINE_JOINER.join(
+                "var Foobar = require('./i0');",
+                "var show = new Foobar();",
+                "show.foobar();")
         },
         new String[] {
-            "function Hello$$module$i0(){} " +
-                "var module$i0 = Hello$$module$i0;" +
-                "function Bar$$module$i0(){} " +
-                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
-                "module$i0=Bar$$module$i0;",
-            "var module$i1 = {};" +
-                "var Foobar$$module$i1=module$i0;" +
-                "var show$$module$i1=new Foobar$$module$i1();" +
-                "show$$module$i1.foobar();"
+            LINE_JOINER.join(
+                "function Hello$$module$i0(){} ",
+                "var module$i0 = Hello$$module$i0;",
+                "function Bar$$module$i0(){} ",
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};",
+                "module$i0=Bar$$module$i0;"),
+            LINE_JOINER.join(
+                "var Foobar = module$i0;",
+                "var show = new Foobar();",
+                "show.foobar();")
         });
   }
 
   public void testMultipleExportAssignments2() {
     test(createCompilerOptions(),
         new String[] {
-            "/** @constructor */ function Hello() {} " +
-                "module.exports.foo = Hello;" +
-                "/** @constructor */ function Bar() {} " +
-                "Bar.prototype.foobar = function() { alert('foobar'); };" +
-                "module.exports.foo = Bar;",
-            "var Foobar = require('./i0');" +
-                "var show = new Foobar.foo();" +
-                "show.foobar();"
+            LINE_JOINER.join(
+                "/** @constructor */ function Hello() {} ",
+                "module.exports.foo = Hello;",
+                "/** @constructor */ function Bar() {} ",
+                "Bar.prototype.foobar = function() { alert('foobar'); };",
+                "module.exports.foo = Bar;"),
+            LINE_JOINER.join(
+                "var Foobar = require('./i0');",
+                "var show = new Foobar.foo();",
+                "show.foobar();")
         },
         new String[] {
-            "var module$i0 = {};" +
-                "function Hello$$module$i0(){} " +
-                "module$i0.foo = Hello$$module$i0;" +
-                "function Bar$$module$i0(){} " +
-                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
-                "module$i0.foo=Bar$$module$i0;",
-            "var module$i1 = {};" +
-                "var Foobar$$module$i1=module$i0;" +
-                "var show$$module$i1=new Foobar$$module$i1.foo();" +
-                "show$$module$i1.foobar();"
+            LINE_JOINER.join(
+                "var module$i0 = {};",
+                "function Hello$$module$i0(){} ",
+                "module$i0.foo = Hello$$module$i0;",
+                "function Bar$$module$i0(){} ",
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};",
+                "module$i0.foo=Bar$$module$i0;"),
+            LINE_JOINER.join(
+                "var Foobar = module$i0;",
+                "var show = new Foobar.foo();",
+                "show.foobar();")
         });
   }
 
   public void testMultipleExportAssignments3() {
     test(createCompilerOptions(),
         new String[] {
-            "/** @constructor */ function Hello() {} " +
-                "module.exports.foo = Hello;" +
-                "/** @constructor */ function Bar() {} " +
-                "Bar.prototype.foobar = function() { alert('foobar'); };" +
-                "exports.foo = Bar;",
-            "var Foobar = require('./i0');" +
-                "var show = new Foobar.foo();" +
-                "show.foobar();"
+            LINE_JOINER.join(
+                "/** @constructor */ function Hello() {} ",
+                "module.exports.foo = Hello;",
+                "/** @constructor */ function Bar() {} ",
+                "Bar.prototype.foobar = function() { alert('foobar'); };",
+                "exports.foo = Bar;"),
+            LINE_JOINER.join(
+                "var Foobar = require('./i0');",
+                "var show = new Foobar.foo();",
+                "show.foobar();")
         },
         new String[] {
-            "var module$i0 = {};" +
-                "function Hello$$module$i0(){} " +
-                "module$i0.foo = Hello$$module$i0;" +
-                "function Bar$$module$i0(){} " +
-                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};" +
-                "module$i0.foo=Bar$$module$i0;",
-            "var module$i1 = {};" +
-                "var Foobar$$module$i1=module$i0;" +
-                "var show$$module$i1=new Foobar$$module$i1.foo();" +
-                "show$$module$i1.foobar();"
+            LINE_JOINER.join(
+                "var module$i0 = {};",
+                "function Hello$$module$i0(){} ",
+                "module$i0.foo = Hello$$module$i0;",
+                "function Bar$$module$i0(){} ",
+                "Bar$$module$i0.prototype.foobar=function(){alert(\"foobar\")};",
+                "module$i0.foo=Bar$$module$i0;"),
+            LINE_JOINER.join(
+                "var Foobar = module$i0;",
+                "var show = new Foobar.foo();",
+                "show.foobar();")
         });
   }
 
   public void testCrossModuleSubclass1() {
     test(createCompilerOptions(),
          new String[] {
-           "/** @constructor */ function Hello() {} " +
-           "module.exports = Hello;",
-           "var Hello = require('./i0');" +
-           "var util = {inherits: function (x, y){}};" +
-           "/**\n" +
-           " * @constructor\n" +
-           " * @extends {Hello}\n" +
-           " */\n" +
-           "var SubHello = function () {};" +
-           "util.inherits(SubHello, Hello);"
+             LINE_JOINER.join(
+                 "/** @constructor */ function Hello() {} ",
+                 "module.exports = Hello;"),
+             LINE_JOINER.join(
+                 "var Hello = require('./i0');",
+                 "var util = {inherits: function (x, y){}};",
+                 "/**",
+                 " * @constructor",
+                 " * @extends {Hello}",
+                 " */",
+                 "var SubHello = function () {};",
+                 "util.inherits(SubHello, Hello);")
          },
          new String[] {
-           "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
-           "var module$i1={};" +
-           "var Hello$$module$i1=Hello$$module$i0;" +
-           "var util$$module$i1={inherits:function(x,y){}};" +
-           "var SubHello$$module$i1=function(){};" +
-           "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
+             LINE_JOINER.join(
+                 "function Hello$$module$i0(){}",
+                 "var module$i0=Hello$$module$i0;"),
+             LINE_JOINER.join(
+                 "var Hello = Hello$$module$i0;",
+                 "var util = {inherits: function (x, y){}};",
+                 "var SubHello = function () {};",
+                 "util.inherits(SubHello, Hello);")
          });
   }
 
   public void testCrossModuleSubclass2() {
     test(createCompilerOptions(),
          new String[] {
-           "/** @constructor */ function Hello() {} " +
-           "module.exports = Hello;",
-           "var Hello = require('./i0');" +
-           "var util = {inherits: function (x, y){}};" +
-           "/**\n" +
-           " * @constructor\n" +
-           " * @extends {Hello}\n" +
-           " */\n" +
-           "function SubHello() {}" +
-           "util.inherits(SubHello, Hello);"
+             LINE_JOINER.join(
+                 "/** @constructor */ function Hello() {} ",
+                 "module.exports = Hello;"),
+             LINE_JOINER.join(
+                 "var Hello = require('./i0');",
+                 "var util = {inherits: function (x, y){}};",
+                 "/**",
+                 " * @constructor",
+                 " * @extends {Hello}",
+                 " */",
+                 "function SubHello() {}",
+                 "util.inherits(SubHello, Hello);")
          },
          new String[] {
-           "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
-           "var module$i1={};" +
-           "var Hello$$module$i1=Hello$$module$i0;" +
-           "var util$$module$i1={inherits:function(x,y){}};" +
-           "function SubHello$$module$i1(){}" +
-           "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
+             LINE_JOINER.join(
+                 "function Hello$$module$i0(){}",
+                 "var module$i0=Hello$$module$i0;"),
+             LINE_JOINER.join(
+                 "var Hello = Hello$$module$i0;",
+                 "var util = {inherits:function(x,y){}};",
+                 "function SubHello(){}",
+                 "util.inherits(SubHello, Hello);")
          });
   }
 
   public void testCrossModuleSubclass3() {
     test(createCompilerOptions(),
          new String[] {
-           "/** @constructor */ function Hello() {} " +
-           "module.exports = Hello;",
-           "var Hello = require('./i0');" +
-           "var util = {inherits: function (x, y){}};" +
-           "/**\n" +
-           " * @constructor\n" +
-           " * @extends {Hello}\n" +
-           " */\n" +
-           "function SubHello() { Hello.call(this); }" +
-           "util.inherits(SubHello, Hello);"
+             LINE_JOINER.join(
+                 "/** @constructor */ function Hello() {} ",
+                 "module.exports = Hello;"),
+             LINE_JOINER.join(
+                 "var Hello = require('./i0');",
+                 "var util = {inherits: function (x, y){}};",
+                 "/**",
+                 " * @constructor",
+                 " * @extends {Hello}",
+                 " */",
+                 "function SubHello() { Hello.call(this); }",
+                 "util.inherits(SubHello, Hello);")
          },
          new String[] {
-           "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
-           "var module$i1={};" +
-           "var Hello$$module$i1=Hello$$module$i0;" +
-           "var util$$module$i1={inherits:function(x,y){}};" +
-           "function SubHello$$module$i1(){ Hello$$module$i1.call(this); }" +
-           "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
+             LINE_JOINER.join(
+                 "function Hello$$module$i0(){}",
+                 "var module$i0=Hello$$module$i0;"),
+             LINE_JOINER.join(
+                 "var Hello = Hello$$module$i0;",
+                 "var util = {inherits:function(x,y){}};",
+                 "function SubHello(){ Hello.call(this); }",
+                 "util.inherits(SubHello, Hello);")
          });
   }
 
   public void testCrossModuleSubclass4() {
     test(createCompilerOptions(),
          new String[] {
-           "/** @constructor */ function Hello() {} " +
-           "module.exports = {Hello: Hello};",
-           "var i0 = require('./i0');" +
-           "var util = {inherits: function (x, y){}};" +
-           "/**\n" +
-           " * @constructor\n" +
-           " * @extends {i0.Hello}\n" +
-           " */\n" +
-           "function SubHello() { i0.Hello.call(this); }" +
-           "util.inherits(SubHello, i0.Hello);"
+             LINE_JOINER.join(
+                 "/** @constructor */ function Hello() {} ",
+                 "module.exports = {Hello: Hello};"),
+             LINE_JOINER.join(
+                 "var i0 = require('./i0');",
+                 "var util = {inherits: function (x, y){}};",
+                 "/**",
+                 " * @constructor",
+                 " * @extends {i0.Hello}",
+                 " */",
+                 "function SubHello() { i0.Hello.call(this); }",
+                 "util.inherits(SubHello, i0.Hello);")
          },
          new String[] {
-           "function Hello$$module$i0(){}" +
-           "var module$i0={Hello: Hello$$module$i0};",
-           "var module$i1={};" +
-           "var i0$$module$i1=module$i0;" +
-           "var util$$module$i1={inherits:function(x,y){}};" +
-           "function SubHello$$module$i1(){ i0$$module$i1.Hello.call(this); }" +
-           "util$$module$i1.inherits(SubHello$$module$i1,i0$$module$i1.Hello);"
+             LINE_JOINER.join(
+                 "function Hello$$module$i0(){}",
+                 "var module$i0={Hello: Hello$$module$i0};"),
+             LINE_JOINER.join(
+                 "var i0 = module$i0;",
+                 "var util = {inherits:function(x,y){}};",
+                 "function SubHello(){ i0.Hello.call(this); }",
+                 "util.inherits(SubHello,i0.Hello);")
          });
   }
 
   public void testCrossModuleSubclass5() {
     test(createCompilerOptions(),
          new String[] {
-           "/** @constructor */ function Hello() {} " +
-           "module.exports = Hello;",
-           "var Hello = require('./i0');" +
-           "var util = {inherits: function (x, y){}};" +
-           "/**\n" +
-           " * @constructor\n" +
-           " * @extends {./i0}\n" +
-           " */\n" +
-           "function SubHello() { Hello.call(this); }" +
-           "util.inherits(SubHello, Hello);"
+             LINE_JOINER.join(
+                 "/** @constructor */ function Hello() {} ",
+                 "module.exports = Hello;"),
+             LINE_JOINER.join(
+                 "var Hello = require('./i0');",
+                 "var util = {inherits: function (x, y){}};",
+                 "/**",
+                 " * @constructor",
+                 " * @extends {./i0}",
+                 " */",
+                 "function SubHello() { Hello.call(this); }",
+                 "util.inherits(SubHello, Hello);")
          },
          new String[] {
-           "function Hello$$module$i0(){}" +
-           "var module$i0=Hello$$module$i0;",
-           "var module$i1={};" +
-           "var Hello$$module$i1=Hello$$module$i0;" +
-           "var util$$module$i1={inherits:function(x,y){}};" +
-           "function SubHello$$module$i1(){ Hello$$module$i1.call(this); }" +
-           "util$$module$i1.inherits(SubHello$$module$i1,Hello$$module$i1);"
+             LINE_JOINER.join(
+                 "function Hello$$module$i0(){}",
+                 "var module$i0=Hello$$module$i0;"),
+             LINE_JOINER.join(
+                 "var Hello = Hello$$module$i0;",
+                 "var util = {inherits:function(x,y){}};",
+                 "function SubHello(){ Hello.call(this); }",
+                 "util.inherits(SubHello, Hello);")
          });
   }
 
   public void testCrossModuleSubclass6() {
     test(createCompilerOptions(),
          new String[] {
-           "/** @constructor */ function Hello() {} " +
-           "module.exports = {Hello: Hello};",
-           "var i0 = require('./i0');" +
-           "var util = {inherits: function (x, y){}};" +
-           "/**\n" +
-           " * @constructor\n" +
-           " * @extends {./i0.Hello}\n" +
-           " */\n" +
-           "function SubHello() { i0.Hello.call(this); }" +
-           "util.inherits(SubHello, i0.Hello);"
+             LINE_JOINER.join(
+                 "/** @constructor */ function Hello() {} ",
+                 "module.exports = {Hello: Hello};"),
+             LINE_JOINER.join(
+                 "var i0 = require('./i0');",
+                 "var util = {inherits: function (x, y){}};",
+                 "/**",
+                 " * @constructor",
+                 " * @extends {./i0.Hello}",
+                 " */",
+                 "function SubHello() { i0.Hello.call(this); }",
+                 "util.inherits(SubHello, i0.Hello);")
          },
          new String[] {
-           "function Hello$$module$i0(){}" +
-           "var module$i0={Hello: Hello$$module$i0};",
-           "var module$i1={};" +
-           "var i0$$module$i1=module$i0;" +
-           "var util$$module$i1={inherits:function(x,y){}};" +
-           "function SubHello$$module$i1(){ i0$$module$i1.Hello.call(this); }" +
-           "util$$module$i1.inherits(SubHello$$module$i1,i0$$module$i1.Hello);"
+             LINE_JOINER.join(
+                 "function Hello$$module$i0(){}",
+                 "var module$i0={Hello: Hello$$module$i0};"),
+             LINE_JOINER.join(
+                 "var i0 = module$i0;",
+                 "var util = {inherits:function(x,y){}};",
+                 "function SubHello(){ i0.Hello.call(this); }",
+                 "util.inherits(SubHello, i0.Hello);")
          });
   }
 


### PR DESCRIPTION
Full module rewriting of a CommonJS module should only occur if the module exports a symbol. `require` can be used within other module types as a module loader and its presence should not infer that the entire file is a CommonJS module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1626)
<!-- Reviewable:end -->
