### PR TITLE
Fix sourcemap composition for JSON stream input

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1044,7 +1044,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
           String sourceMapPath = jsonFile.getPath() + ".map";
           SourceFile sourceMap = SourceFile.fromCode(sourceMapPath,
               jsonFile.getSourceMap());
-          inputSourceMaps.put(sourceMapPath, new SourceMapInput(sourceMap));
+          inputSourceMaps.put(jsonFile.getPath(), new SourceMapInput(sourceMap));
           foundJsonInputSourceMap = true;
         }
       }

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1920,6 +1920,49 @@ public final class CommandLineRunnerTest extends TestCase {
         + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
   }
 
+  public void testJsonStreamSourceMap() {
+    String inputSourceMap = "{\n" +
+        "\"version\":3,\n" +
+        "\"file\":\"one.out.js\",\n" +
+        "\"lineCount\":1,\n" +
+        "\"mappings\":\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+        + "OAAAF,IAAA,CAAYC,CAAZ,CADc,CAGhBD,GAAA,CAAI,QAAJ;\",\n" +
+        "\"sources\":[\"one.js\"],\n" +
+        "\"names\":[\"log\",\"a\",\"console\"]\n" +
+        "}";
+    inputSourceMap = inputSourceMap.replace("\"", "\\\"");
+    String inputString = "[{"
+        + "\"src\": \"function log(a){console.log(a)}log(\\\"one.js\\\");\", "
+        + "\"path\":\"one.out.js\", "
+        + "\"sourceMap\": \"" + inputSourceMap + "\" }]";
+    args.add("--json_streams=BOTH");
+    args.add("--js_output_file=bar.js");
+    args.add("--apply_input_source_maps");
+
+    CommandLineRunner runner = new CommandLineRunner(
+        args.toArray(new String[]{}),
+        new ByteArrayInputStream(inputString.getBytes()),
+        new PrintStream(outReader),
+        new PrintStream(errReader));
+
+    lastCompiler = runner.getCompiler();
+    try {
+      runner.doRun();
+    } catch (IOException e) {
+      e.printStackTrace();
+      fail("Unexpected exception " + e);
+    }
+    String output = new String(outReader.toByteArray(), UTF_8);
+    assertThat(output).isEqualTo("[{"
+        + "\"src\":\"function log(a){console.log(a)}log(\\\"one.js\\\");\\n\","
+        + "\"path\":\"bar.js\","
+        + "\"source_map\":\"{\\n\\\"version\\\":3,\\n\\\"file\\\":\\\"bar.js\\\",\\n"
+        + "\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+        + "OAAAF,IAAA,CAAYC,CAAZ,CADc,CAGhBD,GAAA,CAAI,QAAJ;\\\",\\n"
+        + "\\\"sources\\\":[\\\"one.js\\\"],\\n\\\"names\\\":[\\\"log\\\",\\\"a\\\","
+        + "\\\"console\\\"]\\n}\\n\"}]");
+  }
+
   public void testOutputModuleNaming() {
     String inputString = "[{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
     args.add("--json_streams=BOTH");


### PR DESCRIPTION
#1971 had changes for JSON streams that didn't get moved to the internal CL. This adds those missing changes and fixes JSON Stream source maps.