### PR TITLE
Mark CanvasRenderingContext2D.prototype.canvas as non-nullable

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -79,7 +79,7 @@ HTMLCanvasElement.prototype.getContext = function(contextId, opt_args) {};
  */
 function CanvasRenderingContext2D() {}
 
-/** @type {HTMLCanvasElement} */
+/** @type {!HTMLCanvasElement} */
 CanvasRenderingContext2D.prototype.canvas;
 
 /**


### PR DESCRIPTION
From the spec: https://www.w3.org/TR/2dcontext/#dom-context-2d-canvas
"The canvas attribute must return the canvas element that the context paints on."

Does the **must** implies that the canvas is always defined?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1686)
<!-- Reviewable:end -->
