### PR TITLE
Aggressively inline IIFEs even when assumeClosuresOnlyCaptureReferences is false

### DIFF
--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -2539,7 +2539,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     String expected =
         "var x = new function() {};" +
         "/** @this {F} */" +
-        "(function (y) { y.bar = function() { alert(3); }; })(x);" +
+        "x.bar = function() { alert(3); };" +
         "x.bar();";
 
     CompilerOptions options = createCompilerOptions();


### PR DESCRIPTION
Take 2 at fixing #2100. Follow up to discussion at #2103.

Tweak the function inlining heuristic such that it is much more aggressive about inlining IIFEs.