### PR TITLE
Revert "Rewrite internal references to classes so that we don't crash…

### DIFF
--- a/src/com/google/javascript/jscomp/Es6ExtractClasses.java
+++ b/src/com/google/javascript/jscomp/Es6ExtractClasses.java
@@ -16,17 +16,12 @@
 
 package com.google.javascript.jscomp;
 
-import static com.google.javascript.jscomp.Es6ToEs3Converter.CANNOT_CONVERT;
-
-import com.google.common.base.Preconditions;
 import com.google.javascript.jscomp.ExpressionDecomposer.DecompositionType;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
 
-import java.util.Deque;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Set;
 
 /**
@@ -66,13 +61,11 @@ public final class Es6ExtractClasses
   @Override
   public void process(Node externs, Node root) {
     NodeTraversal.traverseRootsEs6(compiler, this, externs, root);
-    NodeTraversal.traverseRootsEs6(compiler, new SelfReferenceRewriter(), externs, root);
   }
 
   @Override
   public void hotSwapScript(Node scriptRoot, Node originalRoot) {
     NodeTraversal.traverseEs6(compiler, scriptRoot, this);
-    NodeTraversal.traverseEs6(compiler, scriptRoot, new SelfReferenceRewriter());
   }
 
   @Override
@@ -82,85 +75,18 @@ public final class Es6ExtractClasses
     }
   }
 
-  private class SelfReferenceRewriter implements NodeTraversal.Callback {
-    private class ClassDescription {
-      Node nameNode;
-      String outerName;
-
-      ClassDescription(Node nameNode, String outerName) {
-        this.nameNode = nameNode;
-        this.outerName = outerName;
-      }
-    }
-
-    private Deque<ClassDescription> classStack = new LinkedList<>();
-
-    private boolean needsInnerNameRewriting(Node classNode, Node parent) {
-      Preconditions.checkArgument(classNode.isClass());
-      return classNode.getFirstChild().isName() && parent.isName();
-    }
-
-    @Override
-    public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
-      if (n.isClass() && needsInnerNameRewriting(n, parent)) {
-        classStack.addFirst(new ClassDescription(n.getFirstChild(), parent.getString()));
-      }
-      return true;
-    }
-
-    @Override
-    public void visit(NodeTraversal t, Node n, Node parent) {
-      switch (n.getType()) {
-        case CLASS:
-          if (needsInnerNameRewriting(n, parent)) {
-            classStack.removeFirst();
-            n.replaceChild(n.getFirstChild(), IR.empty().useSourceInfoFrom(n.getFirstChild()));
-            compiler.reportCodeChange();
-          }
-          break;
-        case NAME:
-          maybeUpdateClassSelfRef(t, n, parent);
-          break;
-        default:
-          break;
-      }
-    }
-
-    private void maybeUpdateClassSelfRef(NodeTraversal t, Node nameNode, Node parent) {
-      for (ClassDescription klass : classStack) {
-        if (nameNode != klass.nameNode && nameNode.matchesQualifiedName(klass.nameNode)) {
-          Var var = t.getScope().getVar(nameNode.getString());
-          if (var != null && var.getNameNode() == klass.nameNode) {
-            parent.replaceChild(nameNode, IR.name(klass.outerName).useSourceInfoFrom(nameNode));
-            compiler.reportCodeChange();
-            return;
-          }
-        }
-      }
-    }
-  }
-
   private boolean shouldExtractClass(Node classNode, Node parent) {
-    boolean isAnonymous = classNode.getFirstChild().isEmpty();
     if (NodeUtil.isClassDeclaration(classNode)
-        || isAnonymous && parent.isName()
-        || (isAnonymous && parent.isAssign() && parent.getParent().isExprResult())) {
+        || parent.isName()
+        || (parent.isAssign() && parent.getParent().isExprResult())) {
       // No need to extract. Handled directly by Es6ToEs3Converter.ClassDeclarationMetadata#create.
       return false;
     }
-
-    if (NodeUtil.mayHaveSideEffects(classNode)
-        // Don't extract the class if it's not safe to do so. For example,
-        // var c = maybeTrue() && class extends someSideEffect() {};
-        // TODO(brndn): it is possible to be less conservative. If the classNode is DECOMPOSABLE,
-        // we could use the expression decomposer to move it out of the way.
-        || expressionDecomposer.canExposeExpression(classNode) != DecompositionType.MOVABLE) {
-      compiler.report(
-          JSError.make(classNode, CANNOT_CONVERT, "class expression that cannot be extracted"));
-      return false;
-    }
-
-    return true;
+    // Don't extract the class if it's not safe to do so. For example,
+    // var c = maybeTrue() && class extends someSideEffect() {};
+    // TODO(brndn): it is possible to be less conservative. If the classNode is DECOMPOSABLE,
+    // we could use the expression decomposer to move it out of the way.
+    return expressionDecomposer.canExposeExpression(classNode) == DecompositionType.MOVABLE;
   }
 
   private void extractClass(Node classNode, Node parent) {

--- a/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
+++ b/src/com/google/javascript/jscomp/Es6ToEs3Converter.java
@@ -46,7 +46,6 @@ import javax.annotation.Nullable;
  *
  * @author tbreisacher@google.com (Tyler Breisacher)
  */
-// TODO(tbreisacher): This class does too many things. Break it into smaller passes.
 public final class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapCompilerPass {
   private final AbstractCompiler compiler;
 
@@ -546,9 +545,9 @@ public final class Es6ToEs3Converter implements NodeTraversal.Callback, HotSwapC
     ClassDeclarationMetadata metadata = ClassDeclarationMetadata.create(classNode, parent);
 
     if (metadata == null || metadata.fullClassName == null) {
-      throw new IllegalStateException(
-          "Can only convert classes that are declarations or the right hand"
-          + " side of a simple assignment: " + classNode);
+      cannotConvert(parent, "Can only convert classes that are declarations or the right hand"
+          + " side of a simple assignment.");
+      return;
     }
     if (metadata.hasSuperClass() && !metadata.superClassNameNode.isQualifiedName()) {
       compiler.report(JSError.make(metadata.superClassNameNode, DYNAMIC_EXTENDS_TYPE));

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1494,7 +1494,7 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testES6TranspiledByDefault() {
-    test("var x = class {};", "var x = function() {};");
+    test("var x = class X {};", "var x = function() {};");
   }
 
   public void testES5ChecksByDefault() {

--- a/test/com/google/javascript/jscomp/Es6ExtractClassesTest.java
+++ b/test/com/google/javascript/jscomp/Es6ExtractClassesTest.java
@@ -39,86 +39,7 @@ public final class Es6ExtractClassesTest extends CompilerTestCase {
     test(
         "f(class{});",
         LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {};",
-            "f(testcode$classdecl$var0);"));
-  }
-
-  public void testSelfReference1() {
-    test(
-        "var Outer = class Inner { constructor() { alert(Inner); } };",
-        LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {",
-            "  constructor() { alert(testcode$classdecl$var0); }",
-            "};",
-            "var Outer=testcode$classdecl$var0"));
-
-    test(
-        "let Outer = class Inner { constructor() { alert(Inner); } };",
-        LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {",
-            "  constructor() { alert(testcode$classdecl$var0); }",
-            "};",
-            "let Outer=testcode$classdecl$var0"));
-
-    test(
-        "const Outer = class Inner { constructor() { alert(Inner); } };",
-        LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {",
-            "  constructor() { alert(testcode$classdecl$var0); }",
-            "};",
-            "const Outer=testcode$classdecl$var0"));
-  }
-
-  public void testSelfReference2() {
-    test(
-        "alert(class C { constructor() { alert(C); } });",
-        LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {",
-            "  constructor() { alert(testcode$classdecl$var0); }",
-            "};",
-            "alert(testcode$classdecl$var0)"));
-  }
-
-  public void testSelfReference3() {
-    test(
-        LINE_JOINER.join(
-            "alert(class C {",
-            "  m1() { class C {}; alert(C); }",
-            "  m2() { alert(C); }",
-            "});"),
-        LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {",
-            "  m1() { class C {}; alert(C); }",
-            "  m2() { alert(testcode$classdecl$var0); }",
-            "};",
-            "alert(testcode$classdecl$var0)"));
-  }
-
-  public void testSelfReference_googModule() {
-    test(
-        LINE_JOINER.join(
-            "goog.module('example');",
-            "exports = class Inner { constructor() { alert(Inner); } };"),
-        LINE_JOINER.join(
-            "goog.module('example');",
-            "const testcode$classdecl$var0 = class {",
-            "  constructor() {",
-            "    alert(testcode$classdecl$var0);",
-            "  }",
-            "};",
-            "exports = testcode$classdecl$var0;"));
-  }
-
-  public void testSelfReference_qualifiedName() {
-    test(
-        "outer.qual.Name = class Inner { constructor() { alert(Inner); } };",
-        LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {",
-            "  constructor() {",
-            "    alert(testcode$classdecl$var0);",
-            "  }",
-            "};",
-            "outer.qual.Name = testcode$classdecl$var0;"));
+            "const testcode$classdecl$var0 = class {};", "f(testcode$classdecl$var0);"));
   }
 
   public void testConstAssignment() {
@@ -158,34 +79,22 @@ public final class Es6ExtractClassesTest extends CompilerTestCase {
   }
 
   public void testConditionalBlocksExtractionFromCall() {
-    testError("maybeTrue() && f(class{});", CANNOT_CONVERT);
+    testSame("maybeTrue() && f(class{});");
   }
 
   public void testExtractionFromArrayLiteral() {
     test(
         "var c = [class C {}];",
         LINE_JOINER.join(
-            "const testcode$classdecl$var0 = class {};",
-            "var c = [testcode$classdecl$var0];"));
+            "const testcode$classdecl$var0 = class C {};", "var c = [testcode$classdecl$var0];"));
+  }
+
+  public void testConditionalBlocksExtractionFromArrayLiteral() {
+    testSame("var c = maybeTrue() && [class {}]");
   }
 
   public void testTernaryOperatorBlocksExtraction() {
-    testError("var c = maybeTrue() ? class A {} : anotherExpr", CANNOT_CONVERT);
-    testError("var c = maybeTrue() ? anotherExpr : class B {}", CANNOT_CONVERT);
-  }
-
-  public void testCannotExtract() {
-    testError(
-        "var c = maybeTrue() && class A extends sideEffect() {}",
-        CANNOT_CONVERT);
-
-    testError(
-        LINE_JOINER.join(
-            "var x;",
-            "function f(x, y) {}",
-
-            "f(x = 2, class Foo { [x=3]() {} });"),
-        CANNOT_CONVERT);
+    testSame("var c = maybeTrue() ? class A {} : class B {}");
   }
 
   public void testClassesHandledByEs6ToEs3Converter() {


### PR DESCRIPTION
… on things like"

This reverts commit b78e9d690bca36ba0b78ac1330980142a613b8bd.

This commit cause error on Template es6 classes, such as:

/**
 * @constructor
 * @template T
 */
var A = class A {
  constructor() {}

  /**
   * @return {T}  // error here:  ERROR - Bad type annotation. Unknown type T
   */
  foo() {}
}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1871)
<!-- Reviewable:end -->
