### PR TITLE
[tiny] add ArrayBuffer to Blob constructor

### DIFF
--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -27,7 +27,7 @@
 
 /**
  * @see http://dev.w3.org/2006/webapi/FileAPI/#dfn-Blob
- * @param {Array<ArrayBufferView|Blob|string>=} opt_blobParts
+ * @param {Array<ArrayBuffer|ArrayBufferView|Blob|string>=} opt_blobParts
  * @param {Object=} opt_options
  * @constructor
  * @nosideeffects


### PR DESCRIPTION
After tracking back through the `Blob` constructor documentation (and how I've become to used to working with the API) I think a minor adjustment needs to be made to the Blob Constructor type definition.

Tracking through from the [`Blob` constructor](https://w3c.github.io/FileAPI/#dfn-Blob) we see that a `BlobPart` can either be:

```
BufferSource or Blob or USVString
```

And the definition for a `BufferSource` is the following:

```
ArrayBuffer or ArrayBufferView
```

As defined here: https://heycam.github.io/webidl/#BufferSource