### PR TITLE
Devirtualize duplicate methods

### DIFF
--- a/src/com/google/javascript/jscomp/DevirtualizePrototypeMethods.java
+++ b/src/com/google/javascript/jscomp/DevirtualizePrototypeMethods.java
@@ -87,6 +87,9 @@ class DevirtualizePrototypeMethods
   private static boolean isCall(UseSite site) {
     Node node = site.node;
     Node parent = node.getParent();
+    if (parent == null) {
+      return false;
+    }
     return (parent.getFirstChild() == node) && parent.isCall();
   }
 
@@ -275,7 +278,7 @@ class DevirtualizePrototypeMethods
       // Multiple definitions prevent rewrite.
       Collection<Definition> singleSiteDefinitions =
           defFinder.getDefinitionsReferencedAt(nameNode);
-      if (singleSiteDefinitions.size() > 1) {
+      if (!allDefinitionsEquivalent(singleSiteDefinitions)) {
         return false;
       }
       Preconditions.checkState(!singleSiteDefinitions.isEmpty());
@@ -292,6 +295,33 @@ class DevirtualizePrototypeMethods
       }
     }
 
+    return true;
+  }
+
+  /**
+   * Given a set of method definitions, verify they are the same.
+   */
+  boolean allDefinitionsEquivalent(
+      Collection<Definition> definitions) {
+    if (definitions.size() <= 1) {
+      return true;
+    }
+
+    Definition first = null;
+    for (Definition definition : definitions) {
+      if (definition.getRValue() == null) {
+        return false; // We can't tell if they're all the same.
+      }
+
+      if (first == null) {
+        first = definition;
+        continue;
+      }
+
+      if (!compiler.areNodesEqualForInlining(first.getRValue(), definition.getRValue())) {
+        return false;
+      }
+    }
     return true;
   }
 


### PR DESCRIPTION
The background on this PR is that we have a lot of autogenerated protobufs with the same method over and over again (e.g., `MyProtobuf.prototype.getIndex = function () { return this.getFieldValue(this, 'getIndex'); }`)

Closure Compiler doesn't do a great job optimizing these because it can't figure out how to coalesce the definitions. I'm hoping this will improve the situation.
