### PR TITLE
New lint check: CheckUnusedLabels

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -40,6 +40,7 @@ import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckNullableReturn;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
+import com.google.javascript.jscomp.lint.CheckUnusedLabels;
 import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 import com.google.javascript.jscomp.parsing.ParserRunner;
 import com.google.javascript.rhino.IR;
@@ -1563,6 +1564,7 @@ public final class DefaultPassConfig extends PassConfig {
           .add(new CheckInterfaces(compiler))
           .add(new CheckJSDocStyle(compiler))
           .add(new CheckPrototypeProperties(compiler))
+          .add(new CheckUnusedLabels(compiler))
           .add(new CheckUnusedPrivateProperties(compiler))
           .add(new CheckUselessBlocks(compiler));
       return combineChecks(compiler, callbacks.build());

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -29,6 +29,7 @@ import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckNullableReturn;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
+import com.google.javascript.jscomp.lint.CheckUnusedLabels;
 import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 import com.google.javascript.jscomp.newtypes.JSTypeCreatorFromJSDoc;
 
@@ -499,6 +500,7 @@ public class DiagnosticGroups {
           CheckRequiresAndProvidesSorted.PROVIDES_NOT_SORTED,
           CheckRequiresAndProvidesSorted.PROVIDES_AFTER_REQUIRES,
           CheckUnusedPrivateProperties.UNUSED_PRIVATE_PROPERTY,
+          CheckUnusedLabels.UNUSED_LABEL,
           CheckUselessBlocks.USELESS_BLOCK,
           RhinoErrorReporter.JSDOC_MISSING_BRACES_WARNING,
           RhinoErrorReporter.JSDOC_MISSING_TYPE_WARNING,

--- a/src/com/google/javascript/jscomp/LintPassConfig.java
+++ b/src/com/google/javascript/jscomp/LintPassConfig.java
@@ -24,6 +24,7 @@ import com.google.javascript.jscomp.lint.CheckInterfaces;
 import com.google.javascript.jscomp.lint.CheckJSDocStyle;
 import com.google.javascript.jscomp.lint.CheckPrototypeProperties;
 import com.google.javascript.jscomp.lint.CheckRequiresAndProvidesSorted;
+import com.google.javascript.jscomp.lint.CheckUnusedLabels;
 import com.google.javascript.jscomp.lint.CheckUselessBlocks;
 
 import java.util.List;
@@ -111,6 +112,7 @@ class LintPassConfig extends PassConfig.PassConfigDelegate {
                   new CheckEnums(compiler),
                   new CheckInterfaces(compiler),
                   new CheckPrototypeProperties(compiler),
+                  new CheckUnusedLabels(compiler),
                   new CheckUselessBlocks(compiler)));
         }
       };

--- a/src/com/google/javascript/jscomp/lint/CheckUnusedLabels.java
+++ b/src/com/google/javascript/jscomp/lint/CheckUnusedLabels.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp.lint;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.DiagnosticType;
+import com.google.javascript.jscomp.HotSwapCompilerPass;
+import com.google.javascript.jscomp.NodeTraversal;
+import com.google.javascript.jscomp.NodeTraversal.Callback;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.Token;
+
+/**
+ * Check for unused labels blocks. This can help catching errors like:
+ *   () => {a: 2}  // Returns undefined, not an Object
+ *
+ * Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-unused-labels.js)
+ */
+public final class CheckUnusedLabels implements Callback, HotSwapCompilerPass {
+  public static final DiagnosticType UNUSED_LABEL = DiagnosticType.warning(
+      "JSC_UNUSED_LABEL", "Unused label {0}.");
+
+  private class LabelContext {
+    private final String name;
+    private final LabelContext parent;
+    private boolean used;
+
+    private LabelContext(String name, LabelContext parent) {
+      this.name = name;
+      this.parent = parent;
+    }
+  }
+
+  private final AbstractCompiler compiler;
+  private LabelContext currentContext;
+
+  public CheckUnusedLabels(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    NodeTraversal.traverseEs6(compiler, root, this);
+  }
+
+  @Override
+  public void hotSwapScript(Node scriptRoot, Node originalRoot) {
+    NodeTraversal.traverseEs6(compiler, scriptRoot, this);
+  }
+
+  @Override
+  public final boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
+    switch (n.getType()) {
+      case Token.BREAK:
+      case Token.CONTINUE:
+        if (n.hasChildren()) {
+          LabelContext temp = currentContext;
+          while (temp != null) {
+            if (temp.name.equals(n.getFirstChild().getString())) {
+              temp.used = true;
+              break;
+            }
+            temp = temp.parent;
+          }
+        }
+        return false;
+      case Token.LABEL:
+        currentContext = new LabelContext(n.getFirstChild().getString(), currentContext);
+    }
+    return true;
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    if (n.isLabel() && currentContext != null) {
+      if (!currentContext.used) {
+        t.report(n, UNUSED_LABEL, n.getFirstChild().getString());
+      }
+      currentContext = currentContext.parent;
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/lint/CheckUnusedLabelsTest.java
+++ b/test/com/google/javascript/jscomp/lint/CheckUnusedLabelsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.lint;
+
+import static com.google.javascript.jscomp.lint.CheckUnusedLabels.UNUSED_LABEL;
+
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.CompilerPass;
+import com.google.javascript.jscomp.Es6CompilerTestCase;
+
+/**
+ * Test case for {@link CheckUnusedLabels}.
+ */
+public final class CheckUnusedLabelsTest extends Es6CompilerTestCase {
+  @Override
+  public CompilerPass getProcessor(Compiler compiler) {
+    return new CheckUnusedLabels(compiler);
+  }
+
+  public void testCheckUnusedLabels_noWarning() {
+    testSame("L: if (true) { break L; }");
+    testSame("L: for (;;) { if (true) { break L; } }");
+    testSame("L1: L2: if (true) { if (true) { break L1; } break L2; }");
+  }
+
+  public void testCheckUnusedLabels_warning() {
+    testWarning("L: var x = 0;", UNUSED_LABEL);
+    testWarning("L: { f(); }", UNUSED_LABEL);
+    testWarning("L: for (;;) {}", UNUSED_LABEL);
+    testWarning("L1: for (;;) { L2: if (true) { break L2; } }", UNUSED_LABEL);
+    testWarningEs6("() => {a: 2}", UNUSED_LABEL);
+  }
+}


### PR DESCRIPTION
Check for unused labels blocks. This can help catching errors like:
```js
() => {a: 2}  // Returns undefined, not an Object
```
Inspired by ESLint (https://github.com/eslint/eslint/blob/master/lib/rules/no-unused-labels.js)

Fixes #1128.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1665)
<!-- Reviewable:end -->
