### PR TITLE
Add missing ArrayBuffer.isView method in externs

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -306,6 +306,14 @@ ArrayBuffer.prototype.byteLength;
  */
 ArrayBuffer.prototype.slice = function(begin, opt_end) {};
 
+/**
+ * @param {*} arg
+ * @return {boolean}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView
+ */
+ArrayBuffer.isView = function(arg) {};
+
 
 /**
  * @constructor


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView
See http://www.ecma-international.org/ecma-262/6.0/#sec-arraybuffer.isview
