### PR TITLE
Promises/A+ compilance test script and instructions

### DIFF
--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/README.md
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/README.md
@@ -1,0 +1,37 @@
+# Running the Promises/A+ Compliance Test Suite
+
+The closure-compiler Promises implementation used when transpiling & polyfilling
+ES6-level JavaScript code back to ES5 or ES3 has been tested against the
+Promises/A+ Compliance Test Suite. The code for these tests and general
+instructions for running them may be found at
+https://github.com/promises-aplus/promises-tests.
+
+Compliance with the Promises/A+ spec is sufficent for normal use of promises
+and for the closure-compiler to use them internally to implement async
+functions. However, the [ECMAScript spec](https://tc39.github.io/ecma262/)
+defines additional behavior primarily revolving around making subclasses of
+Promise behave in predictable ways. The closure-compiler implementation of
+Promises does not provide this behavior, so subclassing of Promise is
+discouraged if you intend to have your code work in environments that do not
+support native-JavaScript Promises.
+
+This directory contains files that were used in order to run the Promise/A+
+compliance tests.
+
+
+*   run-tests.sh
+
+
+    Run this with no arguments to execute the tests. It requires:
+
+    *   The compiler must be built first.
+    *   npm must be installed
+
+*   test-adapter.js
+
+    tells the tests how to get Promise objects for testing.
+    run-tests.sh will compile this file.
+
+*   test-externs.js
+
+    Needed for compiling test-adapter.js

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/run-tests.sh
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/run-tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+#
+# Copyright 2016 The Closure Compiler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+if ! type npm >/dev/null 2>&1; then
+    echo "npm must be installed to run these tests" >&2
+    exit 1
+fi
+
+if ! type java >/dev/null 2>&1; then
+    echo "java must be installed to run these tests" >&2
+    exit 1
+fi
+
+cd $(dirname $0)
+TEST_HOME=$(pwd)
+cd ../../../../../../../..
+JSCOMP_HOME=$(pwd)
+JSCOMP_TARGET=$JSCOMP_HOME/target
+JSCOMP_JAR=$JSCOMP_TARGET/closure-compiler-1.0-SNAPSHOT.jar
+
+if [[ ! -r $JSCOMP_JAR ]]; then
+    echo "You must build the compiler before running these tests" >&2
+    exit 1
+fi
+
+TEST_TARGET=$JSCOMP_TARGET/promise_aplus
+mkdir -p $TEST_TARGET
+cd $TEST_TARGET
+
+COMPILED_TEST_ADAPTER=test-adapter-compiled.js
+java -jar $JSCOMP_JAR \
+    --externs $TEST_HOME/test-externs.js \
+    --js $TEST_HOME/test-adapter.js \
+    --js_output_file $COMPILED_TEST_ADAPTER
+
+npm install promises-aplus-tests
+$(npm bin)/promises-aplus-tests $COMPILED_TEST_ADAPTER

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/test-adapter.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/test-adapter.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Defines methods to allow the Promises/A+ compliance tests to
+ * create Promises.
+ */
+// TODO(bradfordcsmith): This assignment is only needed until we start really
+// polyfilling Promises.
+Promise = $jscomp_Promise;
+exports.resolved = function(value) { return Promise.resolve(value); };
+exports.rejected = function(reason) { return Promise.reject(reason); };
+exports.deferred = function() {
+  var capability = {};
+  capability.promise = new Promise(function(resolve, reject) {
+    capability.resolve = resolve;
+    capability.reject = reject;
+  });
+  return capability;
+};

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/test-externs.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/promise_aplus/test-externs.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO(brad4d): This is only needed until we really start polyfilling.
+var $jscomp_Promise;


### PR DESCRIPTION
Now that polyfilling of Promises (#1826) is partially implemented, we can run the Promise/A+ conformance tests against them.
