### PR TITLE
Exposes inputSourceMaps attribute.

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -85,6 +85,15 @@ public class CompilerOptions {
   public void setSkipTranspilationAndCrash(boolean value) {
     skipTranspilationAndCrash = value;
   }
+  
+  /**
+   * Sets the input sourcemap files, indexed by the JS files they refer to.
+   *
+   * @param inputSourceMaps the collection of input sourcemap files
+   */
+  public void setInputSourceMaps(final ImmutableMap<String, SourceMapInput> inputSourceMaps) {
+    this.inputSourceMaps = inputSourceMaps;  
+  } 
 
   /**
    * Whether to infer consts. This should not be configurable by


### PR DESCRIPTION
This allows to configure the input sourcemaps with Java API easily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1867)
<!-- Reviewable:end -->
