### PR TITLE
Parse //# sourceMappingURL= comments that contain inline source maps.

### DIFF
--- a/src/com/google/JsComp.gwt.xml
+++ b/src/com/google/JsComp.gwt.xml
@@ -16,6 +16,7 @@
 <module rename-to="jscomp">
   <inherits name="com.google.common.base.Base"/>
   <inherits name="com.google.common.collect.Collect"/>
+  <inherits name="com.google.common.io.Io"/>
   <inherits name="com.google.gwt.json.JSON"/>
   <source path="debugging/sourcemap"/>
   <source path="javascript/jscomp" excludes=".svn,.git,**/ant/**,**/refactoring/**,**/webservice/**,**/testing/**,**/linker/**"/>

--- a/src/com/google/debugging/sourcemap/Base64.java
+++ b/src/com/google/debugging/sourcemap/Base64.java
@@ -16,6 +16,7 @@
 
 package com.google.debugging.sourcemap;
 
+import com.google.common.io.BaseEncoding;
 import java.util.Arrays;
 
 /**
@@ -64,6 +65,14 @@ public final class Base64 {
     int result = BASE64_DECODE_MAP[c];
     assert (result != -1) : "invalid char";
     return BASE64_DECODE_MAP[c];
+  }
+
+  /**
+   * @param str A base64 encoded String.
+   * @return The decoded byte array.
+   */
+  public static byte[] fromBase64(String str) {
+    return BaseEncoding.base64Url().decode(str);
   }
 
   /**

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -382,6 +382,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     options.sourceMapDetailLevel = config.sourceMapDetailLevel;
     options.sourceMapFormat = config.sourceMapFormat;
     options.sourceMapLocationMappings = config.sourceMapLocationMappings;
+    options.parseInlineSourceMaps = config.parseInlineSourceMaps;
     options.applyInputSourceMaps = config.applyInputSourceMaps;
 
     ImmutableMap.Builder<String, SourceMapInput> inputSourceMaps
@@ -2068,6 +2069,14 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       return this;
     }
 
+    private boolean parseInlineSourceMaps = false;
+
+    public CommandLineConfig setParseInlineSourceMaps(
+        boolean parseInlineSourceMaps) {
+      this.parseInlineSourceMaps = parseInlineSourceMaps;
+      return this;
+    }
+    
     private String variableMapInputFile = "";
 
     /**

--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -470,6 +470,12 @@ public abstract class AbstractCompiler implements SourceExcerptProvider {
    */
   abstract Set<String> getExternProperties();
 
+  /**
+   * Adds a {@link SourceMapInput} for the given {@code sourceFileName}, to be used for error
+   * reporting and source map combining.
+   */
+  public abstract void addInputSourceMap(String name, SourceMapInput sourceMap);
+
   abstract void addComments(String filename, List<Comment> comments);
 
   /**

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -303,6 +303,12 @@ public class CommandLineRunner extends
         + "(i.e. input-file-path|input-source-map)")
     private List<String> sourceMapInputs = new ArrayList<>();
 
+    @Option(name = "--parse_inline_source_maps",
+        handler = BooleanOptionHandler.class,
+        hidden = true,
+        usage = "Parse inline source maps (//# sourceMappingURL=data:...)")
+    private Boolean parseInlineSourceMaps = true;
+
     @Option(name = "--apply_input_source_maps",
         handler = BooleanOptionHandler.class,
         hidden = true,
@@ -1280,6 +1286,7 @@ public class CommandLineRunner extends
     List<FlagEntry<JsSourceType>> mixedSources = null;
     List<LocationMapping> mappings = null;
     ImmutableMap<String, String> sourceMapInputs = null;
+    boolean parseInlineSourceMaps = false;
     boolean applyInputSourceMaps = false;
     try {
       flags.parse(processedArgs);
@@ -1293,6 +1300,7 @@ public class CommandLineRunner extends
       mixedSources = flags.getMixedJsSources();
       mappings = flags.getSourceMapLocationMappings();
       sourceMapInputs = flags.getSourceMapInputs();
+      parseInlineSourceMaps = flags.parseInlineSourceMaps;
       applyInputSourceMaps = flags.applyInputSourceMaps;
     } catch (CmdLineException e) {
       reportError(e.getMessage());
@@ -1428,6 +1436,7 @@ public class CommandLineRunner extends
           .setSourceMapFormat(flags.sourceMapFormat)
           .setSourceMapLocationMappings(mappings)
           .setSourceMapInputFiles(sourceMapInputs)
+          .setParseInlineSourceMaps(parseInlineSourceMaps)
           .setApplyInputSourceMaps(applyInputSourceMaps)
           .setWarningGuards(Flags.guardLevels)
           .setDefine(flags.define)

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -166,6 +166,10 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   private ConcurrentHashMap<String, SourceFile> sourceMapOriginalSources
       = new ConcurrentHashMap<>();
 
+  /** Configured {@link SourceMapInput}s, plus any source maps discovered in source files. */
+  private ConcurrentHashMap<String, SourceMapInput> inputSourceMaps
+      = new ConcurrentHashMap<>();
+
   // Map from filenames to lists of all the comments in each file.
   private Map<String, List<Comment>> commentsPerFile = new HashMap<>();
 
@@ -483,6 +487,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
    * Do any initialization that is dependent on the compiler options.
    */
   private void initBasedOnOptions() {
+    inputSourceMaps.putAll(options.inputSourceMaps);
     // Create the source map if necessary.
     if (options.sourceMapOutputPath != null) {
       sourceMap = options.sourceMapFormat.getInstance();
@@ -1721,6 +1726,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   @Override
   Node parseTestCode(String js) {
     initCompilerOptionsIfTesting();
+    initBasedOnOptions();
     CompilerInput input = new CompilerInput(
         SourceFile.fromCode("[testcode]", js));
     if (inputsById == null) {
@@ -2234,7 +2240,8 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
             options.canContinueAfterErrors()
                 ? Config.RunMode.KEEP_GOING
                 : Config.RunMode.STOP_AFTER_ERROR,
-            options.extraAnnotationNames);
+            options.extraAnnotationNames,
+            options.parseInlineSourceMaps);
     return config;
   }
 
@@ -2357,9 +2364,17 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   }
 
   @Override
+  public void addInputSourceMap(String sourceFileName, SourceMapInput inputSourceMap) {
+    inputSourceMaps.put(sourceFileName, inputSourceMap);
+  }
+
+  @Override
   public OriginalMapping getSourceMapping(String sourceName, int lineNumber,
       int columnNumber) {
-    SourceMapInput sourceMap = options.inputSourceMaps.get(sourceName);
+    if (sourceName == null) {
+      return null;
+    }
+    SourceMapInput sourceMap = inputSourceMaps.get(sourceName);
     if (sourceMap == null) {
       return null;
     }

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -949,6 +949,11 @@ public class CompilerOptions {
       SourceMap.Format.DEFAULT;
 
   /**
+   * Whether to parse inline source maps.
+   */
+  boolean parseInlineSourceMaps = true;
+
+  /**
    * Whether to apply input source maps to the output, i.e. map back to original inputs from
    * input files that have source maps applied to them.
    */

--- a/src/com/google/javascript/jscomp/JsAst.java
+++ b/src/com/google/javascript/jscomp/JsAst.java
@@ -153,6 +153,12 @@ public class JsAst implements SourceAst {
       if (compiler.getOptions().preservesDetailedSourceInfo()) {
         compiler.addComments(sourceFile.getName(), result.comments);
       }
+      if (result.sourceMap != null) {
+        String sourceMapName = sourceFile.getName() + ".inline.map";
+        SourceMapInput sourceMapInput =
+            new SourceMapInput(SourceFile.fromCode(sourceMapName, result.sourceMap));
+        compiler.addInputSourceMap(sourceFile.getName(), sourceMapInput);
+      }
     } catch (IOException e) {
       compiler.report(
           JSError.make(AbstractCompiler.READ_ERROR, sourceFile.getName()));

--- a/src/com/google/javascript/jscomp/gwt/client/JsfileParser.java
+++ b/src/com/google/javascript/jscomp/gwt/client/JsfileParser.java
@@ -217,7 +217,8 @@ public class JsfileParser implements EntryPoint {
             Config.LanguageMode.ECMASCRIPT6,
             Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE,
             Config.RunMode.KEEP_GOING,
-            /* extraAnnotationNames */ ImmutableSet.<String>of());
+            /* extraAnnotationNames */ ImmutableSet.<String>of(),
+            /* parseInlineSourceMaps */ true);
 
     SourceFile source = SourceFile.fromCode(filename, code);
     FileInfo info = new FileInfo(errorReporter);

--- a/src/com/google/javascript/jscomp/parsing/Config.java
+++ b/src/com/google/javascript/jscomp/parsing/Config.java
@@ -114,13 +114,19 @@ public final class Config {
    */
   final LanguageMode languageMode;
 
+  /**
+   * Parse inline source maps (//# sourceMappingURL=data:...).
+   */
+  final boolean parseInlineSourceMaps;
+
   Config(Set<String> annotationWhitelist, Set<String> suppressionNames, LanguageMode languageMode) {
     this(
         annotationWhitelist,
         JsDocParsing.TYPES_ONLY,
         RunMode.STOP_AFTER_ERROR,
         suppressionNames,
-        languageMode);
+        languageMode,
+        false);
   }
 
   Config(
@@ -128,7 +134,9 @@ public final class Config {
       JsDocParsing parseJsDocDocumentation,
       RunMode keepGoing,
       Set<String> suppressionNames,
-      LanguageMode languageMode) {
+      LanguageMode languageMode,
+      boolean parseInlineSourceMaps) {
+    this.parseInlineSourceMaps = parseInlineSourceMaps;
     this.annotationNames = buildAnnotationNames(annotationWhitelist);
     this.parseJsDocDocumentation = parseJsDocDocumentation;
     this.keepGoing = keepGoing;

--- a/src/com/google/javascript/jscomp/parsing/ParserRunner.java
+++ b/src/com/google/javascript/jscomp/parsing/ParserRunner.java
@@ -19,6 +19,7 @@ package com.google.javascript.jscomp.parsing;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.SourceMapInput;
 import com.google.javascript.jscomp.parsing.Config.JsDocParsing;
 import com.google.javascript.jscomp.parsing.Config.LanguageMode;
 import com.google.javascript.jscomp.parsing.Config.RunMode;
@@ -38,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** parser runner */
 public final class ParserRunner {
@@ -59,14 +61,16 @@ public final class ParserRunner {
         languageMode,
         JsDocParsing.TYPES_ONLY,
         RunMode.STOP_AFTER_ERROR,
-        extraAnnotationNames);
+        extraAnnotationNames,
+        true);
   }
 
   public static Config createConfig(
       LanguageMode languageMode,
       JsDocParsing jsdocParsingMode,
       RunMode runMode,
-      Set<String> extraAnnotationNames) {
+      Set<String> extraAnnotationNames,
+      boolean parseInlineSourceMaps) {
 
     initResourceConfig();
     Set<String> effectiveAnnotationNames;
@@ -81,7 +85,8 @@ public final class ParserRunner {
         jsdocParsingMode,
         runMode,
         suppressionNames,
-        languageMode);
+        languageMode,
+        parseInlineSourceMaps);
   }
 
   public static Set<String> getReservedVars() {
@@ -133,7 +138,7 @@ public final class ParserRunner {
         comments = p.getComments();
       }
     }
-    return new ParseResult(root, comments, features);
+    return new ParseResult(root, comments, features, p.getInlineSourceMap());
   }
 
   // TODO(sdh): this is less useful if we end up needing the node for library version detection
@@ -212,11 +217,14 @@ public final class ParserRunner {
     public final Node ast;
     public final List<Comment> comments;
     public final FeatureSet features;
+    @Nullable
+    public final String sourceMap;
 
-    public ParseResult(Node ast, List<Comment> comments, FeatureSet features) {
+    public ParseResult(Node ast, List<Comment> comments, FeatureSet features, String sourceMap) {
       this.ast = ast;
       this.comments = comments;
       this.features = features;
+      this.sourceMap = sourceMap;
     }
   }
 }

--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -17,6 +17,7 @@
 package com.google.javascript.jscomp.parsing.parser;
 
 import com.google.common.collect.ImmutableList;
+import com.google.debugging.sourcemap.Base64;
 import com.google.javascript.jscomp.parsing.parser.FeatureSet.Feature;
 import com.google.javascript.jscomp.parsing.parser.trees.AmbientDeclarationTree;
 import com.google.javascript.jscomp.parsing.parser.trees.ArgumentListTree;
@@ -121,11 +122,14 @@ import com.google.javascript.jscomp.parsing.parser.util.LookaheadErrorReporter.P
 import com.google.javascript.jscomp.parsing.parser.util.SourcePosition;
 import com.google.javascript.jscomp.parsing.parser.util.SourceRange;
 import com.google.javascript.jscomp.parsing.parser.util.Timer;
-
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * Parses a javascript file.
@@ -170,16 +174,19 @@ public class Parser {
   private final Scanner scanner;
   private final ErrorReporter errorReporter;
   private final Config config;
+  private final boolean parseInlineSourceMaps;
   private final CommentRecorder commentRecorder = new CommentRecorder();
   private final ArrayDeque<Boolean> inGeneratorContext = new ArrayDeque<>();
   private FeatureSet features = FeatureSet.ES3;
   private SourcePosition lastSourcePosition;
+  @Nullable
+  private String inlineSourceMap;
 
-  public Parser(
-      Config config, ErrorReporter errorReporter,
-      SourceFile source, int offset, boolean initialGeneratorContext) {
+  public Parser(Config config, ErrorReporter errorReporter, SourceFile source, int offset,
+      boolean initialGeneratorContext, boolean parseInlineSourceMaps) {
     this.config = config;
     this.errorReporter = errorReporter;
+    this.parseInlineSourceMaps = parseInlineSourceMaps;
     this.scanner = new Scanner(errorReporter, commentRecorder, source, offset);
     this.inGeneratorContext.add(initialGeneratorContext);
     lastSourcePosition = scanner.getPosition();
@@ -188,7 +195,7 @@ public class Parser {
   public Parser(
       Config config, ErrorReporter errorReporter,
       SourceFile source, int offset) {
-    this(config, errorReporter, source, offset, false);
+    this(config, errorReporter, source, offset, false, true);
   }
 
   public Parser(Config config, ErrorReporter errorReporter, SourceFile source) {
@@ -240,12 +247,26 @@ public class Parser {
     }
   }
 
-  private static class CommentRecorder implements Scanner.CommentRecorder{
+  private static final Pattern SOURCE_MAPPING_URL_PATTERN = Pattern.compile("^//#\\s*sourceMappingURL=");
+  private static final String BASE64_URL_PREFIX = "data:application/json;base64,";
+
+  private class CommentRecorder implements Scanner.CommentRecorder {
     private ImmutableList.Builder<Comment> comments =
         ImmutableList.builder();
     @Override
     public void recordComment(
         Comment.Type type, SourceRange range, String value) {
+      if (parseInlineSourceMaps) {
+        Matcher matcher = SOURCE_MAPPING_URL_PATTERN.matcher(value);
+        if (matcher.find()) {
+          String url = value.substring(matcher.group(0).length());
+          if (url.startsWith(BASE64_URL_PREFIX)) {
+            byte[] data = Base64.fromBase64(url.substring(BASE64_URL_PREFIX.length()));
+            String source = new String(data, StandardCharsets.UTF_8);
+            inlineSourceMap = source;
+          }
+        }
+      }
       comments.add(new Comment(value, range, type));
     }
 
@@ -260,6 +281,15 @@ public class Parser {
 
   public FeatureSet getFeatures() {
     return features;
+  }
+
+  /**
+   * Returns the decoded JSON source of an inline source map comment if any was found, or
+   * {@code null} otherwise.
+   */
+  @Nullable
+  public String getInlineSourceMap() {
+    return inlineSourceMap;
   }
 
   // 14 Program
@@ -4028,7 +4058,8 @@ public class Parser {
         new LookaheadErrorReporter(),
         this.scanner.getFile(),
         this.scanner.getOffset(),
-        inGeneratorContext());
+        inGeneratorContext(),
+        true);
   }
 
   /**

--- a/test/com/google/javascript/jscomp/parsing/AttachJsdocsTest.java
+++ b/test/com/google/javascript/jscomp/parsing/AttachJsdocsTest.java
@@ -788,7 +788,8 @@ public final class AttachJsdocsTest extends BaseJSTypeTestCase {
             mode,
             Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE,
             Config.RunMode.KEEP_GOING,
-            null);
+            null,
+            true);
     Node script = ParserRunner.parse(
         new SimpleSourceFile("input", false),
         source,

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -4640,7 +4640,8 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
             JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE,
             RunMode.KEEP_GOING,
             extraSuppressions,
-            LanguageMode.ECMASCRIPT3);
+            LanguageMode.ECMASCRIPT3,
+            true);
 
     ParseResult result = ParserRunner.parse(
         new SimpleSourceFile("source", false), code, config, testErrorReporter);
@@ -4690,7 +4691,8 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
             parseDocumentation,
             RunMode.STOP_AFTER_ERROR,
             extraSuppressions,
-            LanguageMode.ECMASCRIPT3);
+            LanguageMode.ECMASCRIPT3,
+            true);
 
     StaticSourceFile file = new SimpleSourceFile("testcode", false);
 

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -22,6 +22,10 @@ import static com.google.javascript.jscomp.testing.NodeSubject.assertNode;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.debugging.sourcemap.SourceMapConsumerV3;
+import com.google.gson.JsonParser;
+import com.google.javascript.jscomp.SourceFile;
+import com.google.javascript.jscomp.SourceMapInput;
 import com.google.javascript.jscomp.parsing.Config.LanguageMode;
 import com.google.javascript.jscomp.parsing.ParserRunner.ParseResult;
 import com.google.javascript.jscomp.parsing.parser.FeatureSet;
@@ -3303,6 +3307,26 @@ public final class ParserTest extends BaseJSTypeTestCase {
     }
   }
 
+  public void testParseInlineSourceMap() {
+    String code = "var X = (function () {\n"
+        + "    function X(input) {\n" 
+        + "        this.y = input;\n" 
+        + "    }\n"
+        + "    return X;\n" 
+        + "}());\n"
+        + "console.log(new X(1));\n" 
+        + "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZm9vLmpz"
+        + "Iiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZm9vLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQU"
+        + "FBO0lBR0UsV0FBWSxLQUFhO1FBQ3ZCLElBQUksQ0FBQyxDQUFDLEdBQUcsS0FBSyxDQUFDO0lBQ2pCLENBQUM7"
+        + "SUFDSCxRQUFDO0FBQUQsQ0FBQyxBQU5ELElBTUM7QUFFRCxPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQy"
+        + "xDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMifQ==";
+    ParseResult result = doParse(code);
+    assertThat(result.sourceMap).named("inline source map").isNotNull();
+    SourceMapInput input = new SourceMapInput(SourceFile.fromCode("test.js.map", result.sourceMap));
+    SourceMapConsumerV3 sourceMap = input.getSourceMap();
+    assertThat(sourceMap.getOriginalSources()).containsExactly("foo.ts");
+  }
+
   private String getRequiresEs6Message(Feature feature) {
     return requiresLanguageModeMessage(LanguageMode.ECMASCRIPT6, feature);
   }
@@ -3358,6 +3382,10 @@ public final class ParserTest extends BaseJSTypeTestCase {
    * @return The parse tree.
    */
   private Node parseWarning(String string, String... warnings) {
+    return doParse(string, warnings).ast;
+  }
+
+  private ParserRunner.ParseResult doParse(String string, String... warnings) {
     TestErrorReporter testErrorReporter = new TestErrorReporter(null, warnings);
     StaticSourceFile file = new SimpleSourceFile("input", false);
     ParserRunner.ParseResult result = ParserRunner.parse(
@@ -3365,7 +3393,6 @@ public final class ParserTest extends BaseJSTypeTestCase {
         string,
         createConfig(),
         testErrorReporter);
-    Node script = result.ast;
 
     // check expected features if specified
     if (expectedFeatures != null) {
@@ -3375,8 +3402,7 @@ public final class ParserTest extends BaseJSTypeTestCase {
     // verifying that all warnings were seen
     testErrorReporter.assertHasEncounteredAllErrors();
     testErrorReporter.assertHasEncounteredAllWarnings();
-
-    return script;
+    return result;
   }
 
   /**
@@ -3393,7 +3419,8 @@ public final class ParserTest extends BaseJSTypeTestCase {
           mode,
           Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE,
           Config.RunMode.KEEP_GOING,
-          null);
+          null,
+          true);
     } else {
       return ParserRunner.createConfig(mode, null);
     }


### PR DESCRIPTION
Standalone source maps can already be specified using --source_map_input. This adds support for inline source maps using data URLs with base64 encoding. Inline source maps make it easier to preserve the source map / file association across build steps and file transfers.