### PR TITLE
Adding support for ES6 modules with non-JS extensions:

### DIFF
--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -148,7 +148,10 @@ public final class ModuleLoader {
      * @return The normalized module URI, or {@code null} if not found.
      */
     public ModuleUri resolveEs6Module(String moduleName) {
-      URI resolved = locateNoCheck(moduleName + ".js");
+      // Typically module names don't have the ".js" extension. 
+      // But tolerate this, and support explicit ".jsx" extension:
+      if (!moduleName.endsWith(".js") && !moduleName.endsWith(".jsx")) moduleName += ".js";
+      URI resolved = locateNoCheck(moduleName);
       if (!moduleUris.contains(resolved) && errorHandler != null) {
         errorHandler.report(CheckLevel.WARNING, JSError.make(LOAD_WARNING, moduleName));
       }

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -33,6 +33,14 @@ public final class ModuleLoaderTest extends TestCase {
     assertUri("js/a.js", loader.resolve("js\\a.js"));
     assertUri("js/b.js", loader.resolve("js\\a.js").resolveEs6Module("./b"));
   }
+  
+  public void testJsxExtension() {
+	  ModuleLoader loader =
+        new ModuleLoader(null, ImmutableList.of("."), inputs("js/a.js", "js/b.js", "js/c.jsx"));
+    assertUri("js/a.js", loader.resolve("js/a.js"));
+    assertUri("js/b.js", loader.resolve("js/a.js").resolveEs6Module("./b"));
+    assertUri("js/c.jsx", loader.resolve("js/a.js").resolveEs6Module("./c.jsx"));
+  }
 
   public void testLocateCommonJs() throws Exception {
     ModuleLoader loader = new ModuleLoader(


### PR DESCRIPTION
existing:
```js
import "./MyJsFile" -> MyJsFile.js
```
and now:
```js
import "./MyJsxFile.jsx" -> MyJsFile.jsx
```

@ChadKillingsworth might want to glance at this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1774)
<!-- Reviewable:end -->
