### PR TITLE
Fix closure linter for private members

### DIFF
--- a/src/com/google/javascript/jscomp/ClosureCodingConvention.java
+++ b/src/com/google/javascript/jscomp/ClosureCodingConvention.java
@@ -391,7 +391,7 @@ public final class ClosureCodingConvention extends CodingConventions.Proxy {
 
   @Override
   public boolean isPrivate(String name) {
-    return false;
+    return name.endsWith("_");
   }
 
   @Override


### PR DESCRIPTION
I'm getting errors like:

```
closure/templates/test/greeter.js:35: WARNING - Private property name_ should end with '_'
  this.name_ = name;
```

Because of this:

https://github.com/google/closure-compiler/blob/c0f6720d0b58f2a84d7a9cfb6adc26b5a9da5d62/src/com/google/javascript/jscomp/lint/CheckJSDocStyle.java#L202

This is because the Closure convention always returns false for isPrivate. Now it's better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1768)
<!-- Reviewable:end -->
