### PR TITLE
Make LintPassConfig public

### DIFF
--- a/src/com/google/javascript/jscomp/LintPassConfig.java
+++ b/src/com/google/javascript/jscomp/LintPassConfig.java
@@ -37,8 +37,8 @@ import java.util.List;
  * DiagnosticGroup enabled, but some of the lint checks depend on type information, which is not
  * available when looking at a single file, so those are omitted here.
  */
-class LintPassConfig extends PassConfig.PassConfigDelegate {
-  LintPassConfig(CompilerOptions options) {
+public class LintPassConfig extends PassConfig.PassConfigDelegate {
+  public LintPassConfig(CompilerOptions options) {
     super(new DefaultPassConfig(options));
   }
 


### PR DESCRIPTION
I'm planning on using this class in the Closure Rules repository
because there currently exists no flags for the Linter class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1767)
<!-- Reviewable:end -->
