### PR TITLE
Use the return value of super() calls in ES6 constructors

### DIFF
--- a/src/com/google/javascript/jscomp/CheckEventfulObjectDisposal.java
+++ b/src/com/google/javascript/jscomp/CheckEventfulObjectDisposal.java
@@ -361,7 +361,7 @@ public final class CheckEventfulObjectDisposal implements CompilerPass {
        * global variable.
        */
       Node base = getBase(n);
-      if (base != null && base.isThis()) {
+      if (base != null && NodeUtil.isThisOrAlias(base)) {
         if (base.getJSType().isUnknownType()) {
           // Handle anonymous function created in constructor:
           //

--- a/src/com/google/javascript/jscomp/CheckUnusedPrivateProperties.java
+++ b/src/com/google/javascript/jscomp/CheckUnusedPrivateProperties.java
@@ -172,7 +172,7 @@ class CheckUnusedPrivateProperties
   private boolean isCandidatePropertyDefinition(Node n) {
     Preconditions.checkState(n.isGetProp(), n);
     Node target = n.getFirstChild();
-    return target.isThis()
+    return NodeUtil.isThisOrAlias(target)
         || (isConstructor(target))
         || (target.isGetProp()
             && target.getLastChild().getString().equals("prototype"));

--- a/src/com/google/javascript/jscomp/ConformanceRules.java
+++ b/src/com/google/javascript/jscomp/ConformanceRules.java
@@ -1162,7 +1162,7 @@ public final class ConformanceRules {
 
     @Override
     protected ConformanceResult checkConformance(NodeTraversal t, Node n) {
-      if (n.isThis()) {
+      if (NodeUtil.isThisOrAlias(n)) {
         TypeI type = n.getTypeI();
         if (type != null && type.isUnknownType() && !isTypeImmediatelyTightened(n)) {
           Node root = t.getScopeRoot();
@@ -1206,7 +1206,7 @@ public final class ConformanceRules {
     }
 
     private boolean isKnownThis(Node n) {
-      return n.isThis() && !isUnknown(n);
+      return NodeUtil.isThisOrAlias(n) && !isUnknown(n);
     }
   }
 

--- a/src/com/google/javascript/jscomp/ConvertToTypedInterface.java
+++ b/src/com/google/javascript/jscomp/ConvertToTypedInterface.java
@@ -344,7 +344,7 @@ class ConvertToTypedInterface implements CompilerPass {
               if (n.isExprResult()) {
                 Node expr = n.getFirstChild();
                 Node name = expr.isAssign() ? expr.getFirstChild() : expr;
-                if (!name.isGetProp() || !name.getFirstChild().isThis()) {
+                if (!name.isGetProp() || !NodeUtil.isThisOrAlias(name.getFirstChild())) {
                   return;
                 }
                 String pname = name.getLastChild().getString();

--- a/src/com/google/javascript/jscomp/DisambiguateProperties.java
+++ b/src/com/google/javascript/jscomp/DisambiguateProperties.java
@@ -481,7 +481,7 @@ class DisambiguateProperties implements CompilerPass {
           && propertiesToErrorFor.containsKey(name)) {
         String suggestion = "";
         if (type.isAllType() || type.isUnknownType()) {
-          if (n.getFirstChild().isThis()) {
+          if (NodeUtil.isThisOrAlias(n.getFirstChild())) {
             suggestion = "The \"this\" object is unknown in the function, consider using @this";
           } else {
             String qName = n.getFirstChild().getQualifiedName();
@@ -589,7 +589,7 @@ class DisambiguateProperties implements CompilerPass {
           && propertiesToErrorFor.containsKey(propName)) {
         String suggestion = "";
         if (type.isAllType() || type.isUnknownType()) {
-          if (obj.isThis()) {
+          if (NodeUtil.isThisOrAlias(obj)) {
             suggestion = "The \"this\" object is unknown in the function, consider using @this";
           } else {
             String qName = obj.getQualifiedName();

--- a/src/com/google/javascript/jscomp/ExploitAssigns.java
+++ b/src/com/google/javascript/jscomp/ExploitAssigns.java
@@ -78,7 +78,7 @@ class ExploitAssigns extends AbstractPeepholeOptimization {
         // they may be implemented setter functions, and oftentimes
         // setter functions fail on native objects. This is OK for "THIS"
         // objects, because we assume that they are non-native.
-        return !isLValue || value.getFirstChild().isThis();
+        return !isLValue || NodeUtil.isThisOrAlias(value.getFirstChild());
 
       case NAME:
         return true;
@@ -167,7 +167,7 @@ class ExploitAssigns extends AbstractPeepholeOptimization {
           Node leftSide = next.getFirstChild();
           if (leftSide.isName() ||
               leftSide.isGetProp() &&
-              leftSide.getFirstChild().isThis()) {
+              NodeUtil.isThisOrAlias(leftSide.getFirstChild())) {
             // Dive down the right side of the assign.
             parent = next;
             next = leftSide.getNext();

--- a/src/com/google/javascript/jscomp/ExternExportsPass.java
+++ b/src/com/google/javascript/jscomp/ExternExportsPass.java
@@ -566,7 +566,7 @@ final class ExternExportsPass extends NodeTraversal.AbstractPostOrderCallback
   private void handleExportDefinition(NodeTraversal t, Node definitionNode) {
     // For now, only handle properties defined on this inside of a constructor
     if (!definitionNode.isGetProp()
-        || !definitionNode.getFirstChild().isThis()) {
+        || !NodeUtil.isThisOrAlias(definitionNode.getFirstChild())) {
       // Not a property on THIS
       return;
     }

--- a/src/com/google/javascript/jscomp/FunctionInjector.java
+++ b/src/com/google/javascript/jscomp/FunctionInjector.java
@@ -230,7 +230,7 @@ class FunctionInjector {
       if (NodeUtil.isFunctionObjectCall(callNode)) {
         if (!assumeStrictThis) {
           Node thisValue = callNode.getSecondChild();
-          if (thisValue == null || !thisValue.isThis()) {
+          if (thisValue == null || !NodeUtil.isThisOrAlias(thisValue)) {
             return false;
           }
         }
@@ -731,7 +731,7 @@ class FunctionInjector {
     if (!callNode.getFirstChild().isName()) {
       if (NodeUtil.isFunctionObjectCall(callNode)) {
         // TODO(johnlenz): Support replace this with a value.
-        if (cArg == null || !cArg.isThis()) {
+        if (cArg == null || !NodeUtil.isThisOrAlias(cArg)) {
           return CanInlineResult.NO;
         }
         cArg = cArg.getNext();

--- a/src/com/google/javascript/jscomp/FunctionRewriter.java
+++ b/src/com/google/javascript/jscomp/FunctionRewriter.java
@@ -435,7 +435,7 @@ class FunctionRewriter implements CompilerPass {
       Node value = maybeGetSingleReturnRValue(functionNode);
       if (value != null &&
           value.isGetProp() &&
-          value.getFirstChild().isThis()) {
+          NodeUtil.isThisOrAlias(value.getFirstChild())) {
         return value.getLastChild();
       }
       return null;
@@ -510,7 +510,7 @@ class FunctionRewriter implements CompilerPass {
 
       Node assign = statement.getFirstChild();
       Node lhs = assign.getFirstChild();
-      if (lhs.isGetProp() && lhs.getFirstChild().isThis()) {
+      if (lhs.isGetProp() && NodeUtil.isThisOrAlias(lhs.getFirstChild())) {
         Node rhs = assign.getLastChild();
         if (rhs.isName() &&
             rhs.getString().equals(paramNode.getString())) {

--- a/src/com/google/javascript/jscomp/FunctionToBlockMutator.java
+++ b/src/com/google/javascript/jscomp/FunctionToBlockMutator.java
@@ -263,7 +263,7 @@ class FunctionToBlockMutator {
             // has side effects.
 
             Node value = entry.getValue();
-            if (!value.isThis()
+            if (!NodeUtil.isThisOrAlias(value)
                 && (referencesThis
                     || NodeUtil.mayHaveSideEffects(value, compiler))) {
               String newName = getUniqueThisName();

--- a/src/com/google/javascript/jscomp/GlobalTypeInfo.java
+++ b/src/com/google/javascript/jscomp/GlobalTypeInfo.java
@@ -2427,7 +2427,7 @@ class GlobalTypeInfo implements CompilerPass, TypeIRegistry {
   private DeclaredFunctionType getDeclaredFunctionTypeOfCalleeIfAny(
       Node fn, NTIScope currentScope) {
     Preconditions.checkArgument(fn.getParent().isCall());
-    if (fn.isThis() || !fn.isFunction() && !fn.isQualifiedName()) {
+    if (NodeUtil.isThisOrAlias(fn) || !fn.isFunction() && !fn.isQualifiedName()) {
       return null;
     }
     if (fn.isFunction()) {
@@ -2452,7 +2452,7 @@ class GlobalTypeInfo implements CompilerPass, TypeIRegistry {
 
   private static boolean isClassPropertyDeclaration(Node n, NTIScope s) {
     Node parent = n.getParent();
-    return n.isGetProp() && n.getFirstChild().isThis()
+    return n.isGetProp() && NodeUtil.isThisOrAlias(n.getFirstChild())
         && (parent.isAssign() && parent.getFirstChild().equals(n)
             || parent.isExprResult())
         && (s.isConstructor() || s.isPrototypeMethod());

--- a/src/com/google/javascript/jscomp/InlineProperties.java
+++ b/src/com/google/javascript/jscomp/InlineProperties.java
@@ -214,7 +214,7 @@ final class InlineProperties implements CompilerPass {
       String propName = n.getLastChild().getString();
 
       Node value = parent.getLastChild();
-      if (src.isThis()) {
+      if (NodeUtil.isThisOrAlias(src)) {
         // This is a simple assignment like:
         //    this.foo = 1;
         if (inConstructor(t)) {

--- a/src/com/google/javascript/jscomp/InlineSimpleMethods.java
+++ b/src/com/google/javascript/jscomp/InlineSimpleMethods.java
@@ -131,7 +131,7 @@ class InlineSimpleMethods extends MethodCompilerPass {
     }
 
     Node leftChild = expectedGetprop.getFirstChild();
-    if (!leftChild.isThis() &&
+    if (!NodeUtil.isThisOrAlias(leftChild) &&
         !isPropertyTree(leftChild)) {
       return false;
     }
@@ -146,7 +146,7 @@ class InlineSimpleMethods extends MethodCompilerPass {
    */
   private static void replaceThis(Node expectedGetprop, Node replacement) {
     Node leftChild = expectedGetprop.getFirstChild();
-    if (leftChild.isThis()) {
+    if (NodeUtil.isThisOrAlias(leftChild)) {
       expectedGetprop.replaceChild(leftChild, replacement);
     } else {
       replaceThis(leftChild, replacement);

--- a/src/com/google/javascript/jscomp/NTIScope.java
+++ b/src/com/google/javascript/jscomp/NTIScope.java
@@ -224,7 +224,7 @@ final class NTIScope implements DeclaredTypeRegistry {
     Preconditions.checkArgument(qnameNode.isQualifiedName());
     if (qnameNode.isName()) {
       return isDefinedLocally(qnameNode.getString(), false);
-    } else if (qnameNode.isThis()) {
+    } else if (NodeUtil.isThisOrAlias(qnameNode)) {
       return true;
     }
     QualifiedName qname = QualifiedName.fromNode(qnameNode);

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -4763,4 +4763,15 @@ public final class NodeUtil {
     String keyName = propNode.getString();
     return keyName.equals("get") || keyName.equals("set");
   }
+
+  /**
+   * Is this node the this keyword or a
+   * compiler-created alias for it?
+   *
+   * @param n The node
+   * @return True if {@code n} is THIS or a NAME that was originally "this"
+   */
+  public static boolean isThisOrAlias(Node n) {
+    return n.isName() ? "this".equals(n.getOriginalName()) : n.isThis();
+  }
 }

--- a/src/com/google/javascript/jscomp/PureFunctionIdentifier.java
+++ b/src/com/google/javascript/jscomp/PureFunctionIdentifier.java
@@ -728,7 +728,7 @@ class PureFunctionIdentifier implements CompilerPass {
           }
         }
       } else if (NodeUtil.isGet(lhs)) {
-        if (lhs.getFirstChild().isThis()) {
+        if (NodeUtil.isThisOrAlias(lhs.getFirstChild())) {
           sideEffectInfo.setTaintsThis();
         } else {
           Var var = null;
@@ -941,7 +941,7 @@ class PureFunctionIdentifier implements CompilerPass {
           // is fixed. See testLocalizedSideEffects11.
           //if (!caller.knownLocals.contains(name)) {
           //}
-        } else if (objectNode != null && objectNode.isThis()) {
+        } else if (objectNode != null && NodeUtil.isThisOrAlias(objectNode)) {
           thisIsOuterThis = true;
         }
       }

--- a/src/com/google/javascript/jscomp/RemoveUnusedClassProperties.java
+++ b/src/com/google/javascript/jscomp/RemoveUnusedClassProperties.java
@@ -178,7 +178,7 @@ class RemoveUnusedClassProperties
   private boolean isRemovablePropertyDefinition(Node n) {
     Preconditions.checkState(n.isGetProp(), n);
     Node target = n.getFirstChild();
-    return target.isThis()
+    return NodeUtil.isThisOrAlias(target)
         || (this.removeUnusedConstructorProperties && isConstructor(target))
         || (target.isGetProp()
             && target.getLastChild().getString().equals("prototype"));

--- a/src/com/google/javascript/jscomp/RewriteBindThis.java
+++ b/src/com/google/javascript/jscomp/RewriteBindThis.java
@@ -53,7 +53,7 @@ class RewriteBindThis extends AbstractPostOrderCallback implements CompilerPass{
     return parentNode.isGetProp()
         && functionNode.getNext().getString().equals("bind")
         && parentNode.getParent().isCall()
-        && parentNode.getNext().isThis();
+        && NodeUtil.isThisOrAlias(parentNode.getNext());
   }
 
   private boolean canRewriteBinding(Node functionNode) {

--- a/src/com/google/javascript/jscomp/TypeCheck.java
+++ b/src/com/google/javascript/jscomp/TypeCheck.java
@@ -984,7 +984,7 @@ public final class TypeCheck implements NodeTraversal.Callback, CompilerPass {
           return;
         }
 
-        if (NodeUtil.getRootOfQualifiedName(lvalue).isThis() &&
+        if (NodeUtil.isThisOrAlias(NodeUtil.getRootOfQualifiedName(lvalue)) &&
             t.getTypedScope() != var.getScope()) {
           // Don't look at "this.foo" variables from other scopes.
           return;

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -627,7 +627,7 @@ class TypeInference
     JSType nodeType = getJSType(obj);
     ObjectType objectType = ObjectType.cast(
         nodeType.restrictByNotNullOrUndefined());
-    boolean propCreationInConstructor = obj.isThis() &&
+    boolean propCreationInConstructor = NodeUtil.isThisOrAlias(obj) &&
         getJSType(syntacticScope.getRootNode()).isConstructor();
 
     if (objectType == null) {
@@ -980,7 +980,7 @@ class TypeInference
   }
 
   private FlowScope narrowScope(FlowScope scope, Node node, JSType narrowed) {
-    if (node.isThis()) {
+    if (NodeUtil.isThisOrAlias(node)) {
       // "this" references don't need to be modeled in the control flow graph.
       return scope;
     }

--- a/src/com/google/javascript/jscomp/TypedScopeCreator.java
+++ b/src/com/google/javascript/jscomp/TypedScopeCreator.java
@@ -987,7 +987,7 @@ final class TypedScopeCreator implements ScopeCreator {
             builder.inferThisType(
                 info, ownerType.getOwnerFunction().getInstanceType());
             searchedForThisType = true;
-          } else if (ownerNode != null && ownerNode.isThis()) {
+          } else if (ownerNode != null && NodeUtil.isThisOrAlias(ownerNode)) {
             // If we have a 'this' node, use the scope type.
             builder.inferThisType(info, scope.getTypeOfThis());
             searchedForThisType = true;
@@ -2033,7 +2033,7 @@ final class TypedScopeCreator implements ScopeCreator {
       // if the member expression is not of the form: this.someProperty.
       if (info == null ||
           !member.isGetProp() ||
-          !member.getFirstChild().isThis()) {
+          !NodeUtil.isThisOrAlias(member.getFirstChild())) {
         return;
       }
 

--- a/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
+++ b/test/com/google/javascript/jscomp/Es6ToEs3ConverterTest.java
@@ -261,7 +261,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {D}",
             " * @param {...?} var_args",
             " */",
-            "var testcode$classdecl$var0 = function(var_args) { D.apply(this,arguments); };",
+            "var testcode$classdecl$var0 = function(var_args) {",
+            "  return D.apply(this,arguments) || this;",
+            "};",
             "$jscomp.inherits(testcode$classdecl$var0, D);",
             "testcode$classdecl$var0.prototype.f = function() {super.g(); };",
             "f(testcode$classdecl$var0)"));
@@ -549,7 +551,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {D}",
             " * @param {...?} var_args",
             " */",
-            "var C = function(var_args) { D.apply(this, arguments); };",
+            "var C = function(var_args) {",
+            "  return D.apply(this, arguments) || this;",
+            "};",
             "$jscomp.inherits(C, D);"));
     assertThat(getLastCompiler().injected).containsExactly("es6/util/inherits");
 
@@ -560,7 +564,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             "var D = function() {};",
             "/** @constructor @struct @extends {D} */",
             "var C = function() {",
-            "  D.call(this);",
+            "  /** @const @type {!C} */",
+            "  var $jscomp$super$this = D.call(this) || this;",
+            "  return $jscomp$super$this;",
             "}",
             "$jscomp.inherits(C, D);"));
 
@@ -571,7 +577,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             "var D = function() {};",
             "/** @constructor @struct @extends {D} */",
             "var C = function(str) { ",
-            "  D.call(this, str);",
+            "  /** @const @type {!C} */",
+            "  var $jscomp$super$this = D.call(this, str) || this;",
+            "  return $jscomp$super$this;",
             "}",
             "$jscomp.inherits(C, D);"));
 
@@ -582,7 +590,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {ns.D}",
             " * @param {...?} var_args",
             " */",
-            "var C = function(var_args) { ns.D.apply(this, arguments); };",
+            "var C = function(var_args) {",
+            "  return ns.D.apply(this, arguments) || this;",
+            "};",
             "$jscomp.inherits(C, ns.D);"));
 
     // Don't inject $jscomp.inherits() or apply() for externs
@@ -624,7 +634,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @struct @interface",
             " * @param {...?} var_args",
             " * @extends{D} */",
-            "var C = function(var_args) { D.apply(this, arguments); };",
+            "var C = function(var_args) {",
+            "  return D.apply(this, arguments) || this;",
+            "}",
             "C.prototype.g = function() {};"));
   }
 
@@ -656,7 +668,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             "var D = function() {};",
             "/** @constructor @struct @extends {D} */",
             "var C = function() {",
-            "  D.call(this);",
+            "  /** @const @type {!C} */",
+            "  var $jscomp$super$this = D.call(this) || this;",
+            "  return $jscomp$super$this;",
             "}",
             "$jscomp.inherits(C, D);"));
 
@@ -667,7 +681,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             "var D = function() {}",
             "/** @constructor @struct @extends {D} */",
             "var C = function(str) {",
-            "  D.call(this,str);",
+            "  /** @const @type {!C} */",
+            "  var $jscomp$super$this = D.call(this, str) || this;",
+            "  return $jscomp$super$this;",
             "}",
             "$jscomp.inherits(C, D);"));
 
@@ -713,7 +729,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             "C.prototype.method = function() {",
             "  /** @constructor @struct @extends{C} */",
             "  var D = function() {",
-            "    C.call(this);",
+            "    /** @const @type {!D} */",
+            "    var $jscomp$super$this = C.call(this) || this;",
+            "    return $jscomp$super$this;",
             "  }",
             "  $jscomp.inherits(D, C);",
             "};"));
@@ -784,7 +802,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @constructor @struct",
             " * @param {...?} var_args",
             " * @extends{C} */",
-            "  var D = function(var_args) { C.apply(this, arguments); };",
+            "  var D = function(var_args) {",
+            "    return C.apply(this, arguments) || this;",
+            "  };",
             "  $jscomp.inherits(D, C);",
             "};"));
   }
@@ -836,7 +856,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             "var D = function(){};",
             "/** @constructor @struct @extends {D} */",
             "var C=function(args) {",
-            "  D.call.apply(D, [].concat([this], $jscomp.arrayFromIterable(args)));",
+            "  /** @const @type {!C} */",
+            "  var $jscomp$super$this = D.call.apply(D, [].concat([this], $jscomp.arrayFromIterable(args))) || this;",
+            "  return $jscomp$super$this;",
             "};",
             "$jscomp.inherits(C,D);"));
     assertThat(getLastCompiler().injected)
@@ -852,7 +874,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {B}",
             " * @param {...?} var_args",
             " */",
-            "var S = function(var_args) { B.apply(this, arguments); };",
+            "var S = function(var_args) {",
+            "  return B.apply(this, arguments) || this;",
+            "};",
             "$jscomp.inherits(S, B);",
             "/** @this {?} */",
             "S.f=function() { B.f.call(this) }"));
@@ -864,7 +888,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {B}",
             " * @param {...?} var_args",
             " */",
-            "var S = function(var_args) { B.apply(this, arguments); };",
+            "var S = function(var_args) {",
+            "  return B.apply(this, arguments) || this;",
+            "};",
             "$jscomp.inherits(S, B);",
             "S.prototype.f=function() {",
             "  B.prototype.f.call(this);",
@@ -973,7 +999,7 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @param {...?} var_args",
             " */",
             "var CodeClass = function(var_args) {",
-            "  ExternsClass.apply(this,arguments)",
+            "  return ExternsClass.apply(this, arguments) || this;",
             "};",
             "$jscomp.inherits(CodeClass,ExternsClass)"),
         null, null);
@@ -1027,7 +1053,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {Foo}",
             " * @param {...?} var_args",
             " */",
-            "var Sub=function(var_args) { Foo.apply(this, arguments); }",
+            "var Sub = function(var_args) {",
+            "  return Foo.apply(this, arguments) || this;",
+            "};",
             "$jscomp.inherits(Sub, Foo);",
             "(new Sub).f();"));
 
@@ -1054,7 +1082,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {Foo}",
             " * @param {...?} var_args",
             " */",
-            "var Sub = function(var_args) { Foo.apply(this, arguments); };",
+            "var Sub = function(var_args) {",
+            "  return Foo.apply(this, arguments) || this;",
+            "};",
             "$jscomp.inherits(Sub, Foo);"));
   }
 
@@ -1193,7 +1223,9 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @extends {C}",
             " * @param {...?} var_args",
             " */",
-            "var D = function(var_args) { C.apply(this,arguments); };",
+            "var D = function(var_args) {",
+            "  return C.apply(this, arguments) || this;",
+            "};",
             "/** @nocollapse @type {?} */",
             "D.value;",
             "$jscomp.inherits(D, C);",
@@ -1353,7 +1385,7 @@ public final class Es6ToEs3ConverterTest extends CompilerTestCase {
             " * @param {...?} var_args",
             " */",
             "var Sub = function(var_args) {",
-            "  C.apply(this, arguments);",
+            "  return C.apply(this, arguments) || this;",
             "};",
             "$jscomp.inherits(Sub, C)"));
   }

--- a/test/com/google/javascript/jscomp/TypeCheckTest.java
+++ b/test/com/google/javascript/jscomp/TypeCheckTest.java
@@ -4693,6 +4693,32 @@ public final class TypeCheckTest extends CompilerTypeTestCase {
         "Banana.prototype.peel = f;");
   }
 
+  public void testSetprop16() throws Exception {
+    // Create property on an ES6 transpiled class
+    compiler.getOptions().setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT6);
+    compiler.getOptions().setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
+    testTypes(
+        LINE_JOINER.join(
+            DEFAULT_EXTERNS,
+            "Object.prototype.getOwnPropertyDescriptor = function() {};",
+            "Object.prototype.defineProperty = function() {};"),
+        LINE_JOINER.join(
+            "class A { }",
+            "class B extends A {",
+            "  constructor() {",
+            "    super()",
+            "    /** @type {number} */",
+            "    this.foo = 0;",
+            "  }",
+            "}",
+            "(new B()).foo = 'foo';"),
+        LINE_JOINER.join(
+            "assignment to property foo of B",
+            "found   : string",
+            "required: number"),
+        false);
+  }
+
   public void testGetpropDict1() throws Exception {
     testTypes("/**\n" +
               " * @constructor\n" +


### PR DESCRIPTION
Changes transpilation of ES6 super calls in constructors so that if the call returns a value, that value is used instead of `this`. Because you cannot assign to the `this` keyword, the transpilation creates the alias `$jscomp$super$this` which is then used instead of the `this` keyword throughout the constructor.

In order to simplify type inference, the original name of the alias is set to `this`. OTI has been updated to recognize the alias. I'll need a little help with NTI (or it can be done internally if desired).

This is a continuation of the work @MatrixFrog did MatrixFrog@b7948b8541f

Fixes #1669.