### PR TITLE
Fix recommended Maven command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ unit tests too).
 
     This will produce a jar file called `target/closure-compiler-1.0-SNAPSHOT.jar`.
 
-    Running `mvn -DskipTests -pl externs/pom.xml,pom-main.xml` will skip building the GWT
-    version of the compiler. This can speed up the build process significantly.
+    Running `mvn -DskipTests -pl externs/pom.xml,pom-main.xml,pom-main-shaded.xml`
+    will skip building the GWT version of the compiler. This can speed up the build process significantly.
 
 ### Using [Eclipse](http://www.eclipse.org/)
 


### PR DESCRIPTION
Currently recommended command changed in 87d979732554e7f695b02a648609ac304e037ae6 generates no jar files under the `target` directory