### PR TITLE
Add missing states for XMLHttpRequest externs

### DIFF
--- a/externs/browser/w3c_xml.js
+++ b/externs/browser/w3c_xml.js
@@ -400,6 +400,36 @@ XMLHttpRequest.prototype.onreadystatechange;
 XMLHttpRequest.prototype.onerror;
 
 /**
+ * @type {number}
+ * @see https://www.w3.org/TR/XMLHttpRequest/#states
+ */
+XMLHttpRequest.UNSENT;
+
+/**
+ * @type {number}
+ * @see https://www.w3.org/TR/XMLHttpRequest/#states
+ */
+XMLHttpRequest.OPENED;
+
+/**
+ * @type {number}
+ * @see https://www.w3.org/TR/XMLHttpRequest/#states
+ */
+XMLHttpRequest.HEADERS_RECEIVED;
+
+/**
+ * @type {number}
+ * @see https://www.w3.org/TR/XMLHttpRequest/#states
+ */
+XMLHttpRequest.LOADING;
+
+/**
+ * @type {number}
+ * @see https://www.w3.org/TR/XMLHttpRequest/#states
+ */
+XMLHttpRequest.DONE;
+
+/**
  * The FormData object represents an ordered collection of entries. Each entry
  * has a name and value.
  *


### PR DESCRIPTION
As seen here https://www.w3.org/TR/XMLHttpRequest/#states, some states are missing from the W3C XML extern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/closure-compiler/1930)
<!-- Reviewable:end -->
