### PR TITLE
CSSStyleDeclaration implements IArrayLike<string>

### DIFF
--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -416,6 +416,7 @@ function CSSUnknownRule() {}
 /**
  * @constructor
  * @extends {CSSProperties}
+ * @implements {IArrayLike<string>}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration
  */
 function CSSStyleDeclaration() {}


### PR DESCRIPTION
`CSSStyleDeclaration` is a collection of CSS property names. As an example you can try this on any webpage:

```javascript
window.getComputedStyle(document.body, null)
```

Or see this [MDN's example](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration) where `styleObj` is a `CSSStyleDeclaration` object:

```javascript
var styleObj= document.styleSheets[0].cssRules[0].style;
alert(styleObj.cssText);
for (var i = styleObj.length-1; i >= 0; i--) {
   var nameString = styleObj[i];
   styleObj.removeProperty(nameString);
}
alert(styleObj.cssText);
```

