### PR TITLE
Publicize the source_map_input flag

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -312,7 +312,7 @@ public class CommandLineRunner extends
     private List<String> sourceMapLocationMapping = new ArrayList<>();
 
     @Option(name = "--source_map_input",
-        hidden = true,
+        hidden = false,
         usage = "Source map locations for input files, separated by a '|', "
         + "(i.e. input-file-path|input-source-map)")
     private List<String> sourceMapInputs = new ArrayList<>();
@@ -777,6 +777,7 @@ public class CommandLineRunner extends
                     "output_manifest",
                     "output_module_dependencies",
                     "property_renaming_report",
+                    "source_map_input",
                     "source_map_location_mapping",
                     "variable_renaming_report"))
             .putAll(


### PR DESCRIPTION
Now that the compiler composes source maps, document the method for passing them to the compiler.