### PR TITLE
Support class name alias in Es6ToEs3Converter

### DIFF
--- a/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
@@ -444,6 +444,44 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
   }
 
   /**
+   * Class expressions that have class name aliases supplied.
+   */
+  public void testClassExpressionWithClassNameAlias() {
+    test("var C = class Clazz {}",
+        "/** @constructor @struct */ var C = function() { var Clazz = C; }");
+
+    test("var C = class Clazz { foo() {} }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */ var C = function() { var Clazz = C; }",
+            "C.prototype.foo = function() { var Clazz = C; }"));
+
+    test("var C = class Clazz { foo() { return Clazz; } }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */ var C = function() { var Clazz = C; }",
+            "C.prototype.foo = function() { var Clazz = C; return Clazz; }"));
+
+    test("var C = class C { foo() {} }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */ var C = function() {}",
+            "C.prototype.foo = function() {};"));
+
+    test("var C = class Clazz { foo() { var Clazz = 1; } }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */ var C = function() { var Clazz = C; }",
+            "C.prototype.foo = function() { var Clazz = 1; };"));
+
+    test("var C = class Clazz { foo(Clazz) {} }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */ var C = function() { var Clazz = C; }",
+            "C.prototype.foo = function(Clazz) {};"));
+
+    test("ns.C = class Clazz { foo() {} }",
+        LINE_JOINER.join(
+            "/** @constructor @struct */ ns.C = function() { var Clazz = ns.C; }",
+            "ns.C.prototype.foo = function() { var Clazz = ns.C; }"));
+  }
+
+  /**
    * Class expressions that are the RHS of an assignment.
    */
   public void testClassExpressionInAssignment() {
@@ -672,14 +710,6 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
         CANNOT_CONVERT_YET);
   }
 
-  public void testMultiNameClass() {
-    test("var F = class G {}",
-        "/** @constructor @struct */ var F = function() {};");
-
-    test("F = class G {}",
-        "/** @constructor @struct */ F = function() {};");
-  }
-
   public void testClassNested() {
     test(
         "class C { f() { class D {} } }",
@@ -885,7 +915,7 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
   public void testMockingInFunction() {
     // Classes cannot be reassigned in function scope.
     testError("function f() { class C {} C = function() {};}",
-              Es6ToEs3Converter.CLASS_REASSIGNMENT);
+        Es6ToEs3Converter.CLASS_REASSIGNMENT);
   }
 
   // Make sure we don't crash on this code.

--- a/test/com/google/javascript/jscomp/Es6VariableReferenceCheckTest.java
+++ b/test/com/google/javascript/jscomp/Es6VariableReferenceCheckTest.java
@@ -253,7 +253,7 @@ public final class Es6VariableReferenceCheckTest extends CompilerTestCase {
             "      let e = 1;",
             "    }",
             "  } catch (e) {",
-            "      var e;",
+            "    var e;",
             "  }",
             "}"));
 
@@ -277,8 +277,24 @@ public final class Es6VariableReferenceCheckTest extends CompilerTestCase {
     assertNoWarning("class A { f() { return 1729; } }");
   }
 
-  public void testRedeclareClassName() {
+  public void testClassName() {
     assertNoWarning("var Clazz = class Foo {}; var Foo = 3;");
+
+    assertNoWarning(LINE_JOINER.join(
+        "var Foo = class Bar {",
+        "  bar() {",
+        "    var Bar = 3;",
+        "    return Bar;",
+        "  }",
+        "};"));
+
+    assertNoWarning(LINE_JOINER.join(
+        "var Foo = class Bar {",
+        "  bar() {",
+        "    var Foo = 3;",
+        "    return Clasz;",
+        "  }",
+        "};"));
   }
 
   public void testClassExtend() {

--- a/test/com/google/javascript/jscomp/VarCheckTest.java
+++ b/test/com/google/javascript/jscomp/VarCheckTest.java
@@ -174,7 +174,19 @@ public final class VarCheckTest extends Es6CompilerTestCase {
     testSameEs6("var x = class x {};");
     testSameEs6("var y = class x {};");
     testSameEs6("var y = class x { foo() { return new x; } };");
+    testSameEs6("var y = class x extends class { constructor() { x; } } {};");
     testErrorEs6("var Foo = class extends Bar {};", VarCheck.UNDEFINED_VAR_ERROR);
+
+    testErrorEs6(LINE_JOINER.join(
+        "var Foo = class Bar {",
+        "  bar() {",
+        "    var Bar = 3;",
+        "    return Bar;",
+        "  }",
+        "};",
+        "class Baz extends Foo {",
+        "  bar () { return Bar; }",
+        "}"), VarCheck.UNDEFINED_VAR_ERROR);
   }
 
   public void testVarReferenceInExterns() {

--- a/test/com/google/javascript/jscomp/VariableReferenceCheckTest.java
+++ b/test/com/google/javascript/jscomp/VariableReferenceCheckTest.java
@@ -99,6 +99,7 @@ public final class VariableReferenceCheckTest extends Es6CompilerTestCase {
   }
 
   public void testReferencedBleedingFunction() {
+    assertRedeclare("var x = function y() { var y = 1; }");
     assertNoWarning("var x = function y() { return y(); }");
   }
 
@@ -257,6 +258,7 @@ public final class VariableReferenceCheckTest extends Es6CompilerTestCase {
     enableUnusedLocalAssignmentCheck = true;
     assertNoWarning("for (var prop in obj) {}");
   }
+
   /**
    * Expects the JS to generate one bad-read error.
    */


### PR DESCRIPTION
Define the class name alias in member functions, eg.:
Before conversion:

``` js
var C = class Clazz {
  foo() {}
};
```

After conversion:

``` js
/** @constructor @struct */
var C = function() {
  var Clazz = C;
}
C.prototype.foo = function() {
  var Clazz = C;
}
```

Fixes #1546.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1658)

<!-- Reviewable:end -->
