### PR TITLE
Add possibleMissingProperty to DiagnosticGroup

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -198,6 +198,10 @@ public class DiagnosticGroups {
           TypeCheck.INEXISTENT_PROPERTY_WITH_SUGGESTION,
           TypeCheck.POSSIBLE_INEXISTENT_PROPERTY);
 
+  public static final DiagnosticGroup POSSIBLE_MISSING_PROPERTIES =
+      DiagnosticGroups.registerGroup("possibleMissingProperties",
+          TypeCheck.POSSIBLE_INEXISTENT_PROPERTY);
+
   public static final DiagnosticGroup MISSING_RETURN =
       DiagnosticGroups.registerGroup("missingReturn",
           CheckMissingReturn.MISSING_RETURN_STATEMENT);

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -417,6 +417,20 @@ public final class CommandLineRunnerTest extends TestCase {
         TypeCheck.INEXISTENT_PROPERTY);
   }
 
+  public void testCheckPossibleUndefinedProperties1() {
+    args.add("--warning_level=VERBOSE");
+    args.add("--jscomp_error=possibleMissingProperties");
+    test("/** @type {?} */ var x = {}; var y = x.bar;",
+        TypeCheck.POSSIBLE_INEXISTENT_PROPERTY);
+  }
+
+  public void testCheckPossibleUndefinedProperties2() {
+    args.add("--warning_level=VERBOSE");
+    args.add("--jscomp_off=possibleMissingProperties");
+    test("/** @type {?} */ var x = {}; var y = x.bar();",
+        CheckGlobalNames.UNDEFINED_NAME_WARNING);
+  }
+
   public void testDuplicateParams() {
     test("function f(a, a) {}", RhinoErrorReporter.DUPLICATE_PARAM);
     assertThat(lastCompiler.hasHaltingErrors()).isTrue();


### PR DESCRIPTION
This new flag allows for disabling missing properties for unknown types.
This behaviour is desired when you have mixed typed and untyped objects.
In this case you still want the compiler to complain about missing
properties for known types but not for the untyped objects.

Example when this flag is disabled using
```
'--jscomp_error=missingProperty'
'--jscomp_off=possibleMissingProperty':
```
```js
// Typed variable example
/** @constructor */
var A = function() {};
new A().foo; // This will emit an error about 'foo' undefined on 'A'.

// Untyped variable example
/** @type {?} */
var a = {};
a.foo; // No error is emitted.
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1690)
<!-- Reviewable:end -->
