### PR TITLE
Remove the special case for interfaces in isSubTypeOf() in FunctionType

### DIFF
--- a/src/com/google/javascript/rhino/jstype/FunctionType.java
+++ b/src/com/google/javascript/rhino/jstype/FunctionType.java
@@ -1069,15 +1069,6 @@ public class FunctionType extends PrototypeObjectType implements FunctionTypeI {
 
     if (that.isFunctionType()) {
       FunctionType other = that.toMaybeFunctionType();
-      if (other.isInterface()) {
-        // Any function can be assigned to an interface function.
-        return true;
-      }
-      if (isInterface()) {
-        // An interface function cannot be assigned to anything.
-        return false;
-      }
-
       return treatThisTypesAsCovariant(other, implicitImplCache)
           && this.call.isSubtype(other.call, implicitImplCache);
     }

--- a/test/com/google/javascript/jscomp/TypeValidatorTest.java
+++ b/test/com/google/javascript/jscomp/TypeValidatorTest.java
@@ -203,6 +203,21 @@ public final class TypeValidatorTest extends CompilerTestCase {
     assertMismatches(Collections.<TypeMismatch>emptyList());
   }
 
+  public void testExtendInterfaceNoExtraWarning() {
+    testSame(LINE_JOINER.join(
+        "/** @interface */",
+        "function SuperInterface() {}",
+        "/**",
+        " * @constructor",
+        " * @extends {SuperInterface}",
+        " */",
+        "function Sub() {}",
+        "/** @param {!Function} x */ function f(x) {}",
+        "f(SuperInterface);"),
+        TypeCheck.CONFLICTING_EXTENDED_TYPE);
+    assertMismatches(Collections.<TypeMismatch>emptyList());
+  }
+
   private TypeMismatch fromNatives(JSTypeNative a, JSTypeNative b) {
     JSTypeRegistry registry = compiler.getTypeRegistry();
     return new TypeMismatch(


### PR DESCRIPTION
The special case doesn't quite make sense and it's untested. it causes TypeValidator to generate an obscure warning on this code:
```js
/** @interface */ function Foo() {};
var /** Function */ x = Foo;
```
```
input0:3: WARNING - initializing variable
found   : function (this:Foo): ?
required: (Function|null)
var /** Function */ x = Foo;
                            ^
```
It also causes TypeValidator to generate an extra warning when a class accidentally extends an interface.

NTI doesn't have this special handling.

Fixes #1643.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1646)
<!-- Reviewable:end -->