### PR TITLE
Fixed a broken reference link

### DIFF
--- a/externs/browser/fetchapi.js
+++ b/externs/browser/fetchapi.js
@@ -28,7 +28,7 @@
 
 /**
  * @enum {string}
- * @see https://fetch.spec.whatwg.org/#referrerpolicy
+ * @see https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy
  */
 var ReferrerPolicy = {
   NONE: '',


### PR DESCRIPTION
ReferrerPolicy was probably recently moved to the W3C repository.

By the way, I do not see it exposed on Window in Chrome. Why is this in the externs? Does Firefox expose it? Is it specified to be exposed at all?