### PR TITLE
Add support for Object.defineProperties to type-based renaming passes

### DIFF
--- a/src/com/google/javascript/jscomp/DisambiguateProperties.java
+++ b/src/com/google/javascript/jscomp/DisambiguateProperties.java
@@ -502,6 +502,11 @@ class DisambiguateProperties implements CompilerPass {
     }
 
     private void handleObjectLit(NodeTraversal t, Node n) {
+      // Object.defineProperties literals are handled at the CALL node.
+      if (n.getParent().isCall() && NodeUtil.isObjectDefinePropertiesDefinition(n.getParent())) {
+        return;
+      }
+
       for (Node child = n.getFirstChild();
           child != null;
           child = child.getNext()) {
@@ -529,16 +534,20 @@ class DisambiguateProperties implements CompilerPass {
 
     private void handleCall(NodeTraversal t, Node call) {
       Node target = call.getFirstChild();
-      if (!target.isName()) {
+      if (!target.isQualifiedName()) {
         return;
       }
 
-      String renameFunctionName = target.getOriginalQualifiedName();
-      if (renameFunctionName == null
-          || !compiler.getCodingConvention().isPropertyRenameFunction(renameFunctionName)) {
-        return;
+      String functionName = target.getOriginalQualifiedName();
+      if (functionName != null
+          && compiler.getCodingConvention().isPropertyRenameFunction(functionName)) {
+        handlePropertyRenameFunctionCall(t, call, functionName);
+      } else if (NodeUtil.isObjectDefinePropertiesDefinition(call)) {
+        handleObjectDefineProperties(t, call);
       }
+    }
 
+    private void handlePropertyRenameFunctionCall(NodeTraversal t, Node call, String renameFunctionName) {
       if (call.getChildCount() != 2 && call.getChildCount() != 3) {
         compiler.report(
             JSError.make(
@@ -602,6 +611,25 @@ class DisambiguateProperties implements CompilerPass {
                 String.valueOf(type),
                 renameFunctionName,
                 suggestion));
+      }
+    }
+
+    private void handleObjectDefineProperties(NodeTraversal t, Node call) {
+      Node typeObj = call.getSecondChild();
+      JSType type = getType(typeObj);
+      Node objectLiteral = typeObj.getNext();
+      if (!objectLiteral.isObjectLit()) {
+        return;
+      }
+
+      for (Node key : objectLiteral.children()) {
+        if (key.isQuotedString()) {
+          continue;
+        }
+
+        String propName = key.getString();
+        Property prop = getProperty(propName);
+        prop.scheduleRenaming(key, processProperty(t, prop, type, null));
       }
     }
 

--- a/test/com/google/javascript/jscomp/AmbiguatePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/AmbiguatePropertiesTest.java
@@ -33,6 +33,8 @@ public final class AmbiguatePropertiesTest extends CompilerTestCase {
   private static final String EXTERNS =
       "Function.prototype.call=function(){};" +
       "Function.prototype.inherits=function(){};" +
+      "/** @const */ var Object = {};" +
+      "Object.defineProperties = function(typeRef, definitions) {};" +
       "prop.toString;" +
       "var google = { gears: { factory: {}, workerPool: {} } };";
 
@@ -299,6 +301,78 @@ public final class AmbiguatePropertiesTest extends CompilerTestCase {
              "Bar.prototype['getA'] = function(){};" +
              "var bar = new Bar();" +
              "bar['getA']();");
+  }
+
+  public void testObjectDefineProperties() {
+    String js = LINE_JOINER.join(
+        "/** @constructor */ var Bar = function(){};",
+        "Bar.prototype.bar = 0;",
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.bar_ = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype.bar;",
+        "Object.defineProperties(Foo.prototype, {",
+        "  bar: {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.bar_;},",
+        "    /** @this {Foo} */ set: function(value) { this.bar_ = value; }",
+        "  }",
+        "});");
+
+    String result = LINE_JOINER.join(
+        "/** @constructor */ var Bar = function(){};",
+        "Bar.prototype.a = 0;",
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.b = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype.a;",
+        "Object.defineProperties(Foo.prototype, {",
+        "  a: {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.b;},",
+        "    /** @this {Foo} */ set: function(value) { this.b = value; }",
+        "  }",
+        "});");
+
+    test (js, result);
+  }
+
+  public void testObjectDefinePropertiesQuoted() {
+    String js = LINE_JOINER.join(
+        "/** @constructor */ var Bar = function(){};",
+        "Bar.prototype.bar = 0;",
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.bar_ = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype['bar'];",
+        "Object.defineProperties(Foo.prototype, {",
+        "  'a': {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.bar_;},",
+        "    /** @this {Foo} */ set: function(value) { this.bar_ = value; }",
+        "  }",
+        "});");
+
+    String result = LINE_JOINER.join(
+        "/** @constructor */ var Bar = function(){};",
+        "Bar.prototype.b = 0;",
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.b = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype['bar'];",
+        "Object.defineProperties(Foo.prototype, {",
+        "  'a': {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.b;},",
+        "    /** @this {Foo} */ set: function(value) { this.b = value; }",
+        "  }",
+        "});");
+
+    test (js, result);
   }
 
   public void testOverlappingOriginalAndGeneratedNames() {

--- a/test/com/google/javascript/jscomp/DisambiguatePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/DisambiguatePropertiesTest.java
@@ -989,6 +989,84 @@ public final class DisambiguatePropertiesTest extends CompilerTestCase {
     testSets(js, result, "{foo=[[F.prototype], [G.prototype]]}");
   }
 
+  public void testObjectLiteralDefineProperties() {
+    String externs = LINE_JOINER.join(
+        "/** @const */ var Object = {};",
+        "Object.defineProperties = function(typeRef, definitions) {}",
+        "/** @constructor */ function FooBar() {}",
+        "/** @type {string} */ FooBar.prototype.bar_;",
+        "/** @type {string} */ FooBar.prototype.bar;"
+    );
+
+    String js = LINE_JOINER.join(
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.bar_ = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype.bar;",
+        "Object.defineProperties(Foo.prototype, {",
+        "  bar: {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.bar_;},",
+        "    /** @this {Foo} */ set: function(value) { this.bar_ = value; }",
+        "  }",
+        "});");
+
+    String result = LINE_JOINER.join(
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.Foo$bar_ = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype.Foo_prototype$bar;",
+        "Object.defineProperties(Foo.prototype, {",
+        "  Foo_prototype$bar: {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.Foo$bar_;},",
+        "    /** @this {Foo} */ set: function(value) { this.Foo$bar_ = value; }",
+        "  }",
+        "});");
+    testSets(externs, js, result, "{bar=[[Foo.prototype]], bar_=[[Foo]]}");
+  }
+
+  public void testObjectLiteralDefinePropertiesQuoted() {
+    String externs = LINE_JOINER.join(
+        "/** @const */ var Object = {};",
+        "Object.defineProperties = function(typeRef, definitions) {}",
+        "/** @constructor */ function FooBar() {}",
+        "/** @type {string} */ FooBar.prototype.bar_;",
+        "/** @type {string} */ FooBar.prototype.bar;"
+    );
+
+    String js = LINE_JOINER.join(
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.bar_ = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype['bar'];",
+        "Object.defineProperties(Foo.prototype, {",
+        "  'bar': {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.bar_;},",
+        "    /** @this {Foo} */ set: function(value) { this.bar_ = value; }",
+        "  }",
+        "});");
+
+    String result = LINE_JOINER.join(
+        "/** @struct @constructor */ var Foo = function() {",
+        "  this.Foo$bar_ = 'bar';",
+        "};",
+        "/** @type {?} */ Foo.prototype['bar'];",
+        "Object.defineProperties(Foo.prototype, {",
+        "  'bar': {",
+        "    configurable: true,",
+        "    enumerable: true,",
+        "    /** @this {Foo} */ get: function() { return this.Foo$bar_;},",
+        "    /** @this {Foo} */ set: function(value) { this.Foo$bar_ = value; }",
+        "  }",
+        "});");
+    testSets(externs, js, result, "{bar_=[[Foo]]}");
+  }
+
   public void testObjectLiteralLends() {
     String js = ""
         + "var mixin = function(x) { return x; };"


### PR DESCRIPTION
Improves renaming opportunities for ES6 getters/setters who share names with extern properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1823)
<!-- Reviewable:end -->
