### PR TITLE
Add the check for unnecessary 'use strict' back to ProcessEs6Modules

### DIFF
--- a/src/com/google/javascript/jscomp/ClosureRewriteModule.java
+++ b/src/com/google/javascript/jscomp/ClosureRewriteModule.java
@@ -235,7 +235,7 @@ final class ClosureRewriteModule implements HotSwapCompilerPass {
     @Override
     public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
       if (NodeUtil.isModuleFile(n)) {
-        checkStrictModeDirective(t, n);
+        checkAndSetStrictModeDirective(t, n);
       }
 
       switch (n.getType()) {
@@ -1148,7 +1148,7 @@ final class ClosureRewriteModule implements HotSwapCompilerPass {
     loadModuleStatements.clear();
   }
 
-  private static void checkStrictModeDirective(NodeTraversal t, Node n) {
+  static void checkAndSetStrictModeDirective(NodeTraversal t, Node n) {
     Preconditions.checkState(n.isScript(), n);
 
     Set<String> directives = n.getDirectives();

--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -56,8 +56,6 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
           "Namespace imports ('goog:some.Namespace') cannot use import * as. "
               + "Did you mean to import {0} from ''{1}'';?");
 
-  private static final ImmutableSet<String> USE_STRICT_ONLY = ImmutableSet.of("use strict");
-
   private final ES6ModuleLoader loader;
 
   private final Compiler compiler;
@@ -324,7 +322,7 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
       return;
     }
 
-    setStrictModeDirective(script);
+    ClosureRewriteModule.checkAndSetStrictModeDirective(t, script);
 
     Preconditions.checkArgument(scriptNodeCount == 1,
         "ProcessEs6Modules supports only one invocation per "
@@ -400,22 +398,6 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
 
     exportMap.clear();
     compiler.reportCodeChange();
-  }
-
-  private static void setStrictModeDirective(Node n) {
-    Preconditions.checkState(n.isScript(), n);
-    Set<String> directives = n.getDirectives();
-    if (directives != null && directives.contains("use strict")) {
-      return;
-    } else {
-      if (directives == null) {
-        n.setDirectives(USE_STRICT_ONLY);
-      } else {
-        ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<String>().add("use strict");
-        builder.addAll(directives);
-        n.setDirectives(builder.build());
-      }
-    }
   }
 
   private void rewriteRequires(Node script) {

--- a/test/com/google/javascript/jscomp/CheckConformanceTest.java
+++ b/test/com/google/javascript/jscomp/CheckConformanceTest.java
@@ -1022,7 +1022,6 @@ public final class CheckConformanceTest extends CompilerTestCase {
         "  error_message: 'BanExpose Message'\n" +
         "}";
 
-    setExpectParseWarningsThisTest();
     testSame(
         EXTERNS,
         "/** @expose */ var x;",

--- a/test/com/google/javascript/jscomp/ClosureRewriteModuleTest.java
+++ b/test/com/google/javascript/jscomp/ClosureRewriteModuleTest.java
@@ -45,6 +45,13 @@ public final class ClosureRewriteModuleTest extends Es6CompilerTestCase {
     return 1;
   }
 
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    options.setWarningLevel(DiagnosticGroups.LINT_CHECKS, CheckLevel.WARNING);
+    return options;
+  }
+
   public void testBasic0() {
     testSame("");
     testSame("goog.provide('a');");
@@ -1261,5 +1268,11 @@ public final class ClosureRewriteModuleTest extends Es6CompilerTestCase {
               "/** @const */ a.b.c = module$exports$a$b$c"),
           "goog.require('a.b.c'); use(a.b.c);"
         });
+  }
+
+  public void testUselessUseStrict() {
+    testWarning(LINE_JOINER.join(
+        "'use strict';",
+        "goog.module('b.c.c');"), ClosureRewriteModule.USELESS_USE_STRICT_DIRECTIVE);
   }
 }

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -1131,6 +1131,8 @@ public abstract class CompilerTestCase extends TestCase {
           "Unexpected parse warnings(s): " + LINE_JOINER.join(compiler.getWarnings()),
           0,
           compiler.getWarnings().length);
+    } else {
+      assertThat(compiler.getWarningCount()).isGreaterThan(0);
     }
 
     if (astValidationEnabled) {

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -44,6 +44,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
     CompilerOptions options = super.getOptions();
     // ECMASCRIPT5 to Trigger module processing after parsing.
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
+    options.setWarningLevel(DiagnosticGroups.LINT_CHECKS, CheckLevel.WARNING);
     return options;
   }
 
@@ -642,5 +643,21 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
   public void testImportWithoutReferences() {
     testModules("import 'other';", "goog.require('module$other');");
+  }
+
+  public void testUselessUseStrict() {
+    setExpectParseWarningsThisTest();
+    testModules(LINE_JOINER.join(
+        "'use strict';",
+        "export default undefined;"),
+        LINE_JOINER.join(
+        "'use strict';",
+        "export default undefined;"));
+  }
+
+  public void testUseStrict_noWarning() {
+    testSame(LINE_JOINER.join(
+        "'use strict';",
+        "var x;"));
   }
 }


### PR DESCRIPTION
Rename checkStrictModeDirective() to checkAndSetStrictModeDirective() in
ClosureRewriteModule and reuse that method.

Also modify CompilerTestCase to fail tests if parse warnings are
expected but not reported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1718)
<!-- Reviewable:end -->
