### PR TITLE
Fix typo in extern for processing-js

### DIFF
--- a/contrib/externs/processing-1.4.8.js
+++ b/contrib/externs/processing-1.4.8.js
@@ -119,7 +119,7 @@ PImage.prototype.mask = function(mask){};
 Processing.prototype.createImage = function(w, h, mode){};
 
 var pixels = {};
-pixels.prototype.getLenght = function(){};
+pixels.prototype.getLength = function(){};
 pixels.prototype.getPixel = function(i){};
 pixels.prototype.setPixel = function(i, c){};
 pixels.prototype.toArray = function(){};


### PR DESCRIPTION
Fixes typo in declaration of getLength() method in processing-js extern file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1744)
<!-- Reviewable:end -->
