### PR TITLE
Normalize assignment shorthand like "x += 1" to "x = x + 1"

### DIFF
--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -1868,6 +1868,54 @@ public final class NodeUtil {
     throw new IllegalArgumentException("Not an assignment op:" + n);
   }
 
+  static int getAssignOpFromOp(Node n) {
+    switch (n.getType()) {
+      case Token.BITOR:
+        return Token.ASSIGN_BITOR;
+      case Token.BITXOR:
+        return Token.ASSIGN_BITXOR;
+      case Token.BITAND:
+        return Token.ASSIGN_BITAND;
+      case Token.LSH:
+        return Token.ASSIGN_LSH;
+      case Token.RSH:
+        return Token.ASSIGN_RSH;
+      case Token.URSH:
+        return Token.ASSIGN_URSH;
+      case Token.ADD:
+        return Token.ASSIGN_ADD;
+      case Token.SUB:
+        return Token.ASSIGN_SUB;
+      case Token.MUL:
+        return Token.ASSIGN_MUL;
+      case Token.DIV:
+        return Token.ASSIGN_DIV;
+      case Token.MOD:
+        return Token.ASSIGN_MOD;
+      default:
+        throw new IllegalStateException("Unexpected operator: " + n);
+    }
+  }
+
+  static boolean hasCorrespondingAssignmentOp(Node n) {
+    switch (n.getType()) {
+      case Token.BITOR:
+      case Token.BITXOR:
+      case Token.BITAND:
+      case Token.LSH:
+      case Token.RSH:
+      case Token.URSH:
+      case Token.ADD:
+      case Token.SUB:
+      case Token.MUL:
+      case Token.DIV:
+      case Token.MOD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   /**
    * Determines if the given node contains a function statement or function
    * expression.

--- a/src/com/google/javascript/jscomp/Normalize.java
+++ b/src/com/google/javascript/jscomp/Normalize.java
@@ -527,6 +527,10 @@ class Normalize implements CompilerPass {
       if (n.isFunction()) {
         moveNamedFunctions(n.getLastChild());
       }
+
+      if (NodeUtil.isCompoundAssignementOp(n)) {
+        normalizeAssignShorthand(n);
+      }
     }
 
     // TODO(johnlenz): Move this to NodeTypeNormalizer once the unit tests are
@@ -680,6 +684,22 @@ class Normalize implements CompilerPass {
           previous = current;
         }
         current = next;
+      }
+    }
+
+    private void normalizeAssignShorthand(Node shorthand) {
+      if (shorthand.getFirstChild().isName()) {
+        Node name = shorthand.getFirstChild();
+        shorthand.setType(NodeUtil.getOpFromAssignmentOp(shorthand));
+        Node parent = shorthand.getParent();
+        Node insertPoint = IR.empty();
+        parent.replaceChild(shorthand, insertPoint);
+        Node assign = IR.assign(name.cloneNode().useSourceInfoFrom(name), shorthand)
+            .useSourceInfoFrom(shorthand);
+        assign.setJSDocInfo(shorthand.getJSDocInfo());
+        shorthand.setJSDocInfo(null);
+        parent.replaceChild(insertPoint, assign);
+        compiler.reportCodeChange();
       }
     }
 

--- a/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
@@ -1430,6 +1430,7 @@ public final class CollapsePropertiesTest extends CompilerTestCase {
     testSame("var x = 10; function f() { var y = x; x+=1; alert(y)} ");
     test("var x = {}; x.x = 10; function f() {var y=x.x; x.x++; alert(y)}",
          "var x$x = 10; function f() {var y=x$x; x$x++; alert(y)}");
+    disableNormalize();
     test("var x = {}; x.x = 10; function f() {var y=x.x; x.x+=1; alert(y)}",
          "var x$x = 10; function f() {var y=x$x; x$x+=1; alert(y)}");
   }

--- a/test/com/google/javascript/jscomp/DenormalizeTest.java
+++ b/test/com/google/javascript/jscomp/DenormalizeTest.java
@@ -101,6 +101,22 @@ public final class DenormalizeTest extends CompilerTestCase {
          "for (;a<2;a++) foo()}");
   }
 
+  public void testAssignShorthand() {
+    test("x = x | 1;", "x |= 1;");
+    test("x = x ^ 1;", "x ^= 1;");
+    test("x = x & 1;", "x &= 1;");
+    test("x = x << 1;", "x <<= 1;");
+    test("x = x >> 1;", "x >>= 1;");
+    test("x = x >>> 1;", "x >>>= 1;");
+    test("x = x + 1;", "x += 1;");
+    test("x = x - 1;", "x -= 1;");
+    test("x = x * 1;", "x *= 1;");
+    test("x = x / 1;", "x /= 1;");
+    test("x = x % 1;", "x %= 1;");
+
+    test("/** @suppress {const} */ x = x + 1;", "/** @suppress {const} */ x += 1;");
+  }
+
   /**
    * Create a class to combine the Normalize and Denormalize passes.
    * This is needed because the enableNormalize() call on CompilerTestCase

--- a/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
+++ b/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
@@ -83,12 +83,16 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase  {
   }
 
   public void testDoNotInlineAssignmentOp() {
+    disableNormalize();
     noInline("var x = 1; x += 1;");
     noInline("var x = 1; x -= 1;");
+    enableNormalize(true);
   }
 
   public void testDoNotInlineIntoLhsOfAssign() {
+    disableNormalize();
     noInline("var x = 1; x += 3;");
+    enableNormalize(true);
   }
 
   public void testMultiUse() {

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -3430,6 +3430,26 @@ public final class IntegrationTest extends IntegrationTestCase {
     test(options, "function f(x) { if (x) var x=5; }", "function f(x) { if (x) x=5; }");
   }
 
+  // GitHub issue #250: https://github.com/google/closure-compiler/issues/250
+  public void testInlineStringConcat() {
+    CompilerOptions options = createCompilerOptions();
+    CompilationLevel.ADVANCED_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
+    test(options, LINE_JOINER.join(
+        "function f() {",
+        "  var x = '';",
+        "  x += '1';",
+        "  x += '2';",
+        "  x += '3';",
+        "  x += '4';",
+        "  x += '5';",
+        "  x += '6';",
+        "  x += '7';",
+        "  return x;",
+        "}",
+        "window.f = f;"),
+        "window.a = function() { var b; b = '1234'; b += '5'; b += '6'; return b += '7'; }");
+  }
+
   /** Creates a CompilerOptions object with google coding conventions. */
   @Override
   protected CompilerOptions createCompilerOptions() {

--- a/test/com/google/javascript/jscomp/NameAnalyzerTest.java
+++ b/test/com/google/javascript/jscomp/NameAnalyzerTest.java
@@ -804,6 +804,7 @@ public final class NameAnalyzerTest extends CompilerTestCase {
 
   public void testComplexAssigns() {
     // Complex assigns are not removed by the current pass.
+    disableNormalize();
     testSame("var x = 0; x += 3; x *= 5;");
   }
 
@@ -818,6 +819,7 @@ public final class NameAnalyzerTest extends CompilerTestCase {
 
   public void testComplexNestedAssigns1() {
     // TODO(nicksantos): Make NameAnalyzer smarter, so that we can eliminate y.
+    disableNormalize();
     testSame("var x = 0; var y = 2; y += x = 3; window.alert(x);");
   }
 
@@ -827,6 +829,7 @@ public final class NameAnalyzerTest extends CompilerTestCase {
   }
 
   public void testComplexNestedAssigns3() {
+    disableNormalize();
     test("var x = 0; var y = x += 3; window.alert(x);",
          "var x = 0; x += 3; window.alert(x);");
   }

--- a/test/com/google/javascript/jscomp/NormalizeTest.java
+++ b/test/com/google/javascript/jscomp/NormalizeTest.java
@@ -92,6 +92,22 @@ public final class NormalizeTest extends CompilerTestCase {
          "if (true)a:{ var a; var b; }");
   }
 
+  public void testAssignShorthand() {
+    test("x |= 1;", "x = x | 1;");
+    test("x ^= 1;", "x = x ^ 1;");
+    test("x &= 1;", "x = x & 1;");
+    test("x <<= 1;", "x = x << 1;");
+    test("x >>= 1;", "x = x >> 1;");
+    test("x >>>= 1;", "x = x >>> 1;");
+    test("x += 1;", "x = x + 1;");
+    test("x -= 1;", "x = x - 1;");
+    test("x *= 1;", "x = x * 1;");
+    test("x /= 1;", "x = x / 1;");
+    test("x %= 1;", "x = x % 1;");
+
+    test("/** @suppress {const} */ x += 1;", "/** @suppress {const} */ x = x + 1;");
+  }
+
   public void testDuplicateVarInExterns() {
     test("var extern;",
          "/** @suppress {duplicate} */ var extern = 3;",

--- a/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java
@@ -326,7 +326,7 @@ public final class PeepholeSubstituteAlternateSyntaxTest extends CompilerTestCas
   public void testUndefined() {
     foldSame("var x = undefined");
     foldSame("function f(f) {var undefined=2;var x = undefined;}");
-    this.enableNormalize();
+    enableNormalize();
     fold("var x = undefined", "var x=void 0");
     foldSame(
         "var undefined = 1;" +
@@ -335,7 +335,10 @@ public final class PeepholeSubstituteAlternateSyntaxTest extends CompilerTestCas
     foldSame("try {} catch(undefined) {}");
     foldSame("for (undefined in {}) {}");
     foldSame("undefined++;");
-    fold("undefined += undefined;", "undefined += void 0;");
+    disableNormalize();
+    foldSame("undefined += undefined;");
+    enableNormalize();
+    fold("undefined += undefined;", "undefined = void 0 + void 0;");
   }
 
   public void testSplitCommaExpressions() {


### PR DESCRIPTION
Normalize these in Normalize to free up potential optimizations.
Denormalize them in Denormalize later.

Related to #250.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1663)
<!-- Reviewable:end -->
