### PR TITLE
Remove assignment to properties of return values of no-side-effect calls

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java
+++ b/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java
@@ -117,23 +117,43 @@ class PeepholeRemoveDeadCode extends AbstractPeepholeOptimization {
     return n;
   }
 
+  private Node foldAssignment(Node subtree, Node right) {
+    subtree.getParent().replaceChild(subtree, right.detachFromParent());
+    reportCodeChange();
+    return right;
+  }
+
   /**
-   * Try removing identity assignments
+   * Try removing dead assignments like identity assignments, or assignments to properties of
+   * objects created by calls that have no side effects, like "Object.create({}).prop = 1"
+   *
    * @return the replacement node, if changed, or the original if not
    */
   private Node tryFoldAssignment(Node subtree) {
     Preconditions.checkState(subtree.isAssign());
     Node left = subtree.getFirstChild();
     Node right = subtree.getLastChild();
-    // Only names
+    // Identity assignments on NAMEs only, like "a = a". Cases like "a.b = a.b" are not handled yet.
     if (left.isName()
         && right.isName()
         && left.getString().equals(right.getString())) {
-      subtree.getParent().replaceChild(subtree, right.detachFromParent());
-      reportCodeChange();
-      return right;
+      return foldAssignment(subtree, right);
     }
-    return subtree;
+
+    // Handle cases like "Object.create({}).prop = 1". Note that we only fold if all calls are
+    // side effect free.
+    boolean canFold = false;
+    while (left.isGetProp() || left.isCall()) {
+      if (left.isCall()) {
+        if (left.isNoSideEffectsCall()) {
+          canFold = true;
+        } else {
+          return subtree;
+        }
+      }
+      left = left.getFirstChild();
+    }
+    return canFold ? foldAssignment(subtree, right) : subtree;
   }
 
   /**

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -2124,25 +2124,20 @@ public final class IntegrationTest extends IntegrationTestCase {
 
   public void testFoldLocals5() {
     CompilerOptions options = createCompilerOptions();
-
     options.setFoldConstants(true);
 
-    String code =
-        ""
-        + "function fn(){var a={};a.x={};return a}"
-        + "fn().x.y = 1;";
+    String code = LINE_JOINER.join(
+        "function fn() { var a = {}; a.x = {}; return a; }",
+        "fn().x.y = 1;");
 
-    // "fn" returns a unescaped local object, we should be able to fold it,
-    // but we don't currently.
-    String result = ""
-        + "function fn(){var a={x:{}};return a}"
-        + "fn().x.y = 1;";
-
-    test(options, code, result);
+    // "fn" returns a unescaped local object. we should be able to fold it, but we don't currently.
+    test(options, code, LINE_JOINER.join(
+        "function fn() { var a = {x: {}}; return a }",
+        "fn().x.y = 1;"));
 
     options.setComputeFunctionSideEffects(true);
 
-    test(options, code, result);
+    test(options, code, "function fn() { var a = {x: {}}; return a }");
   }
 
   public void testFoldLocals6() {
@@ -2150,16 +2145,15 @@ public final class IntegrationTest extends IntegrationTestCase {
 
     options.setFoldConstants(true);
 
-    String code =
-        ""
-        + "function fn(){return {}}"
-        + "fn().x.y = 1;";
+    String code = LINE_JOINER.join(
+        "function fn() { return {}; }",
+        "fn().x.y = 1;");
 
     testSame(options, code);
 
     options.setComputeFunctionSideEffects(true);
 
-    testSame(options, code);
+    test(options, code, "function fn() { return {}; }");
   }
 
   public void testFoldLocals7() {

--- a/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
@@ -25,13 +25,21 @@ import com.google.javascript.rhino.Node;
 
 public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
 
-  private static final String MATH =
-      "/** @const */ var Math = {};" +
-      "/** @nosideeffects */ Math.random = function(){};" +
-      "/** @nosideeffects */ Math.sin = function(){};";
+  private static final String MATH = LINE_JOINER.join(
+      "/** @const */ var Math = {};",
+      "/** @nosideeffects */ Math.random = function() {};",
+      "/** @nosideeffects */ Math.sin = function() {};");
+
+  private static final String OBJECT =
+      "/** @nosideeffects */ Object.create = function(proto, opt_properties) {};";
+
+  private static final String JQUERY = LINE_JOINER.join(
+      "/** @constructor */ function $() {};",
+      "/** @nosideeffects */ $.prototype.add = function() {};",
+      "$.prototype.addClass = function() {};");
 
   public PeepholeRemoveDeadCodeTest() {
-    super(MATH);
+    super(MATH + OBJECT + JQUERY);
   }
 
   @Override
@@ -732,6 +740,17 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
     testSame("x.a=x.a");
     test("var y=(x=x)", "var y=x");
     test("y=1 + (x=x)", "y=1 + x");
+
+    // GitHub issue #1745: https://github.com/google/closure-compiler/issues/1745
+    test("Object.create({}).prop = 1", "");
+    test("Object.create(proto).foo.bar.baz = 1", "");
+
+    // add() is side-effect free, but addClass() is not
+    test("var jQuery = new $; jQuery.add().add().bar = 1", "var jQuery = new $;");
+    test("var jQuery = new $; jQuery.add().bar.add().baz = 1", "var jQuery = new $;");
+    test("var jQuery = new $; jQuery.bar.add().baz = 1", "var jQuery = new $;");
+    testSame("var jQuery = new $; jQuery.add().addClass().bar = 1");
+    testSame("var jQuery = new $; jQuery.addClass().add().bar = 1");
   }
 
   public void testTryCatchFinally() {


### PR DESCRIPTION
Assignments like "Object.create({}).prop = 1" is dead code and should be
removed.

Closes #1745.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1746)

<!-- Reviewable:end -->
