### PR TITLE
Remove duplicate INVALID_NO_SIDE_EFFECT_ANNOTATION.

### DIFF
--- a/src/com/google/javascript/jscomp/MarkNoSideEffectCalls.java
+++ b/src/com/google/javascript/jscomp/MarkNoSideEffectCalls.java
@@ -38,11 +38,6 @@ import java.util.Set;
  *
  */
 class MarkNoSideEffectCalls implements CompilerPass {
-  static final DiagnosticType INVALID_NO_SIDE_EFFECT_ANNOTATION =
-      DiagnosticType.error(
-          "JSC_INVALID_NO_SIDE_EFFECT_ANNOTATION",
-          "@nosideeffects may only appear in externs files.");
-
   private final AbstractCompiler compiler;
 
   // Left hand side expression associated with a function node that
@@ -119,7 +114,7 @@ class MarkNoSideEffectCalls implements CompilerPass {
     @Override
     public void visit(NodeTraversal traversal, Node node, Node parent) {
       if (!inExterns && hasNoSideEffectsAnnotation(node)) {
-        traversal.report(node, INVALID_NO_SIDE_EFFECT_ANNOTATION);
+        traversal.report(node, PureFunctionIdentifier.INVALID_NO_SIDE_EFFECT_ANNOTATION);
       }
 
       if (node.isGetProp()) {

--- a/test/com/google/javascript/jscomp/MarkNoSideEffectCallsTest.java
+++ b/test/com/google/javascript/jscomp/MarkNoSideEffectCallsTest.java
@@ -16,7 +16,7 @@
 
 package com.google.javascript.jscomp;
 
-import static com.google.javascript.jscomp.MarkNoSideEffectCalls.INVALID_NO_SIDE_EFFECT_ANNOTATION;
+import static com.google.javascript.jscomp.PureFunctionIdentifier.INVALID_NO_SIDE_EFFECT_ANNOTATION;
 
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;


### PR DESCRIPTION
Remove the one in MarkNoSideEffectCalls and just use the one in
PureFunctionIdentifier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1649)
<!-- Reviewable:end -->
