### PR TITLE
Update EventTarget according to the latest spec

### DIFF
--- a/contrib/externs/w3c_eventsource.js
+++ b/contrib/externs/w3c_eventsource.js
@@ -29,26 +29,15 @@
  */
 function EventSource(url, opt_eventSourceInitDict) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-EventSource.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+EventSource.prototype.addEventListener = function(type, listener, opt_options)
+    {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-EventSource.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+/** @override */
+EventSource.prototype.removeEventListener = function(type, listener, opt_options)
+    {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 EventSource.prototype.dispatchEvent = function(evt) {};
 
 /**

--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -483,26 +483,15 @@ FileError.prototype.code;
  */
 function FileReader() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-FileReader.prototype.addEventListener = function(type, listener, opt_useCapture)
+/** @override */
+FileReader.prototype.addEventListener = function(type, listener, opt_options)
     {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-FileReader.prototype.removeEventListener = function(type, listener,
-    opt_useCapture) {};
+/** @override */
+FileReader.prototype.removeEventListener = function(type, listener, opt_options)
+	{};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 FileReader.prototype.dispatchEvent = function(evt) {};
 
 /**

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -870,26 +870,15 @@ Document.prototype.head;
  */
 function DOMApplicationCache() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 DOMApplicationCache.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 DOMApplicationCache.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 DOMApplicationCache.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -1023,26 +1012,15 @@ function importScripts(var_args) {}
  */
 function WebWorker() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 WebWorker.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 WebWorker.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 WebWorker.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -1078,26 +1056,15 @@ WebWorker.prototype.onerror;
  */
 function Worker(opt_arg0) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 Worker.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 Worker.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 Worker.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -1145,26 +1112,15 @@ Worker.prototype.onerror;
  */
 function SharedWorker(scriptURL, opt_name) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 SharedWorker.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 SharedWorker.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 SharedWorker.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -1789,23 +1745,14 @@ TextTrack.prototype.cues;
  */
 TextTrack.prototype.mode;
 
-/**
- * @override
- * @return {undefined}
- */
+/** @override */
 TextTrack.prototype.addEventListener = function(type, listener, useCapture) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 TextTrack.prototype.dispatchEvent = function(evt) {};
 
-/**
- * @override
- * @return {undefined}
- */
-TextTrack.prototype.removeEventListener = function(type, listener, useCapture)
+/** @override */
+TextTrack.prototype.removeEventListener = function(type, listener, opt_options)
     {};
 
 
@@ -1977,26 +1924,15 @@ MessageChannel.prototype.port2;
  */
 function MessagePort() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 MessagePort.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 MessagePort.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 MessagePort.prototype.dispatchEvent = function(evt) {};
 
 
@@ -2129,14 +2065,14 @@ BroadcastChannel.prototype.close;
 
 /** @override */
 BroadcastChannel.prototype.addEventListener = function(
-    type, listener, useCapture) {};
+    type, listener, opt_options) {};
 
 /** @override */
 BroadcastChannel.prototype.dispatchEvent = function(evt) {};
 
 /** @override */
 BroadcastChannel.prototype.removeEventListener = function(
-    type, listener, useCapture) {};
+    type, listener, opt_options) {};
 
 /**
  * An EventHandler property that specifies the function to execute when a
@@ -2481,26 +2417,15 @@ WebSocket.CLOSING = 2;
  */
 WebSocket.CLOSED = 3;
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 WebSocket.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 WebSocket.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 WebSocket.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -2787,26 +2712,15 @@ XMLHttpRequest.prototype.mozResponseArrayBuffer;
  */
 function XMLHttpRequestEventTarget() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 XMLHttpRequestEventTarget.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 XMLHttpRequestEventTarget.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 XMLHttpRequestEventTarget.prototype.dispatchEvent = function(evt) {};
 
 /**

--- a/externs/browser/mediasource.js
+++ b/externs/browser/mediasource.js
@@ -27,26 +27,15 @@
  */
 function MediaSource() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 MediaSource.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 MediaSource.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 MediaSource.prototype.dispatchEvent = function(evt) {};
 
 /** @type {Array<SourceBuffer>} */
@@ -105,26 +94,15 @@ MediaSource.isTypeSupported = function(type) {};
  */
 function SourceBuffer() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 SourceBuffer.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 SourceBuffer.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 SourceBuffer.prototype.dispatchEvent = function(evt) {};
 
 /** @type {string} */

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -117,24 +117,13 @@ DOMImplementation.prototype.hasFeature = function(feature, version) {};
  */
 function Node() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-Node.prototype.addEventListener = function(type, listener, opt_useCapture) {};
+/** @override */
+Node.prototype.addEventListener = function(type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-Node.prototype.removeEventListener = function(type, listener, opt_useCapture) {};
+/** @override */
+Node.prototype.removeEventListener = function(type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 Node.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -844,25 +833,14 @@ ProcessingInstruction.prototype.target;
 function Window() {}
 Window.prototype.Window;
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-Window.prototype.addEventListener = function(type, listener, opt_useCapture) {};
+/** @override */
+Window.prototype.addEventListener = function(type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
-Window.prototype.removeEventListener = function(type, listener, opt_useCapture)
+/** @override */
+Window.prototype.removeEventListener = function(type, listener, opt_options)
     {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 Window.prototype.dispatchEvent = function(evt) {};
 
 /** @type {?function (Event)} */ Window.prototype.onabort;

--- a/externs/browser/w3c_event.js
+++ b/externs/browser/w3c_event.js
@@ -26,6 +26,7 @@
 
 /**
  * @interface
+ * @see https://dom.spec.whatwg.org/#interface-eventtarget
  */
 function EventTarget() {}
 
@@ -35,24 +36,27 @@ function EventTarget() {}
  *
  * @param {string} type
  * @param {EventListener|function(!Event):(boolean|undefined)} listener
- * @param {boolean} useCapture
+ * @param {(boolean|!AddEventListenerOptions)=} opt_options
  * @return {undefined}
+ * @see https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener
  */
-EventTarget.prototype.addEventListener = function(type, listener, useCapture)
+EventTarget.prototype.addEventListener = function(type, listener, opt_options)
     {};
 
 /**
  * @param {string} type
  * @param {EventListener|function(!Event):(boolean|undefined)} listener
- * @param {boolean} useCapture
+ * @param {(boolean|!EventListenerOptions)=} opt_options
  * @return {undefined}
+ * @see https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener
  */
-EventTarget.prototype.removeEventListener = function(type, listener, useCapture)
+EventTarget.prototype.removeEventListener = function(type, listener, opt_options)
     {};
 
 /**
  * @param {!Event} evt
  * @return {boolean}
+ * @see https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent
  */
 EventTarget.prototype.dispatchEvent = function(evt) {};
 

--- a/externs/browser/w3c_indexeddb.js
+++ b/externs/browser/w3c_indexeddb.js
@@ -235,26 +235,15 @@ webkitIDBDatabaseException.prototype.message;
  */
 function IDBRequest() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 IDBRequest.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 IDBRequest.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 IDBRequest.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -420,26 +409,15 @@ IDBDatabase.prototype.onerror = function() {};
  */
 IDBDatabase.prototype.onversionchange = function() {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 IDBDatabase.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 IDBDatabase.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 IDBDatabase.prototype.dispatchEvent = function(evt) {};
 
 /**

--- a/externs/browser/w3c_permissions.js
+++ b/externs/browser/w3c_permissions.js
@@ -78,27 +78,17 @@ PermissionStatus.prototype.status;
 /** @type {?function(!Event)} */
 PermissionStatus.prototype.onchange;
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 PermissionStatus.prototype.addEventListener = function(type,
                                                        listener,
-                                                       opt_useCapture) {};
+                                                       opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 PermissionStatus.prototype.removeEventListener = function(type,
                                                           listener,
-                                                          opt_useCapture) {};
-/**
- * @override
- * @return {boolean}
- */
+                                                          opt_options) {};
+
+/** @override */
 PermissionStatus.prototype.dispatchEvent = function(evt) {};
 
 

--- a/externs/browser/w3c_rtc.js
+++ b/externs/browser/w3c_rtc.js
@@ -162,26 +162,15 @@ MediaStreamTrackEvent.prototype.track;
  */
 function MediaStream(streamOrTracks) {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 MediaStream.prototype.addEventListener = function(type, listener,
-    opt_useCapture) {};
+    opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 MediaStream.prototype.removeEventListener = function(type, listener,
-    opt_useCapture) {};
+    opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 MediaStream.prototype.dispatchEvent = function(evt) {};
 
 /**
@@ -986,26 +975,15 @@ function RTCPeerConnection(configuration, constraints) {}
  */
 RTCPeerConnection.generateCertificate = function (keygenAlgorithm) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 RTCPeerConnection.prototype.addEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 RTCPeerConnection.prototype.removeEventListener = function(
-    type, listener, opt_useCapture) {};
+    type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 RTCPeerConnection.prototype.dispatchEvent = function(evt) {};
 
 

--- a/externs/browser/w3c_xml.js
+++ b/externs/browser/w3c_xml.js
@@ -296,26 +296,15 @@ XPathNamespace.XPATH_NAMESPACE_NODE = 13;
  */
 function XMLHttpRequest() {}
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 XMLHttpRequest.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 XMLHttpRequest.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 XMLHttpRequest.prototype.dispatchEvent = function(evt) {};
 
 /**

--- a/externs/browser/webkit_notifications.js
+++ b/externs/browser/webkit_notifications.js
@@ -63,26 +63,15 @@ Notification.permission;
  */
 Notification.requestPermission = function(opt_callback) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 Notification.prototype.addEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @param {boolean=} opt_useCapture
- * @override
- * @return {undefined}
- */
+/** @override */
 Notification.prototype.removeEventListener =
-    function(type, listener, opt_useCapture) {};
+    function(type, listener, opt_options) {};
 
-/**
- * @override
- * @return {boolean}
- */
+/** @override */
 Notification.prototype.dispatchEvent = function(evt) {};
 
 /**


### PR DESCRIPTION
`EventTarget` is currently defined according to [DOM Level 2 spec](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget) and this is causing some problems:

1) You cannot pass options object when creating event listeners which is needed if you want to create passive or one time event listeners.

``` javascript
window.addEventListener('click', function() {}, { capture:false, passive:true, once:true });
```

```
JSC_TYPE_MISMATCH: actual parameter 3 of Window.prototype.addEventListener does not match formal parameter
found   : {
  capture: boolean,
  once: boolean,
  passive: boolean
}
required: (boolean|undefined) at line 1 character 48
window.addEventListener('click', function() {}, { capture:false, passive:true...
                                                ^
```

2) All 3 arguments are required on interfaces which extend `EventTarget` but do not override its methods. For example `WorkerGlobalScope`:

``` javascript
/** @type {!WorkerGlobalScope} */
var x;
x.addEventListener('click', function() {});
```

```
JSC_WRONG_ARGUMENT_COUNT: Function EventTarget.addEventListener: called with 2 argument(s). Function requires at least 3 argument(s) and no more than 3 argument(s). at line 3 character 0
x.addEventListener('click', function() {});
^
```

This PR updates `EventTarget` according to [the latest spec](https://dom.spec.whatwg.org/#interface-eventtarget).
