### PR TITLE
Optimize switch with default case / return / throw / continue

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java
+++ b/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java
@@ -296,6 +296,55 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
 
   static final Predicate<Node> MATCH_UNNAMED_BREAK = new MatchUnnamedBreak();
 
+  private Node tryRemoveSwitchWithSingleCase(Node n, boolean shouldIncludeCondition) {
+    Node caseBlock = n.getLastChild().getLastChild();
+    // Drop statements that are dead code
+    boolean shouldDrop = false;
+    for (Node statement: caseBlock.children()) {
+      if (shouldDrop) {
+        statement.detachFromParent();
+      } else if (isExit(statement)) {
+        if (statement.isBreak() && !statement.hasChildren()) {
+          statement.detachFromParent();
+        }
+        shouldDrop = true;
+      }
+    }
+
+    // Back off if the switch contains statements like "if (a) { break; }"
+    if (NodeUtil.has(caseBlock, MATCH_UNNAMED_BREAK, NodeUtil.MATCH_NOT_FUNCTION)) {
+      if (shouldDrop && !isExit(caseBlock.getLastChild())) {
+        reportCodeChange();
+      }
+      return n;
+    } else {
+      // TODO(moz): This needs to change when we optimize for ES6. The block might need to be
+      // preserved in the presence of block-scoped declarations.
+      if (shouldIncludeCondition) {
+        caseBlock.addChildToFront(IR.exprResult(n.removeFirstChild()).srcref(n));
+      }
+      caseBlock.setIsSyntheticBlock(false);
+      n.getParent().replaceChild(n, caseBlock.detachFromParent());
+      reportCodeChange();
+      return caseBlock;
+    }
+  }
+
+  private Node tryRemoveSwitch(Node n) {
+    if (n.hasOneChild()) {
+      // Remove the switch if there are no remaining cases
+      Node condition = n.removeFirstChild();
+      Node replacement = IR.exprResult(condition).srcref(n);
+      n.getParent().replaceChild(n, replacement);
+      reportCodeChange();
+      return replacement;
+    } else if (n.getChildCount() == 2 && n.getLastChild().isDefaultCase()) {
+      return tryRemoveSwitchWithSingleCase(n, true);
+    } else {
+      return n;
+    }
+  }
+
   /**
    * Remove useless switches and cases.
    */
@@ -304,14 +353,14 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
 
     Node defaultCase = tryOptimizeDefaultCase(n);
 
-    // Removing cases when there exists a default case is not safe.
-    if (defaultCase == null) {
+    // Generally, it is unsafe to remove other cases when the default case is not the last one.
+    if (defaultCase == null || n.getLastChild().isDefaultCase()) {
       Node cond = n.getFirstChild(), prev = null, next = null, cur;
 
       for (cur = cond.getNext(); cur != null; cur = next) {
         next = cur.getNext();
         if (!mayHaveSideEffects(cur.getFirstChild()) &&
-            isUselessCase(cur, prev)) {
+            isUselessCase(cur, prev, defaultCase)) {
           removeCase(n, cur);
         } else {
           prev = cur;
@@ -344,11 +393,11 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
             block = cur.getLastChild();
             lastStm = block.getLastChild();
             cur = cur.getNext();
-            if (lastStm != null
-                && lastStm.isBreak()
-                && !lastStm.hasChildren()) {
-              block.removeChild(lastStm);
-              reportCodeChange();
+            if (lastStm != null && isExit(lastStm)) {
+              if (lastStm.isBreak() && !lastStm.hasChildren()) {
+                block.removeChild(lastStm);
+                reportCodeChange();
+              }
               break;
             }
           }
@@ -360,30 +409,13 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
           // If there is one case left, we may be able to fold it
           cur = cond.getNext();
           if (cur != null && cur.getNext() == null) {
-            block = cur.getLastChild();
-            if (!(NodeUtil.has(block, MATCH_UNNAMED_BREAK,
-                NodeUtil.MATCH_NOT_FUNCTION))) {
-              cur.removeChild(block);
-              block.setIsSyntheticBlock(false);
-              n.getParent().replaceChild(n, block);
-              reportCodeChange();
-              return block;
-            }
+            return tryRemoveSwitchWithSingleCase(n, false);
           }
         }
       }
     }
 
-    // Remove the switch if there are no remaining cases.
-    if (n.hasOneChild()) {
-      Node condition = n.removeFirstChild();
-      Node replacement = IR.exprResult(condition).srcref(n);
-      n.getParent().replaceChild(n, replacement);
-      reportCodeChange();
-      return replacement;
-    }
-
-    return null;
+    return tryRemoveSwitch(n);
   }
 
   /**
@@ -410,7 +442,7 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
             ? null : lastNonRemovable;
 
         // Remove the default case if we can
-        if (isUselessCase(c, prevCase)) {
+        if (isUselessCase(c, prevCase, c)) {
           removeCase(n, c);
           return null;
         }
@@ -437,15 +469,17 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
   }
 
   /**
-   * The function assumes that when checking a CASE node there is no
-   * DEFAULT node in the SWITCH.
-   * @return Whether the CASE or DEFAULT block does anything useful.
+   * The function assumes that when checking a CASE node there is no DEFAULT_CASE node in the
+   * SWITCH, or the DEFAULT_CASE is the last case in the SWITCH.
+   *
+   * @return Whether the CASE or DEFAULT_CASE block does anything useful.
    */
-  private boolean isUselessCase(Node caseNode, @Nullable Node previousCase) {
+  private boolean isUselessCase(Node caseNode, @Nullable Node previousCase,
+      @Nullable Node defaultCase) {
     Preconditions.checkState(
         previousCase == null || previousCase.getNext() == caseNode);
-    // A case isn't useless can't be useless if a previous case falls
-    // through to it unless it happens to be the last case in the switch.
+    // A case isn't useless if a previous case falls through to it unless it happens to be the last
+    // case in the switch.
     Node switchNode = caseNode.getParent();
     if (switchNode.getLastChild() != caseNode
         && previousCase != null) {
@@ -472,8 +506,10 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
           // If this is a block with a labelless break, it is useless.
           switch (blockChild.getType()) {
             case Token.BREAK:
-              // A break to a different control structure isn't useless.
-              return blockChild.getFirstChild() == null;
+              // A case with a single labelless break is useless if it is the default case or if
+              // there is no default case. A break to a different control structure isn't useless.
+              return !blockChild.hasChildren()
+                  && (defaultCase == null || defaultCase == executingCase);
             case Token.VAR:
               if (blockChild.hasOneChild()
                   && blockChild.getFirstFirstChild() == null) {

--- a/src/com/google/javascript/jscomp/PureFunctionIdentifier.java
+++ b/src/com/google/javascript/jscomp/PureFunctionIdentifier.java
@@ -476,7 +476,7 @@ class PureFunctionIdentifier implements CompilerPass {
               // Variable definition are not side effects.
               // Just check that the name appears in the context of a
               // variable declaration.
-              Preconditions.checkArgument(NodeUtil.isVarDeclaration(node));
+              Preconditions.checkArgument(NodeUtil.isNameDeclaration(parent));
               Node value = node.getFirstChild();
               // Assignment to local, if the value isn't a safe local value,
               // new object creation or literal or known primitive result

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -3576,19 +3576,8 @@ public final class IntegrationTest extends IntegrationTestCase {
         "switch(exit) {",
         "  case 21: throw 'x';",
         "  default : console.log('good');",
-        "}"), LINE_JOINER.join(
-        // TODO(moz): Seems like we can fold a bit more here. Investigate later.
-        "var a;",
-        "switch ('a') {",
-        "  case 'a':",
-        "    break;",
-        "  default:",
-        "    a = 21;",
-        "}",
-        "switch(a) {",
-        "  case 21: throw 'x';",
-        "  default : console.a('good');",
-        "}"));
+        "}"),
+        "console.a('good');");
   }
 
   /** Creates a CompilerOptions object with google coding conventions. */

--- a/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
@@ -23,7 +23,7 @@ import com.google.javascript.rhino.Node;
  * of multiple peephole passes are in PeepholeIntegrationTest.
  */
 
-public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
+public final class PeepholeRemoveDeadCodeTest extends Es6CompilerTestCase {
 
   private static final String MATH =
       "/** @const */ var Math = {};" +
@@ -314,13 +314,14 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
     fold("var x=1; switch(x) { case 1: var y; }",
         "var y; var x=1;");
 
-    // Can't remove cases if a default exists.
+    // Can't remove cases if a default exists and is not the last case.
     foldSame("function f() {switch(a){default: return; case 1: break;}}");
+    foldSame("function f() {switch(1){default: return; case 1: break;}}"); // foldable
     foldSame("function f() {switch(a){case 1: foo();}}");
     foldSame("function f() {switch(a){case 3: case 2: case 1: foo();}}");
 
     fold("function f() {switch(a){case 2: case 1: default: foo();}}",
-         "function f() {switch(a){default: foo();}}");
+         "function f() { foo(); }");
     fold("switch(a){case 1: default:break; case 2: foo()}",
          "switch(a){case 2: foo()}");
     foldSame("switch(a){case 1: goo(); default:break; case 2: foo()}");
@@ -379,14 +380,16 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
         "case 'bar':\n" +
         "  bar();\n" +
         "}");
-    foldSame("switch ('hasDefaultCase') {\n" +
-        "case 'foo':\n" +
-        "  foo();\n" +
-        "  break;\n" +
-        "default:\n" +
-        "  bar();\n" +
-        "  break;\n" +
-        "}");
+    fold(LINE_JOINER.join(
+        "switch ('hasDefaultCase') {",
+        "  case 'foo':",
+        "    foo();",
+        "    break;",
+        "  default:",
+        "    bar();",
+        "    break;",
+        "}"),
+        "bar();");
     fold("switch ('repeated') {\n" +
         "case 'repeated':\n" +
         "  foo();\n" +
@@ -476,6 +479,227 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
         "    break outer;\n" +
         "}",
         "outer: {f(); break outer;}");
+  }
+
+  public void testOptimizeSwitchWithLabellessBreak() {
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  switch('x') {",
+        "    case 'x': var x = 1; break;",
+        "    case 'y': break;",
+        "  }",
+        "}"),
+        "function f() { var x = 1; }");
+
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  switch('x') {",
+        "    case 'x': var x = 1; break; var y = 2;",
+        "    case 'y': break;",
+        "  }",
+        "}"),
+        "function f() { var x = 1; }");
+
+    // TODO(moz): Convert this to an if statement for better optimization
+    testSame(LINE_JOINER.join(
+        "function f() {",
+        "  switch(x) {",
+        "    case 'y': break;",
+        "    default: var x = 1;",
+        "  }",
+        "}"));
+
+    test(LINE_JOINER.join(
+        "var exit;",
+        "switch ('a') {",
+        "  case 'a':",
+        "    break;",
+        "  default:",
+        "    exit = 21;",
+        "    break;",
+        "}",
+        "switch(exit) {",
+        "  case 21: throw 'x';",
+        "  default : console.log('good');",
+        "}"), LINE_JOINER.join(
+        "var exit;",
+        "switch(exit) {",
+        "  case 21: throw 'x';",
+        "  default : console.log('good');",
+        "}"));
+  }
+
+  public void testOptimizeSwitchWithLabelledBreak() {
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  label:",
+        "  switch('x') {",
+        "    case 'x': break label;",
+        "    case 'y': throw f;",
+        "  }",
+        "}"),
+        "function f() { label: { break label; } }");
+
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  label:",
+        "  switch('x') {",
+        "    case 'x': break label;",
+        "    default: throw f;",
+        "  }",
+        "}"),
+        "function f() { label: { break label; } }");
+  }
+
+  public void testOptimizeSwitchWithReturn() {
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  switch('x') {",
+        "    case 'x': return 1;",
+        "    case 'y': return 2;",
+        "  }",
+        "}"),
+        "function f() { return 1; }");
+
+    // TODO(moz): This is to show that the current optimization might break if the input has block
+    // scoped declarations. We will need to fix the logic for removing blocks to account for this.
+    testEs6(LINE_JOINER.join(
+        "function f() {",
+        "  let x = 1;",
+        "  switch('x') {",
+        "    case 'x': { let x = 2; return 3; }",
+        "    case 'y': return 4;",
+        "  }",
+        "}"),
+        "function f() { let x = 1; let x = 2; return 3; }");
+  }
+
+  public void testOptimizeSwitchWithThrow() {
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  switch('x') {",
+        "    case 'x': throw f;",
+        "    case 'y': throw f;",
+        "  }",
+        "}"),
+        "function f() { throw f; }");
+  }
+
+  public void testOptimizeSwitchWithContinue() {
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  while (true) {",
+        "    switch('x') {",
+        "      case 'x': continue;",
+        "      case 'y': continue;",
+        "    }",
+        "  }",
+        "}"),
+        "function f() { while (true) { continue; } }");
+  }
+
+  // GitHub issue #1722: https://github.com/google/closure-compiler/issues/1722
+  public void testOptimizeSwitchWithDefaultCase() {
+    test(LINE_JOINER.join(
+        "function f() {",
+        "  switch('x') {",
+        "    case 'x': return 1;",
+        "    case 'y': return 2;",
+        "    default: return 3",
+        " }",
+        "}"),
+        "function f() { return 1; }");
+
+    test(LINE_JOINER.join(
+        "switch ('hasDefaultCase') {",
+        "  case 'foo':",
+        "    foo();",
+        "    break;",
+        "  default:",
+        "    bar();",
+        "    break;",
+        "}"),
+        "bar();");
+
+    test(LINE_JOINER.join(
+        "switch (x) {",
+        "  default:",
+        "    if (a) { break; }",
+        "    bar();",
+        "}"),
+        "switch (x) { default: if (a) { break; } bar(); }");
+
+    // Potentially foldable
+    testSame(LINE_JOINER.join(
+        "switch (x) {",
+        "  case x:",
+        "    foo();",
+        "    break;",
+        "  default:",
+        "    if (a) { break; }",
+        "    bar();",
+        "}"));
+
+    test(LINE_JOINER.join(
+        "switch ('hasDefaultCase') {",
+        "  case 'foo':",
+        "    foo();",
+        "    break;",
+        "  default:",
+        "    if (true) { break; }",
+        "    bar();",
+        "}"),
+        "");
+
+    test(LINE_JOINER.join(
+        "switch ('hasDefaultCase') {",
+        "  case 'foo':",
+        "    foo();",
+        "    break;",
+        "  default:",
+        "    if (a) { break; }",
+        "    bar();",
+        "}"),
+        "switch ('hasDefaultCase') { default: if (a) { break; } bar(); }");
+
+    test(LINE_JOINER.join(
+        "switch ('hasDefaultCase') {",
+        "  case 'foo':",
+        "    foo();",
+        "    break;",
+        "  default:",
+        "    foo();",
+        "    break;",
+        "    bar();",
+        "}"),
+        "foo();");
+
+    test(LINE_JOINER.join(
+        "switch (a()) {",
+        "  default:",
+        "    bar();",
+        "    break;",
+        "}"),
+        "a(); bar();");
+
+    test(LINE_JOINER.join(
+        "switch (a()) {",
+        "  default:",
+        "    break;",
+        "    bar();",
+        "}"),
+        "a();");
+
+    test(LINE_JOINER.join(
+        "loop: ",
+        "while (true) {",
+        "  switch (a()) {",
+        "    default:",
+        "      bar();",
+        "      break loop;",
+        "  }",
+        "}"),
+        "loop: while (true) { a(); bar(); break loop; }");
   }
 
   public void testRemoveNumber() {


### PR DESCRIPTION
A default case that is the last case should not prevent optimizing the
other cases.

Also add optimizations for cases that end with return, throw or
continue.

Fixes #1722.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1728)
<!-- Reviewable:end -->
