### PR TITLE
Arrange CommandLineRunner flags into groups for better output

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -24,7 +24,9 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
 import com.google.common.io.Files;
 import com.google.javascript.jscomp.SourceMap.LocationMapping;
 import com.google.javascript.rhino.TokenStream;
@@ -33,6 +35,7 @@ import com.google.protobuf.TextFormat;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.NamedOptionDef;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionDef;
 import org.kohsuke.args4j.OptionHandlerFilter;
@@ -135,6 +138,7 @@ public class CommandLineRunner extends
 
     @Option(name = "--help",
         handler = BooleanOptionHandler.class,
+        hidden = true,
         usage = "Displays this message on stdout and exit")
     private boolean displayHelp = false;
 
@@ -161,7 +165,8 @@ public class CommandLineRunner extends
     // Turn on (very slow) extra sanity checks for use when modifying the
     // compiler.
     @Option(name = "--jscomp_dev_mode",
-        // hidden, no usage
+        hidden  = true,
+        //no usage
         aliases = {"--dev_mode"})
     private CompilerOptions.DevMode jscompDevMode =
         CompilerOptions.DevMode.OFF;
@@ -212,7 +217,6 @@ public class CommandLineRunner extends
     private List<String> module = new ArrayList<>();
 
     @Option(name = "--variable_renaming_report",
-        hidden = true,
         usage = "File where the serialized version of the variable "
         + "renaming map produced should be saved")
     private String variableMapOutputFile = "";
@@ -228,7 +232,6 @@ public class CommandLineRunner extends
     private boolean createNameMapFiles = false;
 
     @Option(name = "--property_renaming_report",
-        hidden = true,
         usage = "File where the serialized version of the property "
         + "renaming map produced should be saved")
     private String propertyMapOutputFile = "";
@@ -303,29 +306,27 @@ public class CommandLineRunner extends
     @SuppressWarnings("unused")
     @Option(name = "--jscomp_error",
         handler = WarningGuardErrorOptionHandler.class,
-        usage = "Make the named class of warnings an error. Options:" +
-        DiagnosticGroups.DIAGNOSTIC_GROUP_NAMES + ". '*' adds all supported.")
+        usage = "Make the named class of warnings an error. Must be one "
+            + "of the error group items. '*' adds all supported.")
     private List<String> jscompError = new ArrayList<>();
 
     // Used to define the flag, values are stored by the handler.
     @SuppressWarnings("unused")
     @Option(name = "--jscomp_warning",
         handler = WarningGuardWarningOptionHandler.class,
-        usage = "Make the named class of warnings a normal warning. " +
-        "Options:" + DiagnosticGroups.DIAGNOSTIC_GROUP_NAMES +
-        ". '*' adds all supported.")
+        usage = "Make the named class of warnings a normal warning. Must be one "
+            + "of the error group items. '*' adds all supported.")
     private List<String> jscompWarning = new ArrayList<>();
 
     // Used to define the flag, values are stored by the handler.
     @SuppressWarnings("unused")
     @Option(name = "--jscomp_off",
         handler = WarningGuardOffOptionHandler.class,
-        usage = "Turn off the named class of warnings. Options:" +
-        DiagnosticGroups.DIAGNOSTIC_GROUP_NAMES + ". '*' adds all supported.")
+        usage = "Turn off the named class of warnings. Must be one "
+            + "of the error group items. '*' adds all supported.")
     private List<String> jscompOff = new ArrayList<>();
 
     @Option(name = "--define",
-        hidden = true,
         aliases = {"--D", "-D"},
         usage = "Override the value of a variable annotated @define. " +
         "The format is <name>[=<val>], where <name> is the name of a @define " +
@@ -387,7 +388,6 @@ public class CommandLineRunner extends
     private boolean generateExports = false;
 
     @Option(name = "--export_local_property_definitions",
-        hidden = true,
         handler = BooleanOptionHandler.class,
         usage = "Generates export code for local properties marked with @export")
     private boolean exportLocalPropertyDefinitions = false;
@@ -477,7 +477,6 @@ public class CommandLineRunner extends
     private boolean polymerPass = false;
 
     @Option(name = "--dart_pass",
-        hidden = true,
         handler = BooleanOptionHandler.class,
         usage = "Rewrite Dart Dev Compiler output to be compiler-friendly.")
     private boolean dartPass = false;
@@ -553,7 +552,6 @@ public class CommandLineRunner extends
     private List<String> hideWarningsFor = new ArrayList<>();
 
     @Option(name = "--extra_annotation_name",
-        hidden = true,
         usage = "A whitelist of tag names in JSDoc. You may specify multiple")
     private List<String> extraAnnotationName = new ArrayList<>();
 
@@ -591,6 +589,7 @@ public class CommandLineRunner extends
     private String instrumentationFile = "";
 
     @Option(name = "--json_streams",
+        hidden = true,
         usage = "Specifies whether standard input and output streams will be "
             + "a JSON array of sources. Each source will be an object of the "
             + "form {path: filename, src: file_contents, srcmap: srcmap_contents }. "
@@ -606,13 +605,11 @@ public class CommandLineRunner extends
     private boolean preserveTypeAnnotations = false;
 
     @Option(name = "--noinject_library",
-        hidden = true,
         usage = "Prevent injecting the named runtime libraries.")
     private List<String> noinjectLibrary = new ArrayList<>();
 
     @Option(
       name = "--dependency_mode",
-      hidden = true,
       usage = "Specifies how the compiler should determine the set and order "
       + "of files for a compilation. Options: NONE the compiler will include "
       + "all src files in the order listed, STRICT files will be included and "
@@ -680,10 +677,110 @@ public class CommandLineRunner extends
       }
     }
 
+    private static Multimap<String, List<String>> categories = new ImmutableMultimap.Builder()
+        .put("Basic Usage", ImmutableList.of("compilation_level", "env",  "externs",  "js",
+            "js_output_file", "language_in", "language_out", "warning_level"))
+
+        .put("Warning and Error Management", ImmutableList.of("conformance_configs",
+            "extra_annotation_name", "hide_warnings_for",
+            "jscomp_error", "jscomp_off", "jscomp_warning", "new_type_inf",
+            "warnings_whitelist_file"))
+
+        .put("Output", ImmutableList.of("assume_function_wrapper", "debug",
+            "export_local_property_definitions", "formatting", "generate_exports", "output_wrapper"))
+
+        .put("Dependency Management", ImmutableList.of("dependency_mode", "entry_point"))
+
+        .put("JS Modules", ImmutableList.of("js_module_root", "process_common_js_modules",
+            "transform_amd_modules"))
+
+        .put("Library and Framework Specific", ImmutableList.of("angular_pass", "dart_pass",
+            "noinject_library", "polymer_pass", "process_closure_primitives", "rewrite_polyfills"))
+
+        .put("Code Splitting", ImmutableList.of("module", "module_output_path_prefix", "module_wrapper"))
+
+        .put("Reports", ImmutableList.of("create_source_map", "output_manifest",
+            "output_module_dependencies", "property_renaming_report", "source_map_location_mapping",
+            "variable_renaming_report"))
+
+        .put("Miscellaneous", ImmutableList.of("charset", "checks_only", "define", "flagfile",
+            "third_party", "use_types_for_optimization", "version"))
+
+        .build();
+
     private void printUsage(PrintStream ps) {
-      parser.printUsage(
-          new OutputStreamWriter(ps, UTF_8), null, OptionHandlerFilter.PUBLIC);
+      OutputStreamWriter outputStream = new OutputStreamWriter(ps, UTF_8);
+
+      boolean isFirst = true;
+      for (Map.Entry<String, List<String>> entry : categories.entries()) {
+        String prefix = "\n\n";
+        String suffix = "";
+        if (isFirst) {
+          isFirst = false;
+          prefix = "";
+        }
+
+        if (entry.getKey().equals("Warning and Error Management")) {
+          suffix = "\n" + boldPrefix + "Available Error Groups: " + normalPrefix
+              + DiagnosticGroups.DIAGNOSTIC_GROUP_NAMES;
+        }
+
+        printCategoryUsage(entry.getKey(), entry.getValue(), outputStream, prefix, suffix);
+      }
+
       ps.flush();
+    }
+
+    private final String boldPrefix = "\033[1m";
+    private final String normalPrefix = "\033[0m";
+
+    private void printCategoryUsage(String CategoryName, List<String> options,
+        OutputStreamWriter outputStream, String prefix, String suffix) {
+
+      final List<String> categoryOptions = options;
+      try {
+        if (prefix != null) {
+          printStringLineWrapped(prefix, outputStream);
+        }
+
+        outputStream.write(boldPrefix + CategoryName + ":\n" + normalPrefix);
+
+        parser.printUsage(outputStream, null, new OptionHandlerFilter() {
+          public boolean select(OptionHandler optionHandler) {
+            if (optionHandler.option instanceof NamedOptionDef) {
+              return !optionHandler.option.hidden() && categoryOptions.contains(
+                  ((NamedOptionDef)optionHandler.option).name().replaceFirst("^--", ""));
+            }
+            return false;
+          }
+        });
+
+        if (suffix != null) {
+          printStringLineWrapped(suffix, outputStream);
+        }
+      } catch (IOException e) { }
+    }
+
+    private final int maxLineLength = 80;
+    private final Pattern whitespacePattern = Pattern.compile("\\s");
+    private void printStringLineWrapped(String input, OutputStreamWriter outputStream)
+        throws IOException {
+      if (input.length() < maxLineLength) {
+        outputStream.write(input);
+        return;
+      }
+
+      int endIndex = maxLineLength;
+      String subString = input.substring(0, maxLineLength);
+      Matcher whitespaceMatcher = whitespacePattern.matcher(subString);
+      boolean foundMatch = false;
+      while(whitespaceMatcher.find()) {
+        endIndex = whitespaceMatcher.start();
+        foundMatch = true;
+      }
+      outputStream.write(input.substring(0, endIndex) + "\n");
+      printStringLineWrapped("    " +  input.substring(foundMatch ? endIndex + 1 : endIndex),
+          outputStream);
     }
 
     private void printShortUsageAfterErrors(PrintStream ps) {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -665,7 +665,6 @@ public final class CommandLineRunnerTest extends TestCase {
     assertThat(runner.shouldRunCompiler()).isFalse();
     assertThat(runner.hasErrors()).isFalse();
     String output = new String(outReader.toByteArray(), UTF_8);
-    assertThat(output).contains(" --help ");
     assertThat(output).contains(" --version ");
   }
 


### PR DESCRIPTION
Fixes #1692 

Organize the command line flags into groups so the `--help` usage is much more readable.

With this change, here's the output:

```
$ java -jar build/compiler.jar --help
Basic Usage:
 --compilation_level (-O) VAL           : Specifies the compilation level to
                                          use. Options: WHITESPACE_ONLY,
                                          SIMPLE, ADVANCED
 --env [BROWSER | CUSTOM]               : Determines the set of builtin externs
                                          to load. Options: BROWSER, CUSTOM.
                                          Defaults to BROWSER.
 --externs VAL                          : The file containing JavaScript
                                          externs. You may specify multiple
 --js VAL                               : The JavaScript filename. You may
                                          specify multiple. The flag name is
                                          optional, because args are interpreted
                                          as files by default. You may also use
                                          minimatch-style glob patterns. For
                                          example, use --js='**.js' --js='!**_te
                                          st.js' to recursively include all js
                                          files that do not end in _test.js
 --js_output_file VAL                   : Primary output filename. If not
                                          specified, output is written to stdout
 --language_in VAL                      : Sets what language spec that input
                                          sources conform. Options: ECMASCRIPT3,
                                          ECMASCRIPT5, ECMASCRIPT5_STRICT,
                                          ECMASCRIPT6 (default), ECMASCRIPT6_STR
                                          ICT, ECMASCRIPT6_TYPED (experimental)
 --language_out VAL                     : Sets what language spec the output
                                          should conform to. Options: ECMASCRIPT
                                          3 (default), ECMASCRIPT5, ECMASCRIPT5_
                                          STRICT, ECMASCRIPT6_TYPED (experimenta
                                          l)
 --warning_level (-W) [QUIET | DEFAULT  : Specifies the warning level to use.
 | VERBOSE]                             : Options: QUIET, DEFAULT, VERBOSE


Warning and Error Management:
 --conformance_configs VAL              : A list of JS Conformance configuration
                                          s in text protocol buffer format.
 --extra_annotation_name VAL            : A whitelist of tag names in JSDoc.
                                          You may specify multiple
 --hide_warnings_for VAL                : If specified, files whose path
                                          contains this string will have their
                                          warnings hidden. You may specify
                                          multiple.
 --jscomp_error VAL                     : Make the named class of warnings an
                                          error. Must be one of the error group
                                          items. '*' adds all supported.
 --jscomp_off VAL                       : Turn off the named class of warnings.
                                          Must be one of the error group items.
                                          '*' adds all supported.
 --jscomp_warning VAL                   : Make the named class of warnings a
                                          normal warning. Must be one of the
                                          error group items. '*' adds all
                                          supported.
 --new_type_inf                         : Checks for type errors using the new
                                          type inference algorithm.
 --warnings_whitelist_file VAL          : A file containing warnings to
                                          suppress. Each line should be of the
                                          form
                                          <file-name>:<line-number>?  <warning-d
                                          escription>

Available Error Groups: accessControls, ambiguousFunctionDecl,
    checkEventfulObjectDisposal, checkRegExp, checkTypes, checkVars,
    conformanceViolations, const, constantProperty, deprecated,
    deprecatedAnnotations, duplicateMessage, es3, es5Strict, externsValidation,
    fileoverviewTags, globalThis, internetExplorerChecks, invalidCasts,
    misplacedTypeAnnotation, missingGetCssName, missingProperties,
    missingProvide, missingRequire, missingReturn, msgDescriptions,
    newCheckTypes, nonStandardJsDocs, reportUnknownTypes, suspiciousCode,
    strictModuleDepCheck, typeInvalidation, undefinedNames, undefinedVars,
    unknownDefines, unnecessaryCasts, unusedLocalVariables,
    unusedPrivateMembers, uselessCode, useOfGoogBase, underscore, visibility

Output:
 --assume_function_wrapper              : Enable additional optimizations based
                                          on the assumption that the output
                                          will be wrapped with a function
                                          wrapper.  This flag is used to
                                          indicate that "global" declarations
                                          will not actually be global but
                                          instead isolated to the compilation
                                          unit. This enables additional
                                          optimizations.
 --export_local_property_definitions    : Generates export code for local
                                          properties marked with @export
 --generate_exports                     : Generates export code for those
                                          marked with @export
 --output_wrapper VAL                   : Interpolate output into this string
                                          at the place denoted by the marker
                                          token %output%. Use marker token
                                          %output|jsstring% to do js string
                                          escaping on the output.


Dependency Management:
 --dependency_mode [NONE | LOOSE |      : Specifies how the compiler should
 STRICT]                                : determine the set and order of files
                                          for a compilation. Options: NONE the
                                          compiler will include all src files
                                          in the order listed, STRICT files
                                          will be included and sorted by
                                          starting from namespaces or files
                                          listed by the --entry_point flag -
                                          files will only be included if they
                                          are referenced by a goog.require or
                                          CommonJS require or ES6 import, LOOSE
                                          same as with STRICT but files which
                                          do not goog.provide a namespace and
                                          are not modules will be automatically
                                          added as --entry_point entries.
                                          Defaults to NONE.
 --entry_point VAL                      : A file or namespace to use as the
                                          starting point for determining which
                                          src files to include in the compilatio
                                          n. ES6 and CommonJS modules are
                                          specified as file paths (without the
                                          extension). Closure-library namespaces
                                          are specified with a "goog:" prefix.
                                          Example: --entry_point=goog:goog.Promi
                                          se


JS Modules:
 --js_module_root VAL                   : Path prefixes to be removed from ES6
                                          & CommonJS modules.
 --process_common_js_modules            : Process CommonJS modules to a
                                          concatenable form.
 --transform_amd_modules                : Transform AMD to CommonJS modules.


Library and Framework Specific:
 --angular_pass                         : Generate $inject properties for
                                          AngularJS for functions annotated
                                          with @ngInject
 --dart_pass                            : Rewrite Dart Dev Compiler output to
                                          be compiler-friendly.
 --noinject_library VAL                 : Prevent injecting the named runtime
                                          libraries.
 --polymer_pass                         : Rewrite Polymer classes to be
                                          compiler-friendly.
 --process_closure_primitives           : Processes built-ins from the Closure
                                          library, such as goog.require(),
                                          goog.provide(), and goog.exportSymbol(
                                          ). True by default.
 --rewrite_polyfills                    : Rewrite ES6 library calls to use
                                          polyfills provided by the compiler's
                                          runtime.


Code Splitting:
 --module VAL                           : A JavaScript module specification.
                                          The format is <name>:<num-js-files>[:[
                                          <dep>,...][:]]]. Module names must be
                                          unique. Each dep is the name of a
                                          module that this module depends on.
                                          Modules must be listed in dependency
                                          order, and JS source files must be
                                          listed in the corresponding order.
                                          Where --module flags occur in
                                          relation to --js flags is unimportant.
                                          <num-js-files> may be set to 'auto'
                                          for the first module if it has no
                                          dependencies. Provide the value
                                          'auto' to trigger module creation
                                          from CommonJSmodules.
 --module_output_path_prefix VAL        : Prefix for filenames of compiled JS
                                          modules. <module-name>.js will be
                                          appended to this prefix. Directories
                                          will be created as needed. Use with
                                          --module
 --module_wrapper VAL                   : An output wrapper for a JavaScript
                                          module (optional). The format is
                                          <name>:<wrapper>. The module name
                                          must correspond with a module
                                          specified using --module. The wrapper
                                          must contain %s as the code placeholde
                                          r. The %basename% placeholder can
                                          also be used to substitute the base
                                          name of the module output file.


Reports:
 --create_source_map VAL                : If specified, a source map file
                                          mapping the generated source files
                                          back to the original source file will
                                          be output to the specified path. The
                                          %outname% placeholder will expand to
                                          the name of the output file that the
                                          source map corresponds to.
 --output_manifest VAL                  : Prints out a list of all the files in
                                          the compilation. If --dependency_mode=
                                          STRICT or LOOSE is specified, this
                                          will not include files that got
                                          dropped because they were not
                                          required. The %outname% placeholder
                                          expands to the JS output file. If
                                          you're using modularization, using
                                          %outname% will create a manifest for
                                          each module.
 --output_module_dependencies VAL       : Prints out a JSON file of dependencies
                                          between modules.
 --property_renaming_report VAL         : File where the serialized version of
                                          the property renaming map produced
                                          should be saved
 --source_map_location_mapping VAL      : Source map location mapping separated
                                          by a '|' (i.e. filesystem-path|webserv
                                          er-path)
 --variable_renaming_report VAL         : File where the serialized version of
                                          the variable renaming map produced
                                          should be saved


Miscellaneous:
 --charset VAL                          : Input and output charset for all
                                          files. By default, we accept UTF-8 as
                                          input and output US_ASCII
 --checks_only (--checks-only)          : Don't generate output. Run checks,
                                          but no optimization passes.
 --define (--D, -D) VAL                 : Override the value of a variable
                                          annotated @define. The format is
                                          <name>[=<val>], where <name> is the
                                          name of a @define variable and <val>
                                          is a boolean, number, or a single-quot
                                          ed string that contains no single
                                          quotes. If [=<val>] is omitted, the
                                          variable is marked true
 --third_party                          : Check source validity but do not
                                          enforce Closure style rules and
                                          conventions
 --use_types_for_optimization           : Enable or disable the optimizations
                                          based on available type information.
                                          Inaccurate type annotations may
                                          result in incorrect results.
 --version                              : Prints the compiler version to stdout
                                          and exit.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1695)
<!-- Reviewable:end -->
