### PR TITLE
Add missing 'paramSerializer' in angular.$http.Config

### DIFF
--- a/contrib/externs/angular-1.5.js
+++ b/contrib/externs/angular-1.5.js
@@ -1468,6 +1468,7 @@ angular.$http;
  *   headers: (Object|undefined),
  *   method: (string|undefined),
  *   params: (Object.<(string|Object)>|undefined),
+ *   paramSerializer: (string|function(Object<string,string>):string|undefined),
  *   responseType: (string|undefined),
  *   timeout: (number|!angular.$q.Promise|undefined),
  *   transformRequest:


### PR DESCRIPTION
See https://docs.angularjs.org/api/ng/service/$http

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1850)
<!-- Reviewable:end -->
