### PR TITLE
Make the order of goog.requires match the order of ES6 imports

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -87,6 +87,8 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
 
   private boolean reportDependencies;
 
+  private Node googRequireInsertSpot;
+
   /**
    * Creates a new ProcessEs6Modules instance which can be used to rewrite
    * ES6 modules to a concatenable form.
@@ -190,7 +192,9 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
       Node require = IR.exprResult(
           IR.call(NodeUtil.newQName(compiler, "goog.require"), IR.string(moduleName)));
       require.copyInformationFromForTree(importDecl);
-      script.addChildToFront(require);
+      script.addChildAfter(require, googRequireInsertSpot);
+      googRequireInsertSpot = require;
+
       if (reportDependencies) {
         t.getInput().addRequire(moduleName);
       }

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -69,10 +69,12 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
     ImmutableList<SourceFile> inputs =
         ImmutableList.of(
             SourceFile.fromCode("other.js", "goog.provide('module$other');"),
+            SourceFile.fromCode("yet_another.js", "goog.provide('module$yet_another');"),
             SourceFile.fromCode(fileName, input));
     ImmutableList<SourceFile> expecteds =
         ImmutableList.of(
             SourceFile.fromCode("other.js", "goog.provide('module$other');"),
+            SourceFile.fromCode("yet_another.js", "goog.provide('module$yet_another');"),
             SourceFile.fromCode(fileName, expected));
     test.test(inputs, expecteds);
   }
@@ -642,6 +644,11 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
   public void testImportWithoutReferences() {
     testModules("import 'other';", "goog.require('module$other');");
+    // GitHub issue #1819: https://github.com/google/closure-compiler/issues/1819
+    // Need to make sure the order of the goog.requires matches the order of the imports.
+    testModules(
+        "import 'other'; import 'yet_another';",
+        "goog.require('module$other'); goog.require('module$yet_another');");
   }
 
   public void testUselessUseStrict() {


### PR DESCRIPTION
Fixes #1819.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1820)
<!-- Reviewable:end -->
