### PR TITLE
Convert IIFE Arguments to Local Variables

### DIFF
--- a/src/com/google/javascript/jscomp/ConvertIIFEArgsToVars.java
+++ b/src/com/google/javascript/jscomp/ConvertIIFEArgsToVars.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import com.google.common.base.Preconditions;
+import com.google.javascript.rhino.IR;
+import com.google.javascript.rhino.Node;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convert the parameters of an immediately invoked function expression to variables
+ * and assign the value from the call arguments. This improves function inlining.
+ *
+ * This pass relies on variable renaming (done during normalization) to avoid
+ * accidental variable capture.
+ *
+ * Since passes which implement OptimizeCalls only handle named functions,
+ * this pass doesn't extend OptimizeCalls.
+ *
+ * @author chadkillingsworth@gmail.com (Chad Killingsworth)
+ */
+public class ConvertIIFEArgsToVars implements CompilerPass, NodeTraversal.Callback {
+  private final AbstractCompiler compiler;
+
+  public ConvertIIFEArgsToVars(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+   NodeTraversal.traverseEs6(compiler, root, this);
+  }
+
+  public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
+    return true;
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    if (!n.isFunction() || parent == null) {
+      return;
+    }
+
+    Node call;
+    Node grandparent = parent.getParent();
+
+    // Check for standard IIFE
+    // (function() { })()
+    if (parent.isCall() && parent.getFirstChild() == n) {
+      call = parent;
+
+    // Check for explicit calls
+    // (function() {} ).call(null)
+    } else if (parent.isGetProp() && parent.getFirstChild() == n &&
+        n.getNext() != null && n.getNext().isString() &&
+        n.getNext().getString().equals("call") &&
+        grandparent != null && grandparent.isCall() &&
+        grandparent.getFirstChild() == parent) {
+      call = grandparent;
+    } else {
+      return;
+    }
+
+    Node funcParams = NodeUtil.getFunctionParameters(n);
+    if (!funcParams.hasChildren() || NodeUtil.isVarArgsFunction(n)) {
+      return;
+    }
+
+    Node param = funcParams.getFirstChild();
+    List<Node> newVars = new ArrayList<>();
+    while (param != null) {
+      newVars.add(IR.var(param.cloneNode(), getCallArgument(param, call))
+          .useSourceInfoFromForTree(param));
+
+      param = param.getNext();
+    }
+    funcParams.removeChildren();
+    for (int i = newVars.size() - 1; i >= 0; i--) {
+      funcParams.getNext().addChildToFront(newVars.get(i));
+    }
+
+    // Remove all arguments of the call node, except "this" if it exists.
+    Node removeRef;
+    if (call.getBooleanProp(Node.FREE_CALL)) {
+      removeRef = call.getFirstChild();
+    } else {
+      removeRef = call.getSecondChild();
+    }
+    while (removeRef.getNext() != null) {
+      call.removeChildAfter(removeRef);
+    }
+
+    compiler.reportCodeChange();
+  }
+
+  /**
+   * For a function param name of an IIFE, find
+   * the matching call argument and return it as a copy.
+   */
+  public Node getCallArgument(Node param, Node call) {
+    Preconditions.checkState(param.isName());
+    Preconditions.checkState(param.getParent() != null && param.getParent().isParamList());
+    Preconditions.checkState(call != null && call.isCall());
+
+    int argIndex = param.getParent().getIndexOfChild(param);
+    Node callArg = call.getSecondChild();
+    if (!call.getBooleanProp(Node.FREE_CALL)) {
+      callArg = callArg.getNext();
+    }
+    for (int i = 0; i < argIndex && callArg != null; i++) {
+      callArg = callArg.getNext();
+    }
+
+    // It's common to call an IIFE with less arguments
+    // than is defined as a way to alias "undefined"
+    // (function(undefined) {})()
+    if (callArg == null) {
+      return NodeUtil.newName(compiler, "undefined", param, param.getString());
+    }
+
+    return callArg.cloneTree();
+  }
+}

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -548,6 +548,12 @@ public final class DefaultPassConfig extends PassConfig {
       passes.add(runtimeTypeCheck);
     }
 
+    // Converts arguments to IIFEs to variable assignments within the function.
+    // Improves later optimizations such as function inlining.
+    if (options.optimizeCalls) {
+      passes.add(convertIIFEArgsToVars);
+    }
+
     // Inlines functions that perform dynamic accesses to static properties of parameters that are
     // typed as {Function}. This turns a dynamic access to a static property of a class definition
     // into a fully qualified access and in so doing enables better dead code stripping.
@@ -2136,6 +2142,14 @@ public final class DefaultPassConfig extends PassConfig {
         passes.addPass(new OptimizeParameters(compiler));
       }
       return passes;
+    }
+  };
+
+  /** Rewrite IIFE calls so that the call arguments are variable assignments */
+  private final PassFactory convertIIFEArgsToVars = new PassFactory("convertIIFEArgsToVars", true) {
+    @Override
+    protected CompilerPass create(AbstractCompiler compiler) {
+      return new ConvertIIFEArgsToVars(compiler);
     }
   };
 

--- a/test/com/google/javascript/jscomp/ConvertIIFEArgsToVarsTest.java
+++ b/test/com/google/javascript/jscomp/ConvertIIFEArgsToVarsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+/**
+ * Tests for {@link ConvertIIFEArgsToVars}.
+ */
+public final class ConvertIIFEArgsToVarsTest extends CompilerTestCase {
+  @Override
+  public CompilerPass getProcessor(Compiler compiler) {
+    return new ConvertIIFEArgsToVars(compiler);
+  }
+
+  @Override
+  public void setUp() {
+    enableNormalize();
+  }
+
+  public void testBasic() {
+    test(
+        LINE_JOINER.join(
+            "var a = 1;",
+            "var b = 2;",
+            "(function(c, d) {",
+            "  console.log(c, d);",
+            "})(a, b)"),
+        LINE_JOINER.join(
+            "var a = 1;",
+            "var b = 2;",
+            "(function() {",
+            "  var c = a;",
+            "  var d = b;",
+            "  console.log(c, d);",
+            "})()"));
+  }
+
+  public void testExplicitThis() {
+    test(
+        LINE_JOINER.join(
+            "var a = 1;",
+            "var b = 2;",
+            "(function(c, d) {",
+            "  console.log(c, d);",
+            "}).call(null, a, b)"),
+        LINE_JOINER.join(
+            "var a = 1;",
+            "var b = 2;",
+            "(function() {",
+            "  var c = a;",
+            "  var d = b;",
+            "  console.log(c, d);",
+            "}).call(null)"));
+  }
+
+  public void testNested() {
+    test(
+        LINE_JOINER.join(
+            "var a = 1;",
+            "var b = 2;",
+            "(function(c, d) {",
+            "  (function(e, f) {",
+            "    console.log(e, f);",
+            "  })(c, d);",
+            "}).call(null, a, b);"),
+        LINE_JOINER.join(
+            "var a = 1;",
+            "var b = 2;",
+            "(function() {",
+            "  var c = a;",
+            "  var d = b;",
+            "  (function() {",
+            "    var e = c;",
+            "    var f = d;",
+            "    console.log(e, f);",
+            "  })();",
+            "}).call(null)"));
+  }
+
+  public void testArgumentsReference() {
+    testSame(LINE_JOINER.join(
+        "var a = 1;",
+        "var b = 2;",
+        "(function(c, d) {",
+        "  var len = arguments.length;",
+        "  console.log(c, d, len);",
+        "}).call(null, a, b);"));
+  }
+
+  public void testUndefinedAlias() {
+    test(
+        LINE_JOINER.join(
+            "(function(c, d) {",
+            "  console.log(c, d);",
+            "})();"),
+        LINE_JOINER.join(
+            "(function() {",
+            "  var c = undefined;",
+            "  var d = undefined;",
+            "  console.log(c, d);",
+            "})();"));
+  }
+
+  public void testMoreArgsThanParams() {
+    test(
+        LINE_JOINER.join(
+            "(function(c, d) {",
+            "  console.log(c, d);",
+            "})(1, 2, 3);"),
+        LINE_JOINER.join(
+            "(function() {",
+            "  var c = 1;",
+            "  var d = 2;",
+            "  console.log(c, d);",
+            "})();"));
+  }
+
+  public void testParamsSameNameAsArgs() {
+    test(
+        LINE_JOINER.join(
+            "var c = 1;",
+            "var d = 2;",
+            "(function(c, d) {",
+            "  console.log(c, d);",
+            "})(c, d);"),
+        LINE_JOINER.join(
+            "var c = 1;",
+            "var d = 2;",
+            "(function() {",
+            "  var c$jscomp$1 = c;",
+            "  var d$jscomp$1 = d;",
+            "  console.log(c$jscomp$1, d$jscomp$1);",
+            "})();"));
+  }
+
+  public void testExprResult() {
+    test(
+        LINE_JOINER.join(
+            "var foo = 4;",
+            "var bar = {};",
+            "bar.baz = (function(bar) {",
+            "  return bar + 2;",
+            "})(foo);"),
+        LINE_JOINER.join(
+            "var foo = 4;",
+            "var bar = {};",
+            "bar.baz = (function() {",
+            "  var bar = foo;",
+            "  return bar + 2;",
+            "})();"));
+  }
+
+  public void testPreventAccidentalVariableCapture() {
+    test(
+        LINE_JOINER.join(
+            "var a = 1;",
+            "(function(c) {",
+            " var a = 2;",
+            " console.log(c);",
+            "})(a)"),
+        LINE_JOINER.join(
+            "var a = 1;",
+            "(function() {",
+            " var c = a;",
+            " var a$jscomp$1 = 2;",
+            " console.log(c);",
+            "})()"));
+  }
+}


### PR DESCRIPTION
Passing arguments to an IIFE seems to block a lot of future optimizations - most importantly function inlining. I believe in this case it's safe to convert the function args to local variable assignments.

Fixes #2100 
