### PR TITLE
Update Service Worker events

### DIFF
--- a/externs/browser/w3c_serviceworker.js
+++ b/externs/browser/w3c_serviceworker.js
@@ -17,6 +17,7 @@
  * @fileoverview Externs for service worker.
  *
  * @see http://www.w3.org/TR/service-workers/
+ * @see https://w3c.github.io/push-api/
  * @externs
  */
 
@@ -192,16 +193,34 @@ PushMessageData.prototype.text = function() {};
 
 
 /**
+ * @typedef {(!BufferSource|string)}
+ * @see https://w3c.github.io/push-api/#idl-def-PushMessageDataInit
+ */
+var PushMessageDataInit;
+
+
+/**
  * @see http://www.w3.org/TR/push-api/#idl-def-PushEvent
  * @constructor
  * @param {string} type
- * @param {!ExtendableEventInit=} opt_eventInitDict
+ * @param {!PushEventInit=} opt_eventInitDict
  * @extends {ExtendableEvent}
  */
 function PushEvent(type, opt_eventInitDict) {}
 
 /** @type {?PushMessageData} */
 PushEvent.prototype.data;
+
+
+/**
+ * @record
+ * @extends {ExtendableEventInit}
+ * @see https://w3c.github.io/push-api/#idl-def-PushEvent
+ */
+function PushEventInit() {};
+
+/** @type {(undefined|!PushMessageDataInit)} */
+PushEventInit.prototype.data;
 
 
 /**
@@ -336,7 +355,7 @@ ServiceWorkerGlobalScope.prototype.skipWaiting = function() {};
 /** @type {!Console} */
 ServiceWorkerGlobalScope.prototype.console;
 
-/** @type {?function(!InstallEvent)} */
+/** @type {?function(!ExtendableEvent)} */
 ServiceWorkerGlobalScope.prototype.oninstall;
 
 /** @type {?function(!ExtendableEvent)} */
@@ -357,11 +376,25 @@ ServiceWorkerGlobalScope.prototype.onbeforeevicted;
  */
 ServiceWorkerGlobalScope.prototype.onevicted;
 
-/** @type {?function(!MessageEvent)} */
+/** @type {?function(!ExtendableMessageEvent)} */
 ServiceWorkerGlobalScope.prototype.onmessage;
 
 /** @type {!IDBFactory|undefined} */
 ServiceWorkerGlobalScope.prototype.indexedDB;
+
+/**
+ * Extended by Push API
+ * @type {?function(!PushEvent)}
+ * @see https://w3c.github.io/push-api/#widl-ServiceWorkerGlobalScope-onpush
+ */
+ServiceWorkerGlobalScope.prototype.onpush;
+
+/**
+ * Extended by Push API
+ * @type {?function(!ExtendableEvent)}
+ * @see https://w3c.github.io/push-api/#widl-ServiceWorkerGlobalScope-onpushsubscriptionchange
+ */
+ServiceWorkerGlobalScope.prototype.onpushsubscriptionchange;
 
 /**
  * While not strictly correct, this should be effectively correct. Notification
@@ -586,12 +619,13 @@ function ExtendableEvent(type, opt_eventInitDict) {}
 ExtendableEvent.prototype.waitUntil = function(f) {};
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined)
- * }}
+ * Defined for the forward compatibility across the derived events
+ * 
+ * @record
+ * @extends {EventInit}
+ * @see https://www.w3.org/TR/service-workers/#extendable-event-init-dictionary
  */
-var ExtendableEventInit;
+function ExtendableEventInit() {};
 
 /**
  * @see http://www.w3.org/TR/service-workers/#install-event-interface
@@ -599,6 +633,7 @@ var ExtendableEventInit;
  * @param {string} type
  * @param {InstallEventInit=} opt_eventInitDict
  * @extends {ExtendableEvent}
+ * @deprecated Use ExtendableEvent
  */
 function InstallEvent(type, opt_eventInitDict) {}
 
@@ -611,6 +646,7 @@ ExtendableEvent.prototype.activeWorker;
  *   cancelable: (boolean|undefined),
  *   activeWorker: (!ServiceWorker|undefined)
  * }}
+ * @deprecated Use ExtendableEventInit
  */
 var InstallEventInit;
 
@@ -663,17 +699,22 @@ FetchEvent.prototype.forwardTo = function(url) {};
  */
 FetchEvent.prototype.default = function() {};
 
+
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   request: (!Request|undefined),
- *   preloadResponse: (!Promise<Response>),
- *   client: (!ServiceWorkerClient|undefined),
- *   isReload: (!boolean|undefined)
- * }}
+ * @record
+ * @extends {ExtendableEventInit}
+ * @see https://www.w3.org/TR/service-workers/#fetch-event-init-dictionary
  */
-var FetchEventInit;
+function FetchEventInit() {};
+
+/** @type {(undefined|!Request)} */
+FetchEventInit.prototype.request;
+
+/** @type {(undefined|!ServiceWorkerClient)} */
+FetchEventInit.prototype.client;
+
+/** @type {(undefined|boolean)} */
+FetchEventInit.prototype.isReload;
 
 
 /**


### PR DESCRIPTION
1) `InstallEvent` was dropped because it has been replaced by `ExtendableEvent`.
MDN says:

> As of May 2015, the install event is an instance of ExtendableEvent rather than a child of it.

I've tested it in the latest Chrome and it is using the `ExtendableEvent`.

2) `ServiceWorkerGlobalScope.prototype.onmessage` handler is fixed so a passed event may call the `ExtendableEvent.prototype.waitUntil` method.

3) Fixed `PushEvent` constructor.

4) Added `onpush` and `onpushsubscriptionchange` from [Push API spec](https://w3c.github.io/push-api/).
