### PR TITLE
Allow applying input source maps to the generated source map.

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -382,6 +382,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     options.sourceMapDetailLevel = config.sourceMapDetailLevel;
     options.sourceMapFormat = config.sourceMapFormat;
     options.sourceMapLocationMappings = config.sourceMapLocationMappings;
+    options.applyInputSourceMaps = config.applyInputSourceMaps;
 
     ImmutableMap.Builder<String, SourceMapInput> inputSourceMaps
         = new ImmutableMap.Builder<>();
@@ -1044,7 +1045,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
           String sourceMapPath = jsonFile.getPath() + ".map";
           SourceFile sourceMap = SourceFile.fromCode(sourceMapPath,
               jsonFile.getSourceMap());
-          inputSourceMaps.put(sourceMapPath, new SourceMapInput(sourceMap));
+          inputSourceMaps.put(jsonFile.getPath(), new SourceMapInput(sourceMap));
           foundJsonInputSourceMap = true;
         }
       }
@@ -2242,6 +2243,17 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
         List<SourceMap.LocationMapping> locationMappings) {
 
       this.sourceMapLocationMappings = ImmutableList.copyOf(locationMappings);
+      return this;
+    }
+
+    private boolean applyInputSourceMaps = false;
+
+    /**
+     * Whether to apply input source maps to the output, i.e. map back to original inputs from
+     * input files that have source maps applied to them.
+     */
+    public CommandLineConfig setApplyInputSourceMaps(boolean applyInputSourceMaps) {
+      this.applyInputSourceMaps = applyInputSourceMaps;
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -303,6 +303,13 @@ public class CommandLineRunner extends
         "(i.e. input-file-path|input-source-map)")
     private List<String> sourceMapInputs = new ArrayList<>();
 
+    @Option(name = "--apply_input_source_maps",
+        handler = BooleanOptionHandler.class,
+        hidden = true,
+        usage = "Whether to apply input source maps to the output source map, " +
+        "i.e. have the result map back to original inputs")
+    private boolean applyInputSourceMaps = true;
+
     // Used to define the flag, values are stored by the handler.
     @SuppressWarnings("unused")
     @Option(
@@ -1273,6 +1280,7 @@ public class CommandLineRunner extends
     List<FlagEntry<JsSourceType>> mixedSources = null;
     List<LocationMapping> mappings = null;
     ImmutableMap<String, String> sourceMapInputs = null;
+    boolean applyInputSourceMaps = false;
     try {
       flags.parse(processedArgs);
 
@@ -1285,6 +1293,7 @@ public class CommandLineRunner extends
       mixedSources = flags.getMixedJsSources();
       mappings = flags.getSourceMapLocationMappings();
       sourceMapInputs = flags.getSourceMapInputs();
+      applyInputSourceMaps = flags.applyInputSourceMaps;
     } catch (CmdLineException e) {
       reportError(e.getMessage());
     } catch (IOException ioErr) {
@@ -1419,6 +1428,7 @@ public class CommandLineRunner extends
           .setSourceMapFormat(flags.sourceMapFormat)
           .setSourceMapLocationMappings(mappings)
           .setSourceMapInputFiles(sourceMapInputs)
+          .setApplyInputSourceMaps(applyInputSourceMaps)
           .setWarningGuards(Flags.guardLevels)
           .setDefine(flags.define)
           .setCharset(flags.charset)

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -80,7 +80,7 @@ import java.util.regex.Matcher;
  * window, document.
  *
  */
-public class Compiler extends AbstractCompiler implements ErrorHandler {
+public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFileMapping {
   static final String SINGLETON_MODULE_NAME = "$singleton$";
 
   static final DiagnosticType MODULE_DEPENDENCY_ERROR =
@@ -487,6 +487,9 @@ public class Compiler extends AbstractCompiler implements ErrorHandler {
     if (options.sourceMapOutputPath != null) {
       sourceMap = options.sourceMapFormat.getInstance();
       sourceMap.setPrefixMappings(options.sourceMapLocationMappings);
+      if (options.applyInputSourceMaps) {
+        sourceMap.setSourceFileMapping(this);
+      }
     }
   }
 

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -945,6 +945,12 @@ public class CompilerOptions {
   public SourceMap.Format sourceMapFormat =
       SourceMap.Format.DEFAULT;
 
+  /**
+   * Whether to apply input source maps to the output, i.e. map back to original inputs from
+   * input files that have source maps applied to them.
+   */
+  public boolean applyInputSourceMaps = false;
+
   public List<SourceMap.LocationMapping> sourceMapLocationMappings =
       Collections.emptyList();
 

--- a/src/com/google/javascript/jscomp/SourceFileMapping.java
+++ b/src/com/google/javascript/jscomp/SourceFileMapping.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp;
+
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
+import javax.annotation.Nullable;
+
+/**
+ * A SourceFileMapping maps a source file, line, and column into an {@link OriginalMapping}.
+ *
+ * @see com.google.debugging.sourcemap.SourceMapping
+ */
+public interface SourceFileMapping {
+  /**
+   * Returns the original mapping for the file name, line number and column position found
+   * in the source map. Returns {@code null} if none is found.
+   *
+   * @param lineNo The line number, 1-based.
+   * @param columnNo The column index, 1-based.
+   */
+  @Nullable
+  OriginalMapping getSourceMapping(String fileName, int lineNo, int columnNo);
+}

--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -99,6 +99,7 @@ public final class CompileTask
   private String sourceMapFormat;
   private File sourceMapOutputFile;
   private String sourceMapLocationMapping;
+  private boolean applyInputSourceMaps;
 
   public CompileTask() {
     this.languageIn = CompilerOptions.LanguageMode.ECMASCRIPT6;
@@ -486,6 +487,8 @@ public final class CompileTask
       LocationMapping lm = new LocationMapping(tokens[0], tokens[1]);
       options.setSourceMapLocationMappings(Arrays.asList(lm));
     }
+
+    options.applyInputSourceMaps = applyInputSourceMaps;
 
     if (sourceMapOutputFile != null) {
       File parentFile = sourceMapOutputFile.getParentFile();

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1920,6 +1920,49 @@ public final class CommandLineRunnerTest extends TestCase {
         + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
   }
 
+  public void testJsonStreamSourceMap() {
+    String inputSourceMap = "{\n" + 
+        "\"version\":3,\n" + 
+        "\"file\":\"one.out.js\",\n" + 
+        "\"lineCount\":1,\n" + 
+        "\"mappings\":\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+            + "OAAAF,IAAA,CAAYC,CAAZ,CADc,CAGhBD,GAAA,CAAI,QAAJ;\",\n" + 
+        "\"sources\":[\"one.js\"],\n" + 
+        "\"names\":[\"log\",\"a\",\"console\"]\n" + 
+        "}";
+    inputSourceMap = inputSourceMap.replace("\"", "\\\"");
+    String inputString = "[{"
+        + "\"src\": \"function log(a){console.log(a)}log(\\\"one.js\\\");\", "
+        + "\"path\":\"one.out.js\", "
+        + "\"sourceMap\": \"" + inputSourceMap + "\" }]";
+    args.add("--json_streams=BOTH");
+    args.add("--js_output_file=bar.js");
+    args.add("--apply_input_source_maps");
+
+    CommandLineRunner runner = new CommandLineRunner(
+        args.toArray(new String[]{}),
+        new ByteArrayInputStream(inputString.getBytes()),
+        new PrintStream(outReader),
+        new PrintStream(errReader));
+
+    lastCompiler = runner.getCompiler();
+    try {
+      runner.doRun();
+    } catch (IOException e) {
+      e.printStackTrace();
+      fail("Unexpected exception " + e);
+    }
+    String output = new String(outReader.toByteArray(), UTF_8);
+    assertThat(output).isEqualTo("[{"
+        + "\"src\":\"function log(a){console.log(a)}log(\\\"one.js\\\");\\n\","
+        + "\"path\":\"bar.js\","
+        + "\"source_map\":\"{\\n\\\"version\\\":3,\\n\\\"file\\\":\\\"bar.js\\\",\\n"
+        + "\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+        + "OAAAF,IAAA,CAAYC,CAAZ,CADc,CAGhBD,GAAA,CAAI,QAAJ;\\\",\\n"
+        + "\\\"sources\\\":[\\\"one.js\\\"],\\n\\\"names\\\":[\\\"log\\\",\\\"a\\\","
+        + "\\\"console\\\"]\\n}\\n\"}]");
+  }
+
   public void testOutputModuleNaming() {
     String inputString = "[{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
     args.add("--json_streams=BOTH");


### PR DESCRIPTION
This allows users to easily map from generated source that's an
input to the compiler back into their original source files.

E.g. when compiling TypeScript, users would have:
    input.ts -(a)-> input.js -(b)-> compiled.js

Where (a) is the TypeScript compilation operation, and (b) is Closure
Compiler. With this option set, the source map generated in (a) is
applied to the operation (b), with the final source map mapping back
into `input.ts` from locations in `compiled.js`.

This also introduces an interface `SourceFileMapping` to avoid
increasing the coupling and responsibility of the Compiler object.