### PR TITLE
jQueryAjaxSettings.prototype.contentType may be a boolean

### DIFF
--- a/contrib/externs/jquery-1.9.js
+++ b/contrib/externs/jquery-1.9.js
@@ -63,7 +63,7 @@ jQueryAjaxSettings.prototype.complete;
 /** @type {(Object<string, RegExp>|undefined)} */
 jQueryAjaxSettings.prototype.contents;
 
-/** @type {(?string|undefined)} */
+/** @type {(?string|boolean|undefined)} */
 jQueryAjaxSettings.prototype.contentType;
 
 /** @type {(Object<?, ?>|jQueryAjaxSettings|undefined)} */


### PR DESCRIPTION
See http://api.jquery.com/jquery.ajax/

contentType (default: 'application/x-www-form-urlencoded; charset=UTF-8')
Type: Boolean or String

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1843)
<!-- Reviewable:end -->
