### PR TITLE
Warn if @abstract and @private appear on the same JSDocInfo

### DIFF
--- a/src/com/google/javascript/rhino/JSDocInfoBuilder.java
+++ b/src/com/google/javascript/rhino/JSDocInfoBuilder.java
@@ -938,7 +938,8 @@ public final class JSDocInfoBuilder {
   public boolean recordAbstract() {
     if (!hasAnySingletonTypeTags()
         && !currentInfo.isInterface()
-        && !currentInfo.isAbstract()) {
+        && !currentInfo.isAbstract()
+        && currentInfo.getVisibility() != Visibility.PRIVATE) {
       currentInfo.setAbstract();
       populated = true;
       return true;

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -1369,6 +1369,22 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
         "Bad type annotation. type annotation incompatible with other annotations");
   }
 
+  public void testParseAbstract_abstractAndNotPrivate() throws Exception {
+    JSDocInfo info1 = parse("* @public \n * @abstract */");
+    assertThat(info1.isAbstract());
+
+    JSDocInfo info2 = parse("* @protected \n * @abstract */");
+    assertThat(info2.isAbstract());
+
+    JSDocInfo info3 = parse("* @package \n * @abstract */");
+    assertThat(info3.isAbstract());
+  }
+
+  public void testParseAbstract_abstractAndPrivate() throws Exception {
+    parse("* @private \n * @abstract */",
+        "Bad type annotation. type annotation incompatible with other annotations");
+  }
+
   public void testStackedAnnotation() throws Exception {
     JSDocInfo info = parse("@const @type {string}*/");
     assertThat(info.isConstant()).isTrue();


### PR DESCRIPTION
"private abstract" methods don't make much sense so warn if one is
found.