### PR TITLE
Remove a trailing ')' in a comment in J2clEqualitySameRewriterPass

### DIFF
--- a/src/com/google/javascript/jscomp/J2clEqualitySameRewriterPass.java
+++ b/src/com/google/javascript/jscomp/J2clEqualitySameRewriterPass.java
@@ -69,7 +69,7 @@ public class J2clEqualitySameRewriterPass extends AbstractPostOrderCallback
   }
 
   private static boolean isEqualitySameMethodName(String fnName) {
-    // The '.$same' case) only happens when collapseProperties is off.
+    // The '.$same' case only happens when collapseProperties is off.
     return fnName != null
         && (fnName.endsWith("Equality$$0same") || fnName.endsWith("Equality.$same"));
   }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1766)
<!-- Reviewable:end -->
