### PR TITLE
Alphabetize the @typedef for angular.Component

### DIFF
--- a/contrib/externs/angular-1.5.js
+++ b/contrib/externs/angular-1.5.js
@@ -464,14 +464,14 @@ angular.Directive;
  *   bindings: (Object.<string, string>|undefined),
  *   controller: (angular.Injectable|string|undefined),
  *   controllerAs: (string|undefined),
+ *   require: (!Object<string, string>|undefined),
  *   template: (string|
  *       function(!angular.JQLite=,!angular.Attributes=): string|
  *       undefined),
  *   templateUrl: (string|
  *       function(!angular.JQLite=,!angular.Attributes=)|
  *       undefined),
- *   transclude: (boolean|!Object.<string, string>|undefined),
- *   require: (!Object<string, string>|undefined)
+ *   transclude: (boolean|!Object.<string, string>|undefined)
  *   }}
  */
 angular.Component;


### PR DESCRIPTION
d34b883b44550ed9921175de03c71e33db7acc19 added "require" to the externs,
but it was not alphabetized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1724)
<!-- Reviewable:end -->
