### PR TITLE
CommonJS module rewriting should ignore goog.module exports.

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -407,10 +407,10 @@ public final class ProcessCommonJSModules implements CompilerPass {
       // If there are no exports, we still need to rewrite type annotations which
       // are module paths
       NodeTraversal.traverseEs6(compiler, script,
-          new SuffixVarsCallback(moduleName, hasExports));
+          new SuffixVarsCallback(moduleName, hasExports && allowFullRewrite));
 
       // If the script has no exports, we don't want to output a goog.provide statement
-      if (!hasExports) {
+      if (!hasExports || !allowFullRewrite) {
         return;
       }
 


### PR DESCRIPTION
The new `goog.module` syntax has an `exports` object which is also used in CommonJS modules. CommonJS module rewriting should ignore `exports` object references in `goog.module` files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1807)
<!-- Reviewable:end -->
