### PR TITLE
Tighten the type annotation of XMLHttpRequest.prototype.response

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2423,8 +2423,8 @@ XMLHttpRequest.prototype.overrideMimeType = function(mimeType) {};
 XMLHttpRequest.prototype.responseType;
 
 /**
- * @type {*}
- * @see http://dev.w3.org/2006/webapi/XMLHttpRequest-2/#the-responsetype-attribute
+ * @type {?(ArrayBuffer|Blob|Document|Object|string)}
+ * @see http://dev.w3.org/2006/webapi/XMLHttpRequest-2/#the-response-attribute
  */
 XMLHttpRequest.prototype.response;
 


### PR DESCRIPTION
Also fix the @see link describing the property.

Fixes #1751.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1753)
<!-- Reviewable:end -->
