### PR TITLE
Fix insertion order when normalizing "const x = 1, y = 2"

### DIFF
--- a/src/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclaration.java
+++ b/src/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclaration.java
@@ -156,30 +156,45 @@ public final class Es6RewriteBlockScopedDeclaration extends AbstractPostOrderCal
     }
   };
 
+  private static void extractInlineJSDoc(Node srcDeclaration, Node srcName, Node destDeclaration) {
+    JSDocInfo existingInfo = srcDeclaration.getJSDocInfo();
+    if (existingInfo == null) {
+      // Extract inline JSDoc from "src" and add it to the "dest" node.
+      existingInfo = srcName.getJSDocInfo();
+      srcName.setJSDocInfo(null);
+    }
+    JSDocInfoBuilder builder = JSDocInfoBuilder.maybeCopyFrom(existingInfo);
+    destDeclaration.setJSDocInfo(builder.build());
+  }
+
+  private static void maybeAddConstJSDoc(Node srcDeclaration, Node srcName, Node destDeclaration) {
+    if (srcDeclaration.isConst()) {
+      extractInlineJSDoc(srcDeclaration, srcName, destDeclaration);
+      JSDocInfoBuilder builder = JSDocInfoBuilder.maybeCopyFrom(destDeclaration.getJSDocInfo());
+      builder.recordConstancy();
+      destDeclaration.setJSDocInfo(builder.build());
+    }
+  }
+
+  private static void handleDeclarationList(Node declarationList, Node parent) {
+    // Normalize: "const i = 0, j = 0;" becomes "/** @const */ var i = 0; /** @const */ var j = 0;"
+    while (declarationList.hasMoreThanOneChild()) {
+      Node name = declarationList.getLastChild();
+      Node newDeclaration = IR.var(name.detachFromParent()).useSourceInfoFrom(declarationList);
+      maybeAddConstJSDoc(declarationList, name, newDeclaration);
+      parent.addChildAfter(newDeclaration, declarationList);
+    }
+    maybeAddConstJSDoc(declarationList, declarationList.getFirstChild(), declarationList);
+    declarationList.setType(Token.VAR);
+  }
+
   private void varify() {
     if (!letConsts.isEmpty()) {
       for (Node n : letConsts) {
         if (n.isConst()) {
-          // Normalize declarations like "const x = 1, y = 2;" so that inline
-          // type annotations are preserved.
-          for (Node child : n.children()) {
-            Node declaration = IR.var(child.detachFromParent());
-            declaration.useSourceInfoFrom(n);
-            JSDocInfo existingInfo = n.getJSDocInfo();
-            if (existingInfo == null) {
-              existingInfo = child.getJSDocInfo();
-              child.setJSDocInfo(null);
-            }
-            JSDocInfoBuilder builder = JSDocInfoBuilder.maybeCopyFrom(existingInfo);
-            builder.recordConstancy();
-            JSDocInfo info = builder.build();
-            declaration.setJSDocInfo(info);
-            n.getParent().addChildAfter(declaration, n);
-          }
-          n.detachFromParent();
-        } else {
-          n.setType(Token.VAR);
+          handleDeclarationList(n, n.getParent());
         }
+        n.setType(Token.VAR);
       }
       compiler.reportCodeChange();
     }
@@ -359,33 +374,16 @@ public final class Es6RewriteBlockScopedDeclaration extends AbstractPostOrderCal
               if (NodeUtil.isNameDeclaration(reference.getParent())) {
                 Node declaration = reference.getParent();
                 Node grandParent = declaration.getParent();
-                // Normalize: "let i = 0, j = 0;" becomes "let i = 0; let j = 0;"
-                while (declaration.getChildCount() > 1) {
-                  Node name = declaration.getLastChild();
-                  grandParent.addChildAfter(
-                      IR.declaration(
-                          name.detachFromParent(), declaration.getType())
-                          .useSourceInfoIfMissingFromForTree(declaration),
-                      declaration);
-                }
-
+                handleDeclarationList(declaration, grandParent);
                 declaration = reference.getParent(); // Might have changed after normalization.
                 // Change declaration to assignment, or just drop it if there's
                 // no initial value.
                 if (reference.hasChildren()) {
-                  JSDocInfo existingInfo = declaration.getJSDocInfo();
-                  if (existingInfo == null) {
-                    existingInfo = reference.getJSDocInfo();
-                    reference.setJSDocInfo(null);
-                  }
-                  JSDocInfoBuilder builder = JSDocInfoBuilder.maybeCopyFrom(existingInfo);
-                  if (declaration.isConst()) {
-                    builder.recordConstancy();
-                  }
-
                   Node newReference = reference.cloneNode();
                   Node assign = IR.assign(newReference, reference.removeFirstChild());
-                  assign.setJSDocInfo(builder.build());
+                  extractInlineJSDoc(declaration, reference, declaration);
+                  maybeAddConstJSDoc(declaration, reference, declaration);
+                  assign.setJSDocInfo(declaration.getJSDocInfo());
 
                   Node replacement = IR.exprResult(assign)
                       .useSourceInfoIfMissingFromForTree(declaration);

--- a/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
+++ b/test/com/google/javascript/jscomp/Es6RewriteBlockScopedDeclarationTest.java
@@ -53,6 +53,7 @@ public final class Es6RewriteBlockScopedDeclarationTest extends CompilerTestCase
   public void testSimple() {
     test("let x = 3;", "var x = 3;");
     test("const x = 3;", "/** @const */ var x = 3;");
+    test("const x = 1, y = 2;", "/** @const */ var x = 1; /** @const */ var y = 2;");
     test("const a = 0; a;", "/** @const */ var a = 0; a;");
     test("if (a) { let x; }", "if (a) { var x; }");
     test("function f() { const x = 3; }",
@@ -477,6 +478,18 @@ public final class Es6RewriteBlockScopedDeclarationTest extends CompilerTestCase
             "  }($jscomp$loop$0);",
             "}"));
 
+    // Preserve inline type annotation
+    test(
+        "for (;;) { let /** number */ x = 3; var f = function() { return x; } }",
+        LINE_JOINER.join(
+            "var $jscomp$loop$0 = {};",
+            "for (;;$jscomp$loop$0 = {x: $jscomp$loop$0.x}) {",
+            "  /** @type {number} */ $jscomp$loop$0.x = 3;",
+            "  var f = function($jscomp$loop$0) {",
+            "    return function() { return $jscomp$loop$0.x}",
+            "  }($jscomp$loop$0);",
+            "}"));
+
     // Preserve inline type annotation and constancy
     test(
         "for (;;) { const /** number */ x = 3; var f = function() { return x; } }",
@@ -486,6 +499,34 @@ public final class Es6RewriteBlockScopedDeclarationTest extends CompilerTestCase
             "  /** @const @type {number} */ $jscomp$loop$0.x = 3;",
             "  var f = function($jscomp$loop$0) {",
             "    return function() { return $jscomp$loop$0.x}",
+            "  }($jscomp$loop$0);",
+            "}"));
+
+    // Preserve inline type annotation on declaration lists
+    test(LINE_JOINER.join(
+        "for (;;) { let /** number */ x = 3, /** number */ y = 4;",
+        "var f = function() { return x + y; } }"),
+        LINE_JOINER.join(
+            "var $jscomp$loop$0 = {};",
+            "for (;;$jscomp$loop$0 = {x: $jscomp$loop$0.x, y: $jscomp$loop$0.y}) {",
+            "  /** @type {number} */ $jscomp$loop$0.x = 3;",
+            "  /** @type {number} */ $jscomp$loop$0.y = 4;",
+            "  var f = function($jscomp$loop$0) {",
+            "    return function() { return $jscomp$loop$0.x + $jscomp$loop$0.y}",
+            "  }($jscomp$loop$0);",
+            "}"));
+
+    // Preserve inline type annotation and constancy on declaration lists
+    test(LINE_JOINER.join(
+        "for (;;) { const /** number */ x = 3, /** number */ y = 4;",
+        "var f = function() { return x + y; } }"),
+        LINE_JOINER.join(
+            "var $jscomp$loop$0 = {};",
+            "for (;;$jscomp$loop$0 = {x: $jscomp$loop$0.x, y: $jscomp$loop$0.y}) {",
+            "  /** @const @type {number} */ $jscomp$loop$0.x = 3;",
+            "  /** @const @type {number} */ $jscomp$loop$0.y = 4;",
+            "  var f = function($jscomp$loop$0) {",
+            "    return function() { return $jscomp$loop$0.x + $jscomp$loop$0.y}",
             "  }($jscomp$loop$0);",
             "}"));
 


### PR DESCRIPTION
This was normalized to:
```js
/** @const */ var y = 2;
/** @const */ var x = 1;
```
because the insertion order was wrong. Fixed now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1660)
<!-- Reviewable:end -->
