### PR TITLE
Fix Math.hypot polyfill to call with zero/one params

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -152,7 +152,7 @@ Math.cbrt = function(value) {};
  * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
  */
-Math.hypot = function(value1, var_args) {};
+Math.hypot = function(var_args) {};
 
 /**
  * @param {number} value1

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -147,7 +147,6 @@ Math.sign = function(value) {};
 Math.cbrt = function(value) {};
 
 /**
- * @param {number} value1
  * @param {...number} var_args
  * @return {number}
  * @nosideeffects

--- a/src/com/google/javascript/jscomp/js/es6/math/hypot.js
+++ b/src/com/google/javascript/jscomp/js/es6/math/hypot.js
@@ -24,15 +24,19 @@ $jscomp.polyfill('Math.hypot', function(orig) {
    *
    * <p>Polyfills the static function Math.hypot().
    *
-   * @param {number} x Any number, or value that can be coerced to a number.
-   * @param {number} y Any number, or value that can be coerced to a number.
-   * @param {...*} var_args More numbers.
+   * @param {...number} var_args Any number, or value that can be coerced to a number.
    * @return {number} The square root of the sum of the squares.
    */
-  var polyfill = function(x, y, var_args) {
+  var polyfill = function(var_args) {
+    if (arguments.length === 0) {
+      return 0;
+    } else if (arguments.length === 1) {
+      return Math.abs(Number(arguments[0]));
+    }
+
     // Make the type checker happy.
-    x = Number(x);
-    y = Number(y);
+    var x = Number(arguments[0]);
+    var y = Number(arguments[1]);
     var i, z, sum;
     // Note: we need to normalize the numbers in case of over/underflow.
     var max = Math.max(Math.abs(x), Math.abs(y));

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/math_hypot_test.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/math_hypot_test.js
@@ -21,7 +21,10 @@ const testSuite = goog.require('goog.testing.testSuite');
 
 testSuite({
   testHypot() {
-    assertRoughlyEquals(5, Math.hypot(3, 4), 1e-10);
+    assertEquals(0, Math.hypot());
+    assertEquals(3, Math.hypot(3));
+    assertEquals(3, Math.hypot(-3));
+
     assertRoughlyEquals(5, Math.hypot(-3, 4), 1e-10);
     assertRoughlyEquals(13, Math.hypot(5, 12), 1e-10);
     assertRoughlyEquals(13, Math.hypot(5, -12), 1e-10);


### PR DESCRIPTION
[A compat-table test](https://kangax.github.io/compat-table/es6/#test-Math_methods_Math.hypot) fails due to this issue.
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
