### PR TITLE
Add SWITCH as the parent of basic block boundaries

### DIFF
--- a/src/com/google/javascript/jscomp/ReferenceCollectingCallback.java
+++ b/src/com/google/javascript/jscomp/ReferenceCollectingCallback.java
@@ -315,6 +315,7 @@ class ReferenceCollectingCallback implements ScopedCallback,
         case Token.HOOK:
         case Token.IF:
         case Token.OR:
+        case Token.SWITCH:
           // The first child of a conditional is not a boundary,
           // but all the rest of the children are.
           return n != parent.getFirstChild();

--- a/test/com/google/javascript/jscomp/InlineVariablesTest.java
+++ b/test/com/google/javascript/jscomp/InlineVariablesTest.java
@@ -1158,4 +1158,18 @@ public final class InlineVariablesTest extends CompilerTestCase {
     testSame("function x_64(){var x_7;for(;;);var x_68=x_7=x_7++;}");
     testSame("function x_64(){var x_7;for(;;);var x_68=x_7=x_7*2;}");
   }
+
+  // GitHub issue #1234: https://github.com/google/closure-compiler/issues/1234
+  public void testSwitchGithubIssue1234() {
+    testSame(LINE_JOINER.join(
+      "var x;",
+      "switch ('a') {",
+      "  case 'a':",
+      "    break;",
+      "  default:",
+      "    x = 1;",
+      "    break;",
+      "}",
+      "use(x);"));
+  }
 }

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -3545,6 +3545,37 @@ public final class IntegrationTest extends IntegrationTestCase {
         "window.a = function() { return '1234567'; }");
   }
 
+  // GitHub issue #1234: https://github.com/google/closure-compiler/issues/1234
+  public void testOptimizeSwitchGithubIssue1234() {
+    CompilerOptions options = createCompilerOptions();
+    CompilationLevel.ADVANCED_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
+    test(options, LINE_JOINER.join(
+        "var exit;",
+        "switch ('a') {",
+        "  case 'a':",
+        "    break;",
+        "  default:",
+        "    exit = 21;",
+        "    break;",
+        "}",
+        "switch(exit) {",
+        "  case 21: throw 'x';",
+        "  default : console.log('good');",
+        "}"), LINE_JOINER.join(
+        // TODO(moz): Seems like we can fold a bit more here. Investigate later.
+        "var a;",
+        "switch ('a') {",
+        "  case 'a':",
+        "    break;",
+        "  default:",
+        "    a = 21;",
+        "}",
+        "switch(a) {",
+        "  case 21: throw 'x';",
+        "  default : console.a('good');",
+        "}"));
+  }
+
   /** Creates a CompilerOptions object with google coding conventions. */
   @Override
   protected CompilerOptions createCompilerOptions() {


### PR DESCRIPTION
This fixes isBlockBoundary() in ReferenceCollectingCallback, which
caused an incorrect inlining in InlineVariables.

Fixes #1234.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1700)
<!-- Reviewable:end -->
