### PR TITLE
Simplify IObject<(string|number),T> to IObject<string,T> in the externs

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -956,7 +956,7 @@ Navigator.prototype.javaEnabled = function() {};
 
 /**
  * @constructor
- * @implements {IObject<(string|number),!Plugin>}
+ * @implements {IObject<string, !Plugin>}
  * @implements {IArrayLike<!Plugin>}
  * @see https://developer.mozilla.org/en/DOM/PluginArray
  */

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -455,7 +455,7 @@ NodeList.prototype.item = function(index) {};
 
 /**
  * @constructor
- * @implements {IObject<(string|number), T>}
+ * @implements {IObject<string, T>}
  * @implements {IArrayLike<T>}
  * @template T
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1780488922

--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -26,7 +26,7 @@
 
 /**
  * @constructor
- * @implements {IObject<(string|number),T>}
+ * @implements {IObject<string, T>}
  * @implements {IArrayLike<T>}
  * @template T
  * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75708506
@@ -57,7 +57,7 @@ HTMLCollection.prototype.namedItem = function(name) {};
 
 /**
  * @constructor
- * @implements {IObject<(string|number),HTMLOptionElement>}
+ * @implements {IObject<string, HTMLOptionElement>}
  * @implements {IArrayLike<!HTMLOptionElement>}
  * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection
  */


### PR DESCRIPTION
These constructors already implement `IArrayLike<T>`, and `IArrayLike<T>` extends `IObject<number,T>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1645)
<!-- Reviewable:end -->