### PR TITLE
Fix multi-line arg parsing for CommandLineRunner

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1165,7 +1165,7 @@ public class CommandLineRunner extends
     // Args4j has a different format that the old command-line parser.
     // So we use some voodoo to get the args into the format that args4j
     // expects.
-    Pattern argPattern = Pattern.compile("(--?[a-zA-Z_]+)=(.*)");
+    Pattern argPattern = Pattern.compile("(--?[a-zA-Z_]+)=(.*)", Pattern.DOTALL);
     Pattern quotesPattern = Pattern.compile("^['\"](.*)['\"]$");
     List<String> processedArgs = new ArrayList<>();
 


### PR DESCRIPTION
The upgrade of args4j in 329f3001d7cb639c74e40ba6936085b99269df45 broke the ability to have multiline arguments such as:

```
--output_wrapper=(function(){
%output%
}).call(this)
```

This restores that functionality.