### PR TITLE
Add EventListenerOptions to EventTarget.add/removeEventListener.

### DIFF
--- a/contrib/externs/w3c_eventsource.js
+++ b/contrib/externs/w3c_eventsource.js
@@ -29,19 +29,13 @@
  */
 function EventSource(url, opt_eventSourceInitDict) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-EventSource.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+EventSource.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-EventSource.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+EventSource.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 EventSource.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -454,19 +454,13 @@ FileError.prototype.code;
  */
 function FileReader() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-FileReader.prototype.addEventListener = function(type, listener, opt_useCapture)
-    {};
+/** @override */
+FileReader.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-FileReader.prototype.removeEventListener = function(type, listener,
-    opt_useCapture) {};
+/** @override */
+FileReader.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 FileReader.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -743,19 +743,13 @@ Document.prototype.head;
  */
 function DOMApplicationCache() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-DOMApplicationCache.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+DOMApplicationCache.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-DOMApplicationCache.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+DOMApplicationCache.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 DOMApplicationCache.prototype.dispatchEvent = function(evt) {};
@@ -887,19 +881,13 @@ function importScripts(var_args) {}
  */
 function WebWorker() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-WebWorker.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+WebWorker.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-WebWorker.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+WebWorker.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 WebWorker.prototype.dispatchEvent = function(evt) {};
@@ -935,19 +923,13 @@ WebWorker.prototype.onerror;
  */
 function Worker(opt_arg0) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-Worker.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+Worker.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-Worker.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+Worker.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 Worker.prototype.dispatchEvent = function(evt) {};
@@ -994,19 +976,13 @@ Worker.prototype.onerror;
  */
 function SharedWorker(scriptURL, opt_name) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-SharedWorker.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+SharedWorker.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-SharedWorker.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+SharedWorker.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 SharedWorker.prototype.dispatchEvent = function(evt) {};
@@ -1604,15 +1580,15 @@ TextTrack.prototype.activeCues;
 TextTrack.prototype.cues;
 
 /** @override */
-TextTrack.prototype.addEventListener = function(type, listener, useCapture) {};
+TextTrack.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
+
+/** @override */
+TextTrack.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 TextTrack.prototype.dispatchEvent = function(evt) {};
-
-/** @override */
-TextTrack.prototype.removeEventListener = function(type, listener, useCapture)
-    {};
-
 
 
 /**
@@ -1778,19 +1754,13 @@ MessageChannel.prototype.port2;
  */
 function MessagePort() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-MessagePort.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+MessagePort.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-MessagePort.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+MessagePort.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 MessagePort.prototype.dispatchEvent = function(evt) {};
@@ -2192,19 +2162,13 @@ WebSocket.CLOSING = 2;
  */
 WebSocket.CLOSED = 3;
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-WebSocket.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+WebSocket.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-WebSocket.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+WebSocket.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 WebSocket.prototype.dispatchEvent = function(evt) {};
@@ -2450,19 +2414,13 @@ XMLHttpRequest.prototype.mozResponseArrayBuffer;
  */
 function XMLHttpRequestEventTarget() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-XMLHttpRequestEventTarget.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+XMLHttpRequestEventTarget.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-XMLHttpRequestEventTarget.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+XMLHttpRequestEventTarget.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 XMLHttpRequestEventTarget.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/mediasource.js
+++ b/externs/browser/mediasource.js
@@ -27,19 +27,13 @@
  */
 function MediaSource() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-MediaSource.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+MediaSource.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-MediaSource.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+MediaSource.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 MediaSource.prototype.dispatchEvent = function(evt) {};
@@ -85,19 +79,13 @@ MediaSource.isTypeSupported = function(type) {};
  */
 function SourceBuffer() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-SourceBuffer.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+SourceBuffer.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-SourceBuffer.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+SourceBuffer.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 SourceBuffer.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -117,17 +117,13 @@ DOMImplementation.prototype.hasFeature = function(feature, version) {};
  */
 function Node() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-Node.prototype.addEventListener = function(type, listener, opt_useCapture) {};
+/** @override */
+Node.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-Node.prototype.removeEventListener = function(type, listener, opt_useCapture) {};
+/** @override */
+Node.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 Node.prototype.dispatchEvent = function(evt) {};
@@ -837,18 +833,13 @@ ProcessingInstruction.prototype.target;
 function Window() {}
 Window.prototype.Window;
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-Window.prototype.addEventListener = function(type, listener, opt_useCapture) {};
+/** @override */
+Window.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-Window.prototype.removeEventListener = function(type, listener, opt_useCapture)
-    {};
+/** @override */
+Window.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 Window.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/w3c_event.js
+++ b/externs/browser/w3c_event.js
@@ -25,6 +25,15 @@
 
 
 /**
+ * @typedef {{
+ *   passive: (boolean|undefined),
+ *   capture: (boolean|undefined)
+ * }}
+ * @see https://dom.spec.whatwg.org/#dictdef-eventlisteneroptions
+ */
+var EventListenerOptions;
+
+/**
  * @interface
  */
 function EventTarget() {}
@@ -32,20 +41,20 @@ function EventTarget() {}
 /**
  * @param {string} type
  * @param {EventListener|function(!Event):(boolean|undefined)} listener
- * @param {boolean} useCapture
+ * @param {(boolean|EventListenerOptions)=} opt_useCaptureOrEventListenerOptions
  * @return {undefined}
  */
-EventTarget.prototype.addEventListener = function(type, listener, useCapture)
-    {};
+EventTarget.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /**
  * @param {string} type
  * @param {EventListener|function(!Event):(boolean|undefined)} listener
- * @param {boolean} useCapture
+ * @param {(boolean|EventListenerOptions)=} opt_useCaptureOrEventListenerOptions
  * @return {undefined}
  */
-EventTarget.prototype.removeEventListener = function(type, listener, useCapture)
-    {};
+EventTarget.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /**
  * @param {!Event} evt

--- a/externs/browser/w3c_indexeddb.js
+++ b/externs/browser/w3c_indexeddb.js
@@ -235,19 +235,13 @@ webkitIDBDatabaseException.prototype.message;
  */
 function IDBRequest() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 IDBRequest.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 IDBRequest.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 IDBRequest.prototype.dispatchEvent = function(evt) {};
@@ -406,19 +400,13 @@ IDBDatabase.prototype.onerror = function() {};
  */
 IDBDatabase.prototype.onversionchange = function() {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 IDBDatabase.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 IDBDatabase.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 IDBDatabase.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/w3c_rtc.js
+++ b/externs/browser/w3c_rtc.js
@@ -152,19 +152,13 @@ MediaStreamTrackEvent.prototype.track;
  */
 function MediaStream(streamOrTracks) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-MediaStream.prototype.addEventListener = function(type, listener,
-    opt_useCapture) {};
+/** @override */
+MediaStream.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-MediaStream.prototype.removeEventListener = function(type, listener,
-    opt_useCapture) {};
+/** @override */
+MediaStream.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 MediaStream.prototype.dispatchEvent = function(evt) {};
@@ -871,19 +865,13 @@ var RTCDataChannelInit;
  */
 function RTCPeerConnection(configuration, constraints) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-RTCPeerConnection.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+RTCPeerConnection.prototype.addEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
-RTCPeerConnection.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+RTCPeerConnection.prototype.removeEventListener =
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 RTCPeerConnection.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/w3c_xml.js
+++ b/externs/browser/w3c_xml.js
@@ -294,19 +294,13 @@ XPathNamespace.XPATH_NAMESPACE_NODE = 13;
  */
 function XMLHttpRequest() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 XMLHttpRequest.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 XMLHttpRequest.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 XMLHttpRequest.prototype.dispatchEvent = function(evt) {};

--- a/externs/browser/webkit_notifications.js
+++ b/externs/browser/webkit_notifications.js
@@ -62,19 +62,13 @@ Notification.permission;
  */
 Notification.requestPermission = function(opt_callback) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 Notification.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- */
+/** @override */
 Notification.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_useCaptureOrEventListenerOptions) {};
 
 /** @override */
 Notification.prototype.dispatchEvent = function(evt) {};


### PR DESCRIPTION
Chrome 51 has introduced support for EventListenerOptions on the
3rd argument. Change EventTarget.h to match the currently
published DOM specification; modifying addEventListener to have
an optional 3rd argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1715)
<!-- Reviewable:end -->
