### PR TITLE
Rewrite type nodes which are absolute module paths

### DIFF
--- a/src/com/google/javascript/jscomp/ES6ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/ES6ModuleLoader.java
@@ -153,6 +153,11 @@ public final class ES6ModuleLoader {
     return name.startsWith("." + MODULE_SLASH) || name.startsWith(".." + MODULE_SLASH);
   }
 
+  /** Whether this is absolute to the compilation. */
+  static boolean isAbsoluteIdentifier(String name) {
+    return name.startsWith(MODULE_SLASH);
+  }
+
   /**
    * Turns a filename into a JS identifier that is used for moduleNames in
    * rewritten code. Removes leading ./, replaces / with $, removes trailing .js

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -646,7 +646,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
     private void fixTypeNode(NodeTraversal t, Node typeNode) {
       if (typeNode.isString()) {
         String name = typeNode.getString();
-        if (ES6ModuleLoader.isRelativeIdentifier(name)) {
+        if (ES6ModuleLoader.isRelativeIdentifier(name) || ES6ModuleLoader.isAbsoluteIdentifier(name)) {
           int lastSlash = name.lastIndexOf('/');
           int endIndex = name.indexOf('.', lastSlash);
           String localTypeName = null;

--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -537,7 +537,7 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
     private void fixTypeNode(NodeTraversal t, Node typeNode) {
       if (typeNode.isString()) {
         String name = typeNode.getString();
-        if (ES6ModuleLoader.isRelativeIdentifier(name)) {
+        if (ES6ModuleLoader.isRelativeIdentifier(name) || ES6ModuleLoader.isAbsoluteIdentifier(name)) {
           int lastSlash = name.lastIndexOf('/');
           int endIndex = name.indexOf('.', lastSlash);
           String localTypeName = null;

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -390,7 +390,9 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testFixTypeNode() {
     testModules(
         LINE_JOINER.join(
-            "export class Child {", "  /** @param {Child} child */", "  useChild(child) {}", "}"),
+            "export class Child {",
+            "  /** @param {Child} child */",
+            "  useChild(child) {}", "}"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "class Child$$module$testcode {",
@@ -417,7 +419,22 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testReferenceToTypeFromOtherModule() {
     testModules(
         LINE_JOINER.join(
-            "export class Foo {", "  /** @param {./other.Baz} baz */", "  useBaz(baz) {}", "}"),
+            "export class Foo {",
+            "  /** @param {./other.Baz} baz */",
+            "  useBaz(baz) {}", "}"),
+        LINE_JOINER.join(
+            "goog.provide('module$testcode');",
+            "class Foo$$module$testcode {",
+            "  /** @param {module$other.Baz} baz */",
+            "  useBaz(baz) {}",
+            "}",
+            "/** @const */ module$testcode.Foo = Foo$$module$testcode;"));
+
+    testModules(
+        LINE_JOINER.join(
+            "export class Foo {",
+            "  /** @param {/other.Baz} baz */",
+            "  useBaz(baz) {}", "}"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "class Foo$$module$testcode {",


### PR DESCRIPTION
Module rewriting already handled cases for relative types which were relative paths. However, absolute paths should also be supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1678)
<!-- Reviewable:end -->
