### PR TITLE
Add USELESS_USE_STRICT_DIRECTIVE to the "lintChecks" DiagnosticGroup

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -508,6 +508,7 @@ public class DiagnosticGroups {
           ClosureCheckModule.LET_GOOG_REQUIRE,
           ClosureCheckModule.REFERENCE_TO_SHORT_IMPORT_BY_LONG_NAME,
           ClosureCheckModule.REFERENCE_TO_SHORT_IMPORT_BY_LONG_NAME_INCLUDING_SHORT_NAME,
+          ClosureRewriteModule.USELESS_USE_STRICT_DIRECTIVE,
           RhinoErrorReporter.JSDOC_MISSING_BRACES_WARNING,
           RhinoErrorReporter.JSDOC_MISSING_TYPE_WARNING,
           RhinoErrorReporter.TOO_MANY_TEMPLATE_PARAMS,


### PR DESCRIPTION
I'm inclined to just remove that warning, but let's make it
suppressible at least.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1717)
<!-- Reviewable:end -->
