### PR TITLE
Only append default sourceMappingURL if no output wrapper is specified

### DIFF
--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -414,8 +414,6 @@ public final class CompileTask
 
         if (result.sourceMap != null) {
           flushSourceMap(result.sourceMap);
-          source.append(System.getProperty("line.separator"));
-          source.append("//# sourceMappingURL=" + sourceMapOutputFile.getName());
         }
         writeResult(source.toString());
       } else {


### PR DESCRIPTION
See #2113.
