### PR TITLE
Enable source map composition by default in the open source command line runner

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -314,7 +314,7 @@ public class CommandLineRunner extends
         hidden = true,
         usage = "Whether to apply input source maps to the output source map, "
         + "i.e. have the result map back to original inputs")
-    private boolean applyInputSourceMaps = false;
+    private boolean applyInputSourceMaps = true;
 
     // Used to define the flag, values are stored by the handler.
     @SuppressWarnings("unused")


### PR DESCRIPTION
[As discussed in the external review](https://github.com/google/closure-compiler/pull/1971#issuecomment-241814093) the overwhelming expectation is that source maps are composed. With transpilation, frequently the intermediate states are never persisted to storage.

Currently, the [gulp plugin composes sourcemaps by default](https://github.com/ChadKillingsworth/closure-compiler-npm/blob/master/lib/gulp/index.js#L178-L192). With the changes provided by #1971, I will either need to do argument inspection (something I have avoided), maintain composition via JS (slow) or warn users of the change.