### PR TITLE
Add hasOwnProperty as a global function

### DIFF
--- a/externs/browser/window.js
+++ b/externs/browser/window.js
@@ -189,3 +189,14 @@ function setInterval(callback, opt_delay) {}
  * @see https://html.spec.whatwg.org/multipage/webappapis.html#timers
  */
 function setTimeout(callback, opt_delay, var_args) {}
+
+/**
+ * Returns whether the object has a property with the specified name.
+ *
+ * @override
+ * @param {*} propertyName Implicitly cast to a string.
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
+ */
+function hasOwnProperty (propertyName) {}


### PR DESCRIPTION
I've come across more than one project that uses `hasOwnProperty` as a global function reference. Example:

```js
hasOwnProperty.call(foo, 'bar');
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1683)
<!-- Reviewable:end -->
