### PR TITLE
Recognize important comments "/*!" and preserve them

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/IRFactory.java
+++ b/src/com/google/javascript/jscomp/parsing/IRFactory.java
@@ -352,7 +352,7 @@ class IRFactory {
 
     if (tree.sourceComments != null) {
       for (Comment comment : tree.sourceComments) {
-        if (comment.type == Comment.Type.JSDOC
+        if ((comment.type == Comment.Type.JSDOC || comment.type == Comment.Type.IMPORTANT)
             && !irFactory.parsedComments.contains(comment)) {
           irFactory.handlePossibleFileOverviewJsDoc(comment);
         } else if (comment.type == Comment.Type.BLOCK) {
@@ -903,7 +903,12 @@ class IRFactory {
           errorReporter);
     jsdocParser.setFileLevelJsDocBuilder(fileLevelJsDocBuilder);
     jsdocParser.setFileOverviewJSDocInfo(fileOverviewInfo);
-    jsdocParser.parse();
+    if (node.type == Comment.Type.IMPORTANT && node.value.length() > 0) {
+      jsdocParser.parseImportantComment();
+    } else {
+      jsdocParser.parse();
+    }
+
     return jsdocParser;
   }
 

--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -282,6 +282,33 @@ public final class JsDocInfoParser {
     return parseHelperLoop(token, new ArrayList<ExtendedTypeInfo>());
   }
 
+  /**
+   * Important comments begin with /*!
+   * They are treated as license blocks, but
+   * no further JSDoc parsing is performed
+   */
+  void parseImportantComment() {
+    state = State.SEARCHING_ANNOTATION;
+    skipEOLs();
+
+    JsDocToken token = next();
+
+    ExtractionInfo info = extractMultilineComment(
+        token, WhitespaceOption.PRESERVE, false, true);
+
+    // An extra space is added by the @license annotation
+    // so we need to add one here so they will be identical
+    String license = " " + info.string;
+
+    if (fileLevelJsDocBuilder != null) {
+      fileLevelJsDocBuilder.addLicense(license);
+    } else if (jsdocBuilder.shouldParseDocumentation()) {
+      jsdocBuilder.recordBlockDescription(license);
+    } else {
+      jsdocBuilder.recordBlockDescription("");
+    }
+  }
+
   private boolean parseHelperLoop(JsDocToken token,
                                   List<ExtendedTypeInfo> extendedTypes) {
     while (true) {

--- a/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
@@ -381,10 +381,14 @@ public class Scanner {
     if (!isAtEnd()) {
       nextChar();
       nextChar();
-      Comment.Type type = (index - startOffset > 4
-          && this.source.contents.charAt(startOffset + 2) == '*')
-          ? Comment.Type.JSDOC
-          : Comment.Type.BLOCK;
+      Comment.Type type = Comment.Type.BLOCK;
+      if (index - startOffset > 4) {
+        if (this.source.contents.charAt(startOffset + 2) == '*') {
+          type = Comment.Type.JSDOC;
+        } else if (this.source.contents.charAt(startOffset + 2) == '!') {
+          type = Comment.Type.IMPORTANT;
+        }
+      }
       SourceRange range = getLineNumberTable().getSourceRange(
           startOffset, index);
       String value = this.source.contents.substring(

--- a/src/com/google/javascript/jscomp/parsing/parser/trees/Comment.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/trees/Comment.java
@@ -32,7 +32,10 @@ public class Comment {
 
     // #!/usr/bin/node
     // Only valid at the start of a file.
-    SHEBANG
+    SHEBANG,
+
+    // /*! comment */
+    IMPORTANT
   }
 
   public final String value;

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -382,17 +382,17 @@ public final class CompilerTest extends TestCase {
   }
 
   // Make sure we correctly output license text.
-  public void testLicenseDirectiveOutput() throws Exception {
-    test("/** @license Your favorite license goes here */ var x;",
+  public void testImportantCommentOutput() throws Exception {
+    test("/*! Your favorite license goes here */ var x;",
         "/*\n Your favorite license goes here */\n",
         null);
   }
 
   // Make sure we output license text even if followed by @fileoverview.
-  public void testLicenseAndOverviewDirectiveWarning() throws Exception {
+  public void testImportantCommentAndOverviewDirectiveWarning() throws Exception {
     List<SourceFile> input = ImmutableList.of(
       SourceFile.fromCode("foo",
-         ("/** @license Your favorite license goes here */\n" +
+         ("/*! Your favorite license goes here */\n" +
         "/** \n" +
         "  * @fileoverview This is my favorite file! */\n" +
         "var x;")));
@@ -402,9 +402,9 @@ public final class CompilerTest extends TestCase {
   }
 
   // Text for the opposite order - @fileoverview, then @license.
-  public void testOverviewAndLicenseDirectiveOutput() throws Exception {
+  public void testOverviewAndImportantCommentOutput() throws Exception {
     test("/** @fileoverview This is my favorite file! */\n" +
-        "/** @license Your favorite license goes here */\n" +
+        "/*! Your favorite license goes here */\n" +
         "var x;",
         "/*\n Your favorite license goes here */\n",
         null);
@@ -412,19 +412,19 @@ public final class CompilerTest extends TestCase {
 
   // Test for sequence of @license and @fileoverview, and make sure
   // all the licenses get copied over.
-  public void testLicenseOverviewLicense() throws Exception {
-     test("/** @license Another license */\n" +
+  public void testImportantCommentOverviewImportantComment() throws Exception {
+     test("/*! Another license */\n" +
          "/** @fileoverview This is my favorite file! */\n" +
-         "/** @license Your favorite license goes here */\n" +
+         "/*! Your favorite license goes here */\n" +
          "var x;",
-         "/*\n Your favorite license goes here  Another license */\n",
+         "/*\n Another license  Your favorite license goes here */\n",
          null);
    }
 
   // Make sure things work even with @license and @fileoverview in the
   // same comment.
-  public void testCombinedLicenseOverviewDirectiveOutput() throws Exception {
-    test("/** @license Your favorite license goes here\n" +
+  public void testCombinedImportantCommentOverviewDirectiveOutput() throws Exception {
+    test("/*! Your favorite license goes here\n" +
         " * @fileoverview This is my favorite file! */\n" +
         "var x;",
         "/*\n Your favorite license goes here\n" +
@@ -433,10 +433,142 @@ public final class CompilerTest extends TestCase {
   }
 
   // Does the presence of @author change anything with the license?
-  public void testCombinedLicenseAuthorDirectiveOutput() throws Exception {
-    test("/** @license Your favorite license goes here\n" +
+  public void testCombinedImportantCommentAuthorDirectiveOutput() throws Exception {
+    test("/*! Your favorite license goes here\n" +
         " * @author Robert */\n" +
         "var x;",
+        "/*\n Your favorite license goes here\n @author Robert */\n",
+        null);
+  }
+
+  // Make sure we concatenate licenses the same way.
+  public void testMultipleImportantCommentDirectiveOutput() throws Exception {
+    test("/*! Your favorite license goes here */\n" +
+        "/*! Another license */\n" +
+        "var x;",
+        "/*\n Your favorite license goes here  Another license */\n",
+        null);
+  }
+
+  public void testImportantCommentLicenseDirectiveOutput() throws Exception {
+    test("/*! Your favorite license goes here */\n" +
+            "/** @license Another license */\n" +
+            "var x;",
+        "/*\n Another license  Your favorite license goes here */\n",
+        null);
+  }
+
+  public void testLicenseImportantCommentDirectiveOutput() throws Exception {
+    test("/** @license Your favorite license goes here */\n" +
+            "/*! Another license */\n" +
+            "var x;",
+        "/*\n Your favorite license goes here  Another license */\n",
+        null);
+  }
+
+  // Do we correctly handle the license if it's not at the top level, but
+  // inside another declaration?
+  public void testImportantCommentInTree() throws Exception {
+    test("var a = function() {\n +" +
+        "/*! Your favorite license goes here */\n" +
+        " 1;};\n",
+        "/*\n Your favorite license goes here */\n",
+        null);
+  }
+
+  public void testMultipleUniqueImportantComments() throws Exception {
+    String js1 = "/*! One license here */\n"
+                 + "var x;";
+    String js2 = "/*! Another license here */\n"
+                 + "var y;";
+    String expected = "/*\n One license here */\n"
+                      + "/*\n Another license here */\n";
+
+    Compiler compiler = new Compiler();
+    CompilerOptions options = createNewFlagBasedOptions();
+    List<SourceFile> inputs = ImmutableList.of(
+        SourceFile.fromCode("testcode1", js1),
+        SourceFile.fromCode("testcode2", js2));
+    Result result = compiler.compile(EMPTY_EXTERNS, inputs, options);
+
+    assertTrue(Joiner.on(",").join(result.errors), result.success);
+    assertEquals(expected, compiler.toSource());
+  }
+
+  public void testMultipleIndenticalImportantComments() throws Exception {
+    String js1 = "/*! Identical license here */\n"
+                 + "var x;";
+    String js2 = "/*! Identical license here */\n"
+                 + "var y;";
+    String expected = "/*\n Identical license here */\n";
+
+    Compiler compiler = new Compiler();
+    CompilerOptions options = createNewFlagBasedOptions();
+    List<SourceFile> inputs = ImmutableList.of(
+        SourceFile.fromCode("testcode1", js1),
+        SourceFile.fromCode("testcode2", js2));
+    Result result = compiler.compile(EMPTY_EXTERNS, inputs, options);
+
+    assertTrue(Joiner.on(",").join(result.errors), result.success);
+    assertEquals(expected, compiler.toSource());
+  }
+
+  // Make sure we correctly output license text.
+  public void testLicenseDirectiveOutput() throws Exception {
+    test("/** @license Your favorite license goes here */ var x;",
+        "/*\n Your favorite license goes here */\n",
+        null);
+  }
+
+  // Make sure we output license text even if followed by @fileoverview.
+  public void testLicenseAndOverviewDirectiveWarning() throws Exception {
+    List<SourceFile> input = ImmutableList.of(
+        SourceFile.fromCode("foo",
+            ("/** @license Your favorite license goes here */\n" +
+                "/** \n" +
+                "  * @fileoverview This is my favorite file! */\n" +
+                "var x;")));
+    assertTrue(
+        (new Compiler()).compile(
+            EMPTY_EXTERNS, input, new CompilerOptions()).success);
+  }
+
+  // Text for the opposite order - @fileoverview, then @license.
+  public void testOverviewAndLicenseDirectiveOutput() throws Exception {
+    test("/** @fileoverview This is my favorite file! */\n" +
+            "/** @license Your favorite license goes here */\n" +
+            "var x;",
+        "/*\n Your favorite license goes here */\n",
+        null);
+  }
+
+  // Test for sequence of @license and @fileoverview, and make sure
+  // all the licenses get copied over.
+  public void testLicenseOverviewLicense() throws Exception {
+    test("/** @license Another license */\n" +
+            "/** @fileoverview This is my favorite file! */\n" +
+            "/** @license Your favorite license goes here */\n" +
+            "var x;",
+        "/*\n Your favorite license goes here  Another license */\n",
+        null);
+  }
+
+  // Make sure things work even with @license and @fileoverview in the
+  // same comment.
+  public void testCombinedLicenseOverviewDirectiveOutput() throws Exception {
+    test("/** @license Your favorite license goes here\n" +
+            " * @fileoverview This is my favorite file! */\n" +
+            "var x;",
+        "/*\n Your favorite license goes here\n" +
+            " @fileoverview This is my favorite file! */\n",
+        null);
+  }
+
+  // Does the presence of @author change anything with the license?
+  public void testCombinedLicenseAuthorDirectiveOutput() throws Exception {
+    test("/** @license Your favorite license goes here\n" +
+            " * @author Robert */\n" +
+            "var x;",
         "/*\n Your favorite license goes here\n @author Robert */\n",
         null);
   }
@@ -494,6 +626,24 @@ public final class CompilerTest extends TestCase {
                  + "var x;";
     String js2 = "/** @license Identical license here */\n"
                  + "var y;";
+    String expected = "/*\n Identical license here */\n";
+
+    Compiler compiler = new Compiler();
+    CompilerOptions options = createNewFlagBasedOptions();
+    List<SourceFile> inputs = ImmutableList.of(
+        SourceFile.fromCode("testcode1", js1),
+        SourceFile.fromCode("testcode2", js2));
+    Result result = compiler.compile(EMPTY_EXTERNS, inputs, options);
+
+    assertTrue(Joiner.on(",").join(result.errors), result.success);
+    assertEquals(expected, compiler.toSource());
+  }
+
+  public void testIndenticalLicenseAndImportantComent() throws Exception {
+    String js1 = "/** @license Identical license here */\n"
+        + "var x;";
+    String js2 = "/*! Identical license here */\n"
+        + "var y;";
     String expected = "/*\n Identical license here */\n";
 
     Compiler compiler = new Compiler();

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -1867,6 +1867,16 @@ public final class ParserTest extends BaseJSTypeTestCase {
     assertThat(n.getFirstChild().getJSDocInfo().isConstructor()).isTrue();
   }
 
+  public void testImportantComment() {
+    isIdeMode = true;
+
+    Node n = parse("/*! Hi mom! */ function Foo() {}");
+    assertNode(n.getFirstChild()).hasType(Token.FUNCTION);
+    assertThat(n.getJSDocInfo()).isNotNull();
+    assertThat(n.getFirstChild().getJSDocInfo()).isNull();
+    assertThat(n.getJSDocInfo().getLicense()).isEqualTo(" Hi mom! ");
+  }
+
   public void testObjectLiteralDoc1() {
     Node n = parse("var x = {/** @type {number} */ 1: 2};");
 


### PR DESCRIPTION
Look for comment blocks beginning with `/*!` and treat them as license blocks. I've had to do a number of preprocessing steps to re-add these licenses on my projects and thought it was about time the compiler handled them appropriately.

Fixes #164 - this one is so old, it was number 275 on Google Code.