### PR TITLE
Use a released version of Guava to compile Closure Compiler.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <jdk.version>1.7</jdk.version>
     <junit.version>4.12</junit.version>
-    <guava.version>20.0-SNAPSHOT</guava.version>
+    <guava.version>20.0</guava.version>
     <protobuf.version>3.0.2</protobuf.version>
   </properties>
 


### PR DESCRIPTION
The 20-SNAPSHOT version apparently has been removed from maven mirrors,
running the build with an empty local maven cache fails to download it.

See also https://github.com/google/guava/issues/2259