### PR TITLE
Add --create_externs_from_exports flag

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1425,7 +1425,10 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
 
     if (!exPath.contains(File.separator)) {
       File outputFile = new File(path);
-      exPath = outputFile.getParent() + File.separatorChar + exPath;
+      String parent = outputFile.getParent();
+      if (parent != null) {
+        exPath = parent + File.separatorChar + exPath;
+      }
     }
 
     return fileNameToOutputWriter2(exPath);

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -667,7 +667,12 @@ public class CommandLineRunner extends
     @Option(name = "--print_source_after_each_pass",
         hidden = true,
         usage = "Whether to iteratively print resulting JS source per pass.")
-        private boolean printSourceAfterEachPass = false;
+    private boolean printSourceAfterEachPass = false;
+
+    @Option(name = "--create_externs_from_exports",
+        usage = "Create an externs file from @export annotations, and store it in the specified "
+            + "output file.")
+    private String createExternsFromExports;
 
     @Argument
     private List<String> arguments = new ArrayList<>();
@@ -1621,6 +1626,8 @@ public class CommandLineRunner extends
     }
 
     options.setPrintSourceAfterEachPass(flags.printSourceAfterEachPass);
+
+    options.setExternExportsPath(flags.createExternsFromExports);
 
     return options;
   }

--- a/src/com/google/javascript/jscomp/ExternExportsPass.java
+++ b/src/com/google/javascript/jscomp/ExternExportsPass.java
@@ -43,9 +43,6 @@ import java.util.TreeSet;
 final class ExternExportsPass extends NodeTraversal.AbstractPostOrderCallback
     implements CompilerPass {
 
-  /** The exports found. */
-  private final List<Export> exports;
-
   /** A map of all assigns to their parent nodes. */
   private final Map<String, Node> definitionMap;
 
@@ -60,6 +57,9 @@ final class ExternExportsPass extends NodeTraversal.AbstractPostOrderCallback
 
   /** A list of exported paths. */
   private final Set<String> alreadyExportedPaths;
+
+  /** The exports found so far; reset between scripts. */
+  private List<Export> exports;
 
   /** A list of function names used to export symbols. */
   private List<String> exportSymbolFunctionNames;
@@ -437,23 +437,6 @@ final class ExternExportsPass extends NodeTraversal.AbstractPostOrderCallback
   @Override
   public void process(Node externs, Node root) {
     NodeTraversal.traverseEs6(compiler, root, this);
-
-    // Sort by path length to ensure that the longer
-    // paths (which may depend on the shorter ones)
-    // come later.
-    Set<Export> sorted =
-        new TreeSet<>(new Comparator<Export>() {
-          @Override
-          public int compare(Export e1, Export e2) {
-            return e1.getExportedPath().compareTo(e2.getExportedPath());
-          }
-        });
-
-    sorted.addAll(exports);
-
-    for (Export export : sorted) {
-      export.generateExterns();
-    }
   }
 
   /**
@@ -476,6 +459,12 @@ final class ExternExportsPass extends NodeTraversal.AbstractPostOrderCallback
   @Override
   public void visit(NodeTraversal t, Node n, Node parent) {
     switch (n.getToken()) {
+      case SCRIPT:
+        // Once we are done with a script, sort and process the exports we've seen so far.
+        // By sorting one script at a time and not sorting symbols between scripts, we do not
+        // disturb the dependency order between scripts.
+        sortAndProcessExports();
+        break;
 
       case NAME:
       case GETPROP:
@@ -511,6 +500,29 @@ final class ExternExportsPass extends NodeTraversal.AbstractPostOrderCallback
       default:
         break;
     }
+  }
+
+  private void sortAndProcessExports() {
+    // For the exports we have so far, sort by path to ensure that the longer paths come later.
+    // This is needed when, for example, we finish visiting "this.x" inside a constructor before
+    // we finish visiting the constructor itself.
+    // This is called once per script to avoid changing the dependency order between scripts.
+    Set<Export> sorted =
+        new TreeSet<>(new Comparator<Export>() {
+          @Override
+          public int compare(Export e1, Export e2) {
+            return e1.getExportedPath().compareTo(e2.getExportedPath());
+          }
+        });
+
+    sorted.addAll(exports);
+
+    for (Export export : sorted) {
+      export.generateExterns();
+    }
+
+    // Clear the list so the next script can be processed without interference from this one.
+    exports = new ArrayList<>();
   }
 
   private void handleSymbolExportCall(Node parent) {

--- a/test/com/google/javascript/jscomp/ExternExportsPassTest.java
+++ b/test/com/google/javascript/jscomp/ExternExportsPassTest.java
@@ -24,6 +24,7 @@ import com.google.javascript.jscomp.testing.BlackHoleErrorManager;
 
 import junit.framework.TestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -694,9 +695,77 @@ public final class ExternExportsPassTest extends TestCase {
             ""));
   }
 
+  public void testDependencyOrderingOfExterns() throws Exception {
+    compileAndCheck(ImmutableList.of(
+        // Source files:
+        Joiner.on("\n").join(
+            "goog.provide('ns.a');",
+            "goog.require('ns.b');",
+            "/**",
+            " * @param {ns.b} b",
+            " * @return {number}",
+            " */",
+            "ns.a = function(b) {",
+            "  return b.x + b.y.length;",
+            "};",
+            "goog.exportSymbol('ns.a', ns.a);"),
+        Joiner.on("\n").join(
+            "goog.provide('ns.b');",
+            "/** @constructor */",
+            "ns.b = function() {",
+            "  /** @type {number} */ this.x = 5;",
+            "  /** @type {string} */ this.y = 'foo';",
+            "};",
+            "goog.exportSymbol('ns.b', ns.b);"),
+        Joiner.on("\n").join(
+            "goog.provide('ns.c');",
+            "goog.require('ns.b');",
+            "/**",
+            " * @param {ns.b} b",
+            " * @return {string}",
+            " */",
+            "ns.c = function(b) {",
+            "  return 'b: {x: ' + b.x + ', y: \"' + b.y + '\"}';",
+            "};",
+            "goog.exportSymbol('ns.c', ns.c);")),
+        // Expected externs, with b (required by a and c) first:
+        Joiner.on("\n").join(
+            "/**",
+            " @const",
+            " @suppress {const,duplicate}",
+            " */",
+            "var ns = {};",
+            "/**",
+            " * @constructor",
+            " */",
+            "ns.b = function() {",
+            "};",
+            "/**",
+            " * @param {(ns.b|null)} b",
+            " * @return {number}",
+            " */",
+            "ns.a = function(b) {",
+            "};",
+            "/**",
+            " * @param {(ns.b|null)} b",
+            " * @return {string}",
+            " */",
+            "ns.c = function(b) {",
+            "};",
+            ""));
+  }
+
   private void compileAndCheck(String js, String expected) {
     Result result = compileAndExportExterns(js);
+    checkResult(result, expected);
+  }
 
+  private void compileAndCheck(List<String> jsList, String expected) {
+    Result result = compileAndExportExterns(jsList);
+    checkResult(result, expected);
+  }
+
+  private void checkResult(Result result, String expected) {
     String fileoverview = Joiner.on("\n").join(
         "/**",
         " * @fileoverview Generated externs.",
@@ -729,15 +798,24 @@ public final class ExternExportsPassTest extends TestCase {
     return compileAndExportExterns(js, "");
   }
 
+  private Result compileAndExportExterns(List<String> jsList) {
+    return compileAndExportExterns(jsList, "");
+  }
+
+  private Result compileAndExportExterns(String js, String externs) {
+    List<String> jsList = ImmutableList.of(js);
+    return compileAndExportExterns(jsList, externs);
+  }
+
   /**
-   * Compiles the passed in JavaScript with the passed in externs and returns
+   * Compiles the passed in list of JavaScript sources with the passed in externs and returns
    * the new externs exported by the this pass.
    *
-   * @param js the source to be compiled
+   * @param jsList the source to be compiled
    * @param externs the externs the {@code js} source needs
    * @return the externs generated from {@code js}
    */
-  private Result compileAndExportExterns(String js, String externs) {
+  private Result compileAndExportExterns(List<String> jsList, String externs) {
     Compiler compiler = new Compiler();
     BlackHoleErrorManager.silence(compiler);
     CompilerOptions options = new CompilerOptions();
@@ -750,11 +828,27 @@ public final class ExternExportsPassTest extends TestCase {
     options.setCheckSymbols(true);
     options.setCheckTypes(runCheckTypes);
 
-    List<SourceFile> inputs = ImmutableList.of(SourceFile.fromCode(
-        "testcode",
+    /* Perform the closure pass so we can use goog.provide and goog.require in tests, and order
+     * sources by their provide/require calls.
+     */
+    options.setClosurePass(true);
+    options.getDependencyOptions().setDependencySorting(true);
+
+    List<SourceFile> inputs = new ArrayList<SourceFile>();
+    // Dummy closure definitions first.
+    inputs.add(SourceFile.fromCode(
+        "goog",
         "var goog = {};"
         + "goog.exportSymbol = function(a, b) {}; "
-        + "goog.exportProperty = function(a, b, c) {}; " + js));
+        + "goog.exportProperty = function(a, b, c) {};"));
+    // Then all the sources from the test.
+    for (int i = 0; i < jsList.size(); ++i) {
+      String name = "source" + i;
+      String code = jsList.get(i);
+      inputs.add(SourceFile.fromCode(name, code));
+    }
+    // Now make the list immutable.
+    inputs = ImmutableList.copyOf(inputs);
 
     List<SourceFile> externFiles = ImmutableList.of(
         SourceFile.fromCode("externs", externs));


### PR DESCRIPTION
Adds the --create_externs_from_exports flag, which allows the creation of externs from exported methods.

Also fixes a minor bug in AbstractCommandLineRunner that prevented the use of that flag with relative paths containing no separators.

Finally, changes the way generated externs are sorted so that they respect dependency order.  Alphabetical sorting is still used, but only within a script.  This is important for the generated externs of a large project to be used directly without editing.

Issue #1399