### PR TITLE
Remove @nosideeffects from functions that @throws in externs

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -62,7 +62,6 @@ HTMLCanvasElement.prototype.height;
  * @param {...*} var_args
  * @return {string}
  * @throws {Error}
- * @nosideeffects
  */
 HTMLCanvasElement.prototype.toDataURL = function(opt_type, var_args) {};
 
@@ -143,7 +142,6 @@ CanvasRenderingContext2D.prototype.setTransform = function(
  * @param {number} y1
  * @return {CanvasGradient}
  * @throws {Error}
- * @nosideeffects
  */
 CanvasRenderingContext2D.prototype.createLinearGradient = function(
     x0, y0, x1, y1) {};
@@ -157,7 +155,6 @@ CanvasRenderingContext2D.prototype.createLinearGradient = function(
  * @param {number} r1
  * @return {CanvasGradient}
  * @throws {Error}
- * @nosideeffects
  */
 CanvasRenderingContext2D.prototype.createRadialGradient = function(
     x0, y0, r0, x1, y1, r1) {};
@@ -167,7 +164,6 @@ CanvasRenderingContext2D.prototype.createRadialGradient = function(
  * @param {string} repetition
  * @return {CanvasPattern}
  * @throws {Error}
- * @nosideeffects
  */
 CanvasRenderingContext2D.prototype.createPattern = function(
     image, repetition) {};
@@ -374,7 +370,6 @@ CanvasRenderingContext2D.prototype.createImageData = function(sw, sh) {};
  * @param {number} sh
  * @return {ImageData}
  * @throws {Error}
- * @nosideeffects
  */
 CanvasRenderingContext2D.prototype.getImageData = function(sx, sy, sw, sh) {};
 

--- a/externs/es3.js
+++ b/externs/es3.js
@@ -384,7 +384,6 @@ Object.prototype.watch = function(prop, handler) {};
 /**
  * @constructor
  * @param {...*} var_args
- * @nosideeffects
  * @throws {Error}
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
  */

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -361,7 +361,6 @@ function Transferable() {}
  * @constructor
  * @noalias
  * @throws {Error}
- * @nosideeffects
  * @implements {Transferable}
  */
 function ArrayBuffer(length) {}
@@ -1131,7 +1130,6 @@ Float64Array.prototype.copyWithin = function(target, start, opt_end) {};
  * @extends {ArrayBufferView}
  * @noalias
  * @throws {Error}
- * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/DataView
  */
 function DataView(buffer, opt_byteOffset, opt_byteLength) {}
@@ -1140,7 +1138,6 @@ function DataView(buffer, opt_byteOffset, opt_byteLength) {}
  * @param {number} byteOffset
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getInt8 = function(byteOffset) {};
 
@@ -1148,7 +1145,6 @@ DataView.prototype.getInt8 = function(byteOffset) {};
  * @param {number} byteOffset
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getUint8 = function(byteOffset) {};
 
@@ -1157,7 +1153,6 @@ DataView.prototype.getUint8 = function(byteOffset) {};
  * @param {boolean=} opt_littleEndian
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getInt16 = function(byteOffset, opt_littleEndian) {};
 
@@ -1166,7 +1161,6 @@ DataView.prototype.getInt16 = function(byteOffset, opt_littleEndian) {};
  * @param {boolean=} opt_littleEndian
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getUint16 = function(byteOffset, opt_littleEndian) {};
 
@@ -1175,7 +1169,6 @@ DataView.prototype.getUint16 = function(byteOffset, opt_littleEndian) {};
  * @param {boolean=} opt_littleEndian
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getInt32 = function(byteOffset, opt_littleEndian) {};
 
@@ -1184,7 +1177,6 @@ DataView.prototype.getInt32 = function(byteOffset, opt_littleEndian) {};
  * @param {boolean=} opt_littleEndian
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getUint32 = function(byteOffset, opt_littleEndian) {};
 
@@ -1193,7 +1185,6 @@ DataView.prototype.getUint32 = function(byteOffset, opt_littleEndian) {};
  * @param {boolean=} opt_littleEndian
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getFloat32 = function(byteOffset, opt_littleEndian) {};
 
@@ -1202,7 +1193,6 @@ DataView.prototype.getFloat32 = function(byteOffset, opt_littleEndian) {};
  * @param {boolean=} opt_littleEndian
  * @return {number}
  * @throws {Error}
- * @nosideeffects
  */
 DataView.prototype.getFloat64 = function(byteOffset, opt_littleEndian) {};
 


### PR DESCRIPTION
By definition, throwing an exception is a side effect, so these two
annotations are contradictory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1648)
<!-- Reviewable:end -->
