### PR TITLE
Rewrite CommonJS require.ensure calls to be an IIFE

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -198,6 +198,27 @@ public final class ProcessCommonJSModules implements CompilerPass {
         visitRequireCall(t, n, parent);
       }
 
+      // Finds calls to require.ensure which is a method to allow async loading of
+      // CommonJS modules:
+      //
+      // require.ensure(['/path/to/module1', '/path/to/module2'], function(require) {
+      //    var module1 = require('/path/to/module1');
+      //    var module2 = require('/path/to/module2');
+      // });
+      //
+      // will be rewritten as an IIFE
+      //
+      // (function() {
+      //   var module1 = require('/path/to/module1');
+      //   var module2 = require('/path/to/module2');
+      // })()
+      //
+      // See http://wiki.commonjs.org/wiki/Modules/Async/A
+      //     http://www.injectjs.com/docs/0.7.x/cjs/require.ensure.html
+      if (n.isCall() && n.getChildCount() == 3
+          && n.getFirstChild().matchesQualifiedName("require.ensure")) {
+        visitRequireEnsureCall(n);
+      }
 
       // Detects UMD pattern, by checking for CommonJS exports and AMD define
       // statements in if-conditions and rewrites the if-then-else block as
@@ -321,6 +342,33 @@ public final class ProcessCommonJSModules implements CompilerPass {
       script.addChildToFront(IR.exprResult(
           IR.call(IR.getprop(IR.name("goog"), IR.string("require")),
               IR.string(moduleName))).useSourceInfoIfMissingFromForTree(require));
+      compiler.reportCodeChange();
+    }
+
+    /**
+     * Visit require.ensure calls. Replace the call with an IIFE.
+     */
+    private void visitRequireEnsureCall(Node n) {
+      Preconditions.checkState(n.getChildCount() == 3);
+      Node callbackFunction = n.getChildAtIndex(2);
+
+      // We only support the form where the first argument is an array literal and
+      // the thc second a callback function which has a single argument
+      // with the name "require".
+      if (!(n.getSecondChild().isArrayLit() && callbackFunction.isFunction()
+          && callbackFunction.getChildCount() == 3 && callbackFunction.getSecondChild().getChildCount() == 1
+          && callbackFunction.getSecondChild().getFirstChild().matchesQualifiedName("require"))) {
+        return;
+      }
+
+      callbackFunction.detachFromParent();
+
+      // Remove the "require" argument from the parameter list.
+      callbackFunction.getSecondChild().removeChildren();
+      n.removeChildren();
+      n.putBooleanProp(Node.FREE_CALL, true);
+      n.addChildrenToFront(callbackFunction);
+
       compiler.reportCodeChange();
     }
 

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -323,4 +323,23 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "goog.require('module$other'); module$other;"
     );
   }
+
+  public void testRequireEnsure() {
+    setFilename("test");
+    testModules(
+        LINE_JOINER.join(
+            "require.ensure(['other'], function(require) {",
+            "  var other = require('other');",
+            "  var bar = other;",
+            "  module.exports = bar;",
+            "});"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "goog.require('module$other');",
+            "(function() {",
+            "  var other=module$other;",
+            "  var bar = other;",
+            "  module$test = bar;",
+            "})()"));
+  }
 }


### PR DESCRIPTION
`require.ensure` is defined by the CommonJS spec: http://wiki.commonjs.org/wiki/Modules/Async/A. It is implemented by the [InjectJS module loader](http://www.injectjs.com/docs/0.7.x/cjs/require.ensure.html) and is also used by WebPack to support async loading of CommonJS modules.

It's a key component to allowing CommonJS modules to work in a browser uncompiled.

After compilation, it serves no use as the modules are all bundled. This removes the calls to `require.ensure` during module rewriting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1630)
<!-- Reviewable:end -->
