### PR TITLE
Fix ResponseInit in Fetch API

### DIFF
--- a/externs/browser/fetchapi.js
+++ b/externs/browser/fetchapi.js
@@ -290,10 +290,11 @@ Response.prototype.clone = function() {};
 
 /**
  * @typedef {{
- *   status : number,
- *   statusText: string,
- *   headers: !HeadersInit
+ *   status : (undefined|number),
+ *   statusText: (undefined|string),
+ *   headers: (undefined|!HeadersInit)
  * }}
+ * @see https://fetch.spec.whatwg.org/#responseinit
  */
 var ResponseInit;
 


### PR DESCRIPTION
As you can see [here](https://fetch.spec.whatwg.org/#responseinit) all ResponseInit properties are optional