### PR TITLE
ServiceWorkerRegistration.update returns a Promise

### DIFF
--- a/externs/browser/w3c_serviceworker.js
+++ b/externs/browser/w3c_serviceworker.js
@@ -156,9 +156,7 @@ ServiceWorkerRegistration.prototype.unregister = function() {};
 /** @type {?function(!Event)} */
 ServiceWorkerRegistration.prototype.onupdatefound;
 
-/**
- * @type {function()}
- */
+/** @return {!Promise<void>} */
 ServiceWorkerRegistration.prototype.update = function() {};
 
 /**


### PR DESCRIPTION
[MDN says](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/update):
[1] Starting with Chrome 46, update() returns a promise that resolves with 'undefined' if the operation completed successfully or there was no update, and rejects if update failed. If the new worker ran but installation failed, the promise still resolves. Formerly, it raised an exception.

It is also updated [in the latest specification](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-obj).
