### PR TITLE
Support the node module resolution algorithm for ES6 modules.

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2525,6 +2525,12 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       return this;
     }
 
+    public CommandLineConfig setModuleResolutionMode(ModuleLoader.ResolutionMode mode) {
+      this.moduleResolutionMode = mode;
+      return this;
+    }
+
+    private ModuleLoader.ResolutionMode moduleResolutionMode = ModuleLoader.ResolutionMode.LEGACY;
   }
 
   /**

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -704,10 +704,23 @@ public class CommandLineRunner extends
         usage = "Rewrite ES6 library calls to use polyfills provided by the compiler's runtime.")
     private boolean rewritePolyfills = true;
 
-    @Option(name = "--print_source_after_each_pass",
-        hidden = true,
-        usage = "Whether to iteratively print resulting JS source per pass.")
-        private boolean printSourceAfterEachPass = false;
+    @Option(
+      name = "--print_source_after_each_pass",
+      hidden = true,
+      usage = "Whether to iteratively print resulting JS source per pass."
+    )
+    private boolean printSourceAfterEachPass = false;
+
+    @Option(
+      name = "--module_resolution",
+      hidden = false,
+      usage =
+          "Specifies how the compiler locates modules. BROWSER requires all module imports "
+              + "to begin with a '.' or '/' and have a file extension. NODE uses the node module "
+              + "rules. LEGACY prepends a '/' to any import not already beginning with a "
+              + "'.' or '/'."
+    )
+    private ModuleLoader.ResolutionMode moduleResolutionMode = ModuleLoader.ResolutionMode.NODE;
 
     @Argument
     private List<String> arguments = new ArrayList<>();
@@ -781,7 +794,10 @@ public class CommandLineRunner extends
             .putAll(
                 "JS Modules",
                 ImmutableList.of(
-                    "js_module_root", "process_common_js_modules", "transform_amd_modules"))
+                    "js_module_root",
+                    "module_resolution",
+                    "process_common_js_modules",
+                    "transform_amd_modules"))
             .putAll(
                 "Library and Framework Specific",
                 ImmutableList.of(
@@ -1507,7 +1523,8 @@ public class CommandLineRunner extends
           .setTracerMode(flags.tracerMode)
           .setInstrumentationTemplateFile(flags.instrumentationFile)
           .setNewTypeInference(flags.useNewTypeInference)
-          .setJsonStreamMode(flags.jsonStreamMode);
+          .setJsonStreamMode(flags.jsonStreamMode)
+          .setModuleResolutionMode(flags.moduleResolutionMode);
     }
     errorStream = null;
   }
@@ -1682,6 +1699,7 @@ public class CommandLineRunner extends
     options.setPrintSourceAfterEachPass(flags.printSourceAfterEachPass);
     options.setStrictModeInput(flags.strictModeInput);
     options.setEmitUseStrict(flags.emitUseStrict);
+    options.setModuleResolutionMode(flags.moduleResolutionMode);
 
     return options;
   }

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1481,9 +1481,15 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
           || options.transformAMDToCJSModules
           || options.processCommonJSModules) {
 
-        this.moduleLoader = new ModuleLoader(this, options.moduleRoots, inputs);
+        this.moduleLoader =
+            new ModuleLoader(
+                this,
+                options.moduleRoots,
+                inputs,
+                ModuleLoader.PathResolver.RELATIVE,
+                options.moduleResolutionMode);
 
-        if (options.processCommonJSModules) {
+        if (options.moduleResolutionMode == ModuleLoader.ResolutionMode.NODE) {
           this.moduleLoader.setPackageJsonMainEntries(processJsonInputs(inputs));
         }
 

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1086,10 +1086,13 @@ public class CompilerOptions {
    */
   private boolean isStrictModeInput = true;
 
+  /** Which algorithm to use for locating ES6 and CommonJS modules */
+  ModuleLoader.ResolutionMode moduleResolutionMode;
+
   /**
    * Should the compiler print its configuration options to stderr when they are initialized?
    *
-   * <p> Default {@code false}.
+   * <p>Default {@code false}.
    */
   public void setPrintConfig(boolean printConfig) {
     this.printConfig = printConfig;
@@ -1108,6 +1111,9 @@ public class CompilerOptions {
 
     // Which environment to use
     environment = Environment.BROWSER;
+
+    // Modules
+    moduleResolutionMode = ModuleLoader.ResolutionMode.LEGACY;
 
     // Checks
     skipNonTranspilationPasses = false;
@@ -2646,6 +2652,14 @@ public class CompilerOptions {
   public CompilerOptions setEmitUseStrict(boolean emitUseStrict) {
     this.emitUseStrict = emitUseStrict;
     return this;
+  }
+
+  public ModuleLoader.ResolutionMode getModuleResolutionMode() {
+    return this.moduleResolutionMode;
+  }
+
+  public void setModuleResolutionMode(ModuleLoader.ResolutionMode mode) {
+    this.moduleResolutionMode = mode;
   }
 
   @Override

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -143,7 +143,9 @@ public class DiagnosticGroups {
 
   public static final DiagnosticGroup COMMON_JS_MODULE_LOAD =
       DiagnosticGroups.registerGroup(
-          "commonJsModuleLoad", ProcessCommonJSModules.COMMON_JS_MODULE_LOAD_ERROR);
+          "commonJsModuleLoad",
+          ProcessCommonJSModules.SUSPICIOUS_EXPORTS_ASSIGNMENT,
+          ProcessCommonJSModules.UNKNOWN_REQUIRE_ENSURE);
 
   public static final DiagnosticGroup GLOBAL_THIS =
       DiagnosticGroups.registerGroup("globalThis",

--- a/src/com/google/javascript/jscomp/ExportTestFunctions.java
+++ b/src/com/google/javascript/jscomp/ExportTestFunctions.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.javascript.jscomp.parsing.parser.util.format.SimpleFormat;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
-
 import java.util.regex.Pattern;
 
 /**

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -43,10 +43,6 @@ public final class ProcessCommonJSModules implements CompilerPass {
   private static final String EXPORTS = "exports";
   private static final String MODULE = "module";
 
-  public static final DiagnosticType COMMON_JS_MODULE_LOAD_ERROR = DiagnosticType.error(
-      "JSC_COMMONJS_MODULE_LOAD_ERROR",
-      "Failed to load module \"{0}\"");
-
   public static final DiagnosticType UNKNOWN_REQUIRE_ENSURE =
       DiagnosticType.warning(
           "JSC_COMMONJS_UNKNOWN_REQUIRE_ENSURE_ERROR", "Unrecognized require.ensure call: {0}");
@@ -356,9 +352,16 @@ public final class ProcessCommonJSModules implements CompilerPass {
     /** Visit require calls. Emit corresponding goog.require call. */
     private void visitRequireCall(NodeTraversal t, Node require, Node parent) {
       String requireName = require.getSecondChild().getString();
-      ModulePath modulePath = t.getInput().getPath().resolveCommonJsModule(requireName);
+      ModulePath modulePath =
+          t.getInput()
+              .getPath()
+              .resolveJsModule(
+                  requireName,
+                  require.getSourceFileName(),
+                  require.getLineno(),
+                  require.getCharno());
       if (modulePath == null) {
-        compiler.report(t.makeError(require, COMMON_JS_MODULE_LOAD_ERROR, requireName));
+        // The module loader will issue an error
         return;
       }
 
@@ -700,9 +703,16 @@ public final class ProcessCommonJSModules implements CompilerPass {
      */
     private void visitRequireCall(NodeTraversal t, Node require, Node parent) {
       String requireName = require.getSecondChild().getString();
-      ModulePath modulePath = t.getInput().getPath().resolveCommonJsModule(requireName);
+      ModulePath modulePath =
+          t.getInput()
+              .getPath()
+              .resolveJsModule(
+                  requireName,
+                  require.getSourceFileName(),
+                  require.getLineno(),
+                  require.getCharno());
       if (modulePath == null) {
-        compiler.report(t.makeError(require, COMMON_JS_MODULE_LOAD_ERROR, requireName));
+        // The module loader will issue an error
         return;
       }
 
@@ -1192,7 +1202,11 @@ public final class ProcessCommonJSModules implements CompilerPass {
             && rValue.getSecondChild().isString()
             && t.getScope().getVar(rValue.getFirstChild().getQualifiedName()) == null) {
           String requireName = rValue.getSecondChild().getString();
-          ModulePath modulePath = t.getInput().getPath().resolveCommonJsModule(requireName);
+          ModulePath modulePath =
+              t.getInput()
+                  .getPath()
+                  .resolveJsModule(
+                      requireName, n.getSourceFileName(), n.getLineno(), n.getCharno());
           if (modulePath == null) {
             return null;
           }
@@ -1229,9 +1243,16 @@ public final class ProcessCommonJSModules implements CompilerPass {
           }
 
           String moduleName = name.substring(0, endIndex);
-          ModulePath modulePath = t.getInput().getPath().resolveCommonJsModule(moduleName);
+          ModulePath modulePath =
+              t.getInput()
+                  .getPath()
+                  .resolveJsModule(
+                      moduleName,
+                      typeNode.getSourceFileName(),
+                      typeNode.getLineno(),
+                      typeNode.getCharno());
           if (modulePath == null) {
-            t.makeError(typeNode, COMMON_JS_MODULE_LOAD_ERROR, moduleName);
+            // The module loader will issue an error
             return;
           }
 

--- a/src/com/google/javascript/jscomp/deps/JsFileParser.java
+++ b/src/com/google/javascript/jscomp/deps/JsFileParser.java
@@ -286,7 +286,11 @@ public final class JsFileParser extends JsFileLineParser {
           if (arg.startsWith("goog:")) {
             requires.add(arg.substring(5)); // cut off the "goog:" prefix
           } else {
-            requires.add(file.resolveEs6Module(arg).toModuleName());
+            ModuleLoader.ModulePath path = file.resolveJsModule(arg);
+            if (path == null) {
+              path = file.resolveModuleAsPath(arg);
+            }
+            requires.add(path.toModuleName());
           }
         }
       }

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -55,9 +55,8 @@ public final class ModuleLoader {
   /** The default module root, the current directory. */
   public static final String DEFAULT_FILENAME_PREFIX = "." + MODULE_SLASH;
 
-  public static final DiagnosticType LOAD_WARNING = DiagnosticType.warning(
-      "JSC_ES6_MODULE_LOAD_WARNING",
-      "Failed to load module \"{0}\"");
+  public static final DiagnosticType LOAD_WARNING =
+      DiagnosticType.warning("JSC_JS_MODULE_LOAD_WARNING", "Failed to load module \"{0}\"");
 
   @Nullable private final ErrorHandler errorHandler;
 
@@ -75,6 +74,8 @@ public final class ModuleLoader {
   /** Used to canonicalize paths before resolution. */
   private final PathResolver pathResolver;
 
+  private final ResolutionMode resolutionMode;
+
   /**
    * Creates an instance of the module loader which can be used to locate ES6 and CommonJS modules.
    *
@@ -84,7 +85,8 @@ public final class ModuleLoader {
       @Nullable ErrorHandler errorHandler,
       Iterable<String> moduleRoots,
       Iterable<? extends DependencyInfo> inputs,
-      PathResolver pathResolver) {
+      PathResolver pathResolver,
+      ResolutionMode resolutionMode) {
     checkNotNull(moduleRoots);
     checkNotNull(inputs);
     checkNotNull(pathResolver);
@@ -99,11 +101,31 @@ public final class ModuleLoader {
     this.packageJsonMainEntries = ImmutableMap.of();
 
     this.nodeModulesRegistry = buildRegistry(this.modulePaths);
+
+    this.resolutionMode = resolutionMode;
   }
 
-  public ModuleLoader(@Nullable ErrorHandler errorHandler,
-      Iterable<String> moduleRoots, Iterable<? extends DependencyInfo> inputs) {
-    this(errorHandler, moduleRoots, inputs, PathResolver.RELATIVE);
+  public ModuleLoader(
+      @Nullable ErrorHandler errorHandler,
+      Iterable<String> moduleRoots,
+      Iterable<? extends DependencyInfo> inputs,
+      ResolutionMode resolutionMode) {
+    this(errorHandler, moduleRoots, inputs, PathResolver.RELATIVE, resolutionMode);
+  }
+
+  public ModuleLoader(
+      @Nullable ErrorHandler errorHandler,
+      Iterable<String> moduleRoots,
+      Iterable<? extends DependencyInfo> inputs,
+      PathResolver pathResolver) {
+    this(errorHandler, moduleRoots, inputs, pathResolver, ResolutionMode.LEGACY);
+  }
+
+  public ModuleLoader(
+      @Nullable ErrorHandler errorHandler,
+      Iterable<String> moduleRoots,
+      Iterable<? extends DependencyInfo> inputs) {
+    this(errorHandler, moduleRoots, inputs, PathResolver.RELATIVE, ResolutionMode.LEGACY);
   }
 
   public Map<String, String> getPackageJsonMainEntries() {
@@ -120,6 +142,7 @@ public final class ModuleLoader {
    */
   public class ModulePath {
     private final String path;
+    private final String[] fileExtensionsToSearch = {"", ".js", ".json"};
 
     private ModulePath(String path) {
       this.path = path;
@@ -149,32 +172,97 @@ public final class ModuleLoader {
     }
 
     /**
-     * Find a CommonJS module {@code requireName}. See
+     * Find a JS module {@code requireName}. See
      * https://nodejs.org/api/modules.html#modules_all_together
      *
      * @return The normalized module URI, or {@code null} if not found.
      */
-    public ModulePath resolveCommonJsModule(String requireName) {
-      String loadAddress;
+    @Nullable
+    public ModulePath resolveJsModule(String moduleAddress) {
+      return resolveJsModule(moduleAddress, null, -1, -1);
+    }
+
+    /**
+     * Find a JS module {@code requireName}. See
+     * https://nodejs.org/api/modules.html#modules_all_together
+     *
+     * @return The normalized module URI, or {@code null} if not found.
+     */
+    @Nullable
+    public ModulePath resolveJsModule(
+        String moduleAddress, String sourcename, int lineno, int colno) {
+      String loadAddress = null;
 
       // * the immediate name require'd
-      if (isAbsoluteIdentifier(requireName) || isRelativeIdentifier(requireName)) {
-        loadAddress = resolveCommonJsModuleFileOrDirectory(requireName);
-      } else {
-        loadAddress = resolveCommonJsModuleFromRegistry(requireName);
+      switch (resolutionMode) {
+        case LEGACY:
+          loadAddress = resolveJsModuleLegacy(moduleAddress, sourcename, lineno, colno);
+          break;
+
+        case BROWSER:
+          if (isAbsoluteIdentifier(moduleAddress) || isRelativeIdentifier(moduleAddress)) {
+            loadAddress = resolveJsModuleFile(moduleAddress);
+          }
+          break;
+
+        case NODE:
+          if (isAbsoluteIdentifier(moduleAddress) || isRelativeIdentifier(moduleAddress)) {
+            loadAddress = resolveJsModuleFileOrDirectory(moduleAddress);
+          } else {
+            loadAddress = resolveJsModuleFromRegistry(moduleAddress);
+          }
+          break;
       }
+
       if (loadAddress != null) {
         return new ModulePath(loadAddress);
       }
+
+      if (errorHandler != null) {
+        errorHandler.report(
+            CheckLevel.WARNING,
+            JSError.make(sourcename, lineno, colno, LOAD_WARNING, moduleAddress));
+      }
+
       return null;
     }
 
-    private String resolveCommonJsModuleFile(String requireName) {
-      String[] extensions = {"", ".js", ".json"};
+    /**
+     * Find a module using the old LEGACY method.
+     * @return The normalized module path.
+     */
+    private String resolveJsModuleLegacy(String moduleName, String sourcename, int lineno, int colno) {
+      // Allow module names with or without the ".js" extension.
+      if (!moduleName.endsWith(".js")) {
+        moduleName += ".js";
+      }
 
-      // Load as a file
-      for (int i = 0; i < extensions.length; i++) {
-        String loadAddress = locate(requireName + extensions[i]);
+      String path = ModuleNames.escapePath(moduleName);
+      if (isRelativeIdentifier(moduleName)) {
+        String ourPath = this.path;
+        int lastIndex = ourPath.lastIndexOf('/');
+        path = ModuleNames.canonicalizePath(ourPath.substring(0, lastIndex + 1) + path);
+      }
+
+      String resolved = normalize(path, moduleRootPaths);
+      if (!modulePaths.contains(resolved) && errorHandler != null) {
+        errorHandler.report(CheckLevel.WARNING, JSError.make(sourcename, lineno, colno, LOAD_WARNING, moduleName));
+      }
+      return resolved;
+    }
+
+    @Nullable
+    private String resolveJsModuleFile(String moduleAddress) {
+      // Edge is the only browser supporting modules currently and requires
+      // a file extension. This may be loosened as more browsers support
+      // ES2015 modules natively.
+      if (resolutionMode == ResolutionMode.BROWSER) {
+        return locate(moduleAddress);
+      }
+
+      // Load node module as a file
+      for (int i = 0; i < fileExtensionsToSearch.length; i++) {
+        String loadAddress = locate(moduleAddress + fileExtensionsToSearch[i]);
         if (loadAddress != null) {
           return loadAddress;
         }
@@ -183,26 +271,28 @@ public final class ModuleLoader {
       return null;
     }
 
-    private String resolveCommonJsModuleFileOrDirectory(String requireName) {
-      String loadAddress = resolveCommonJsModuleFile(requireName);
+    @Nullable
+    private String resolveJsModuleFileOrDirectory(String moduleAddress) {
+      String loadAddress = resolveJsModuleFile(moduleAddress);
       if (loadAddress == null) {
-        loadAddress = resolveCommonJsModuleDirectory(requireName);
+        loadAddress = resolveJsModuleDirectory(moduleAddress);
       }
       return loadAddress;
     }
 
-    private String resolveCommonJsModuleDirectory(String requireName) {
+    @Nullable
+    private String resolveJsModuleDirectory(String moduleAddress) {
       String[] extensions = {
         MODULE_SLASH + "package.json", MODULE_SLASH + "index.js", MODULE_SLASH + "index.json"
       };
 
       // Load as a file
       for (int i = 0; i < extensions.length; i++) {
-        String loadAddress = locate(requireName + extensions[i]);
+        String loadAddress = locate(moduleAddress + extensions[i]);
         if (loadAddress != null) {
           if (i == 0) {
             if (packageJsonMainEntries.containsKey(loadAddress)) {
-              return resolveCommonJsModuleFile(packageJsonMainEntries.get(loadAddress));
+              return resolveJsModuleFile(packageJsonMainEntries.get(loadAddress));
             }
           } else {
             return loadAddress;
@@ -213,7 +303,8 @@ public final class ModuleLoader {
       return null;
     }
 
-    private String resolveCommonJsModuleFromRegistry(String requireName) {
+    @Nullable
+    private String resolveJsModuleFromRegistry(String moduleAddress) {
       for (Map.Entry<String, ImmutableSet<String>> nodeModulesFolder :
           nodeModulesRegistry.entrySet()) {
         if (!this.path.startsWith(nodeModulesFolder.getKey())) {
@@ -221,14 +312,14 @@ public final class ModuleLoader {
         }
 
         // Load as a file
-        String fullModulePath = nodeModulesFolder.getKey() + "node_modules/" + requireName;
-        String loadAddress = resolveCommonJsModuleFile(fullModulePath);
+        String fullModulePath = nodeModulesFolder.getKey() + "node_modules/" + moduleAddress;
+        String loadAddress = resolveJsModuleFile(fullModulePath);
         if (loadAddress != null) {
           return loadAddress;
         }
 
         // Load as a directory
-        loadAddress = resolveCommonJsModuleDirectory(fullModulePath);
+        loadAddress = resolveJsModuleDirectory(fullModulePath);
         if (loadAddress != null) {
           return loadAddress;
         }
@@ -238,46 +329,42 @@ public final class ModuleLoader {
     }
 
     /**
-     * Find an ES6 module {@code moduleName} relative to {@code context}.
-     * @return The normalized module URI, or {@code null} if not found.
+     * Locates the module with the given name, but returns null if there is no JS file in the
+     * expected location.
      */
-    public ModulePath resolveEs6Module(String moduleName) {
-      // Allow module names with or without the ".js" extension.
-      if (!moduleName.endsWith(".js")) {
-        moduleName += ".js";
-      }
-      String resolved = locateNoCheck(moduleName);
-      if (!modulePaths.contains(resolved) && errorHandler != null) {
-        errorHandler.report(CheckLevel.WARNING, JSError.make(LOAD_WARNING, moduleName));
-      }
-      return new ModulePath(resolved);
-    }
-
-    /**
-     * Locates the module with the given name, but returns successfully even if
-     * there is no JS file corresponding to the returned URI.
-     */
-    private String locateNoCheck(String name) {
+    @Nullable
+    private String locate(String name) {
       String path = ModuleNames.escapePath(name);
       if (isRelativeIdentifier(name)) {
         String ourPath = this.path;
         int lastIndex = ourPath.lastIndexOf('/');
         path = ModuleNames.canonicalizePath(ourPath.substring(0, lastIndex + 1) + path);
       }
-      return normalize(path, moduleRootPaths);
-    }
-
-    /**
-     * Locates the module with the given name, but returns null if there is no JS
-     * file in the expected location.
-     */
-    @Nullable
-    private String locate(String name) {
-      String path = locateNoCheck(name);
+      path = normalize(path, moduleRootPaths);
       if (modulePaths.contains(path)) {
         return path;
       }
       return null;
+    }
+
+    /**
+     * Treats the module address as a path and returns the name of that module. Does not verify that
+     * there is actually a JS file at the provided URI.
+     *
+     * <p>Primarily used for per-file ES6 module transpilation
+     */
+    public ModulePath resolveModuleAsPath(String moduleAddress) {
+      if (!moduleAddress.endsWith(".js")) {
+        moduleAddress += ".js";
+      }
+      String path = ModuleNames.escapePath(moduleAddress);
+      if (isRelativeIdentifier(moduleAddress)) {
+        String ourPath = this.path;
+        int lastIndex = ourPath.lastIndexOf('/');
+        path = ModuleNames.canonicalizePath(ourPath.substring(0, lastIndex + 1) + path);
+      }
+      path = normalize(path, moduleRootPaths);
+      return new ModulePath(path);
     }
   }
 
@@ -370,6 +457,14 @@ public final class ModuleLoader {
     for (String modulePath : modulePaths) {
       String[] nodeModulesDirs = modulePath.split("/node_modules/");
       String parentPath = "";
+
+      if (nodeModulesDirs.length > 0 && nodeModulesDirs[0].startsWith("node_modules/")) {
+        if (!registry.containsKey(parentPath)) {
+          registry.put(parentPath, new HashSet<String>());
+        }
+        registry.get(parentPath).add("node_modules/");
+      }
+
       for (int i = 0; i < nodeModulesDirs.length - 1; i++) {
         if (i + 1 < nodeModulesDirs.length) {
           parentPath += nodeModulesDirs[i] + "/";
@@ -433,5 +528,16 @@ public final class ModuleLoader {
 
   /** A trivial module loader with no roots. */
   public static final ModuleLoader EMPTY =
-      new ModuleLoader(null, ImmutableList.<String>of(), ImmutableList.<DependencyInfo>of());
+      new ModuleLoader(
+          null,
+          ImmutableList.<String>of(),
+          ImmutableList.<DependencyInfo>of(),
+          ResolutionMode.LEGACY);
+
+  /** An enum used to specify what algorithm to use to locate non path-based modules */
+  public enum ResolutionMode {
+    BROWSER,
+    LEGACY,
+    NODE
+  }
 }

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -130,13 +130,13 @@ public final class CompilerTest extends TestCase {
         inputs, ImmutableList.of(ModuleIdentifier.forFile("/gin")));
 
     ErrorManager manager = compiler.getErrorManager();
-    if (manager.getErrorCount() > 0) {
-      String error = manager.getErrors()[0].toString();
+    if (manager.getWarningCount() > 0) {
+      String error = manager.getWarnings()[0].toString();
       assertTrue(
           "Unexpected error: " + error,
-          error.contains("Failed to load module \"missing\" at /gin.js"));
+          error.contains("Failed to load module \"missing.js\" at /gin.js"));
     }
-    assertEquals(1, manager.getErrorCount());
+    assertEquals(1, manager.getWarningCount());
   }
 
   private static String normalize(String path) {

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -617,10 +617,10 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setLanguageIn(LanguageMode.ECMASCRIPT6);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
-    test(options,
+    test(
+        options,
         new String[] {
-          "import {x} from 'i1'; alert(x);",
-          "export var x = 5;",
+          "import {x} from './i1'; alert(x);", "export var x = 5;",
         },
         new String[] {
           "goog.require('module$i1'); alert(module$i1.x);",
@@ -636,10 +636,10 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setLanguageIn(LanguageMode.ECMASCRIPT6);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
-    test(options,
+    test(
+        options,
         new String[] {
-          "import {x} from 'i2'; alert(x);",
-          "export var x = 5;",
+          "import {x} from './i2'; alert(x);", "export var x = 5;",
         },
         ModuleLoader.LOAD_WARNING);
   }

--- a/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessEs6ModulesTest.java
@@ -101,40 +101,40 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
   public void testImport() {
     testModules(
-        "import name from 'other'; use(name);",
+        "import name from './other'; use(name);",
         "goog.require('module$other'); use(module$other.default);");
 
-    testModules("import {n as name} from 'other';", "goog.require('module$other');");
+    testModules("import {n as name} from './other';", "goog.require('module$other');");
 
     testModules(
-        "import x, {f as foo, b as bar} from 'other'; use(x);",
-        "goog.require('module$other'); use(module$other.default);");
-
-    testModules(
-        "import {default as name} from 'other'; use(name);",
+        "import x, {f as foo, b as bar} from './other'; use(x);",
         "goog.require('module$other'); use(module$other.default);");
 
     testModules(
-        "import {class as name} from 'other'; use(name);",
+        "import {default as name} from './other'; use(name);",
+        "goog.require('module$other'); use(module$other.default);");
+
+    testModules(
+        "import {class as name} from './other'; use(name);",
         "goog.require('module$other'); use(module$other.class);");
   }
 
   public void testImport_missing() {
     setExpectParseWarningsThisTest();  // JSC_ES6_MODULE_LOAD_WARNING
     testModules(
-        "import name from 'does_not_exist'; use(name);",
+        "import name from './does_not_exist'; use(name);",
         "goog.require('module$does_not_exist'); use(module$does_not_exist.default);");
   }
 
   public void testImportStar() {
     testModules(
-        "import * as name from 'other'; use(name.foo);",
+        "import * as name from './other'; use(name.foo);",
         "goog.require('module$other'); use(module$other.foo)");
   }
 
   public void testTypeNodeRewriting() {
     testModules(
-        "import * as name from 'other'; /** @type {name.foo} */ var x;",
+        "import * as name from './other'; /** @type {name.foo} */ var x;",
         "goog.require('module$other');"
             + "/** @type {module$other.foo} */ var x$$module$testcode;");
   }
@@ -239,7 +239,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
   public void testImportAndExport() {
     testModules(
-        LINE_JOINER.join("import {name as n} from 'other';", "use(n);", "export {n as name};"),
+        LINE_JOINER.join("import {name as n} from './other';", "use(n);", "export {n as name};"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
@@ -250,9 +250,9 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testExportFrom() {
     testModules(
         LINE_JOINER.join(
-            "export {name} from 'other';",
-            "export {default} from 'other';",
-            "export {class} from 'other';"),
+            "export {name} from './other';",
+            "export {default} from './other';",
+            "export {class} from './other';"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
@@ -261,7 +261,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "module$testcode.class = module$other.class;"));
 
     testModules(
-        "export {a, b as c, d} from 'other';",
+        "export {a, b as c, d} from './other';",
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
@@ -270,7 +270,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "module$testcode.d = module$other.d;"));
 
     testModules(
-        "export {a as b, b as a} from 'other';",
+        "export {a as b, b as a} from './other';",
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
@@ -279,9 +279,9 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
     testModules(
         LINE_JOINER.join(
-            "export {default as a} from 'other';",
-            "export {a as a2, default as b} from 'other';",
-            "export {class as switch} from 'other';"),
+            "export {default as a} from './other';",
+            "export {a as a2, default as b} from './other';",
+            "export {class as switch} from './other';"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
@@ -343,7 +343,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testExtendImportedClass() {
     testModules(
         LINE_JOINER.join(
-            "import {Parent} from 'other';",
+            "import {Parent} from './other';",
             "class Child extends Parent {",
             "  /** @param {Parent} parent */",
             "  useParent(parent) {}",
@@ -357,7 +357,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
     testModules(
         LINE_JOINER.join(
-            "import {Parent} from 'other';",
+            "import {Parent} from './other';",
             "class Child extends Parent {",
             "  /** @param {./other.Parent} parent */",
             "  useParent(parent) {}",
@@ -371,7 +371,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
     testModules(
         LINE_JOINER.join(
-            "import {Parent} from 'other';",
+            "import {Parent} from './other';",
             "export class Child extends Parent {",
             "  /** @param {Parent} parent */",
             "  useParent(parent) {}",
@@ -443,7 +443,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testRenameTypedef() {
     testModules(
         LINE_JOINER.join(
-            "import 'other';", "/** @typedef {string|!Object} */", "export var UnionType;"),
+            "import './other';", "/** @typedef {string|!Object} */", "export var UnionType;"),
         LINE_JOINER.join(
             "goog.provide('module$testcode');",
             "goog.require('module$other');",
@@ -456,8 +456,8 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testRenameImportedReference() {
     testModules(
         LINE_JOINER.join(
-            "import {f} from 'other';",
-            "import {b as bar} from 'other';",
+            "import {f} from './other';",
+            "import {b as bar} from './other';",
             "f();",
             "function g() {",
             "  f();",
@@ -501,11 +501,11 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "module$testcode.x = x$$module$testcode"));
 
     testModules(
-        "import * as s from 'other'; goog.require('foo.bar');",
+        "import * as s from './other'; goog.require('foo.bar');",
         "goog.require('module$other'); goog.require('foo.bar');");
 
     testModules(
-        "goog.require('foo.bar'); import * as s from 'other';",
+        "goog.require('foo.bar'); import * as s from './other';",
         "goog.require('module$other'); goog.require('foo.bar'); ");
   }
 
@@ -529,14 +529,14 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
             "module$testcode.x = x$$module$testcode"));
 
     testModules(
-        "import * as s from 'other'; const bar = goog.require('foo.bar');",
+        "import * as s from './other'; const bar = goog.require('foo.bar');",
         LINE_JOINER.join(
             "goog.require('module$other');",
             "goog.require('foo.bar');",
             "const bar$$module$testcode = foo.bar;"));
 
     testModules(
-        "const bar = goog.require('foo.bar'); import * as s from 'other';",
+        "const bar = goog.require('foo.bar'); import * as s from './other';",
         LINE_JOINER.join(
             "goog.require('module$other');",
             "goog.require('foo.bar');",
@@ -553,18 +553,18 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
         LHS_OF_GOOG_REQUIRE_MUST_BE_CONST);
 
     testModules(
-        "import * as s from 'other'; var bar = goog.require('foo.bar');",
+        "import * as s from './other'; var bar = goog.require('foo.bar');",
         LHS_OF_GOOG_REQUIRE_MUST_BE_CONST);
 
     testModules(
-        "var bar = goog.require('foo.bar'); import * as s from 'other';",
+        "var bar = goog.require('foo.bar'); import * as s from './other';",
         LHS_OF_GOOG_REQUIRE_MUST_BE_CONST);
   }
 
   public void testGoogRequiresDestructuring_rewrite() {
     testModules(
         LINE_JOINER.join(
-            "import * as s from 'other';",
+            "import * as s from './other';",
             "const {foo, bar} = goog.require('some.name.space');",
             "use(foo, bar);"),
         LINE_JOINER.join(
@@ -578,14 +578,14 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
 
     testModules(
         LINE_JOINER.join(
-            "import * as s from 'other';",
+            "import * as s from './other';",
             "var {foo, bar} = goog.require('some.name.space');",
             "use(foo, bar);"),
         LHS_OF_GOOG_REQUIRE_MUST_BE_CONST);
 
     testModules(
         LINE_JOINER.join(
-            "import * as s from 'other';",
+            "import * as s from './other';",
             "let {foo, bar} = goog.require('some.name.space');",
             "use(foo, bar);"),
         LHS_OF_GOOG_REQUIRE_MUST_BE_CONST);
@@ -623,7 +623,7 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   public void testObjectDestructuringAndObjLitShorthand() {
     testModules(
         LINE_JOINER.join(
-            "import {f} from 'other';",
+            "import {f} from './other';",
             "const foo = 1;",
             "const {a, b} = f({foo});",
             "use(a, b);"),
@@ -638,11 +638,11 @@ public final class ProcessEs6ModulesTest extends CompilerTestCase {
   }
 
   public void testImportWithoutReferences() {
-    testModules("import 'other';", "goog.require('module$other');");
+    testModules("import './other';", "goog.require('module$other');");
     // GitHub issue #1819: https://github.com/google/closure-compiler/issues/1819
     // Need to make sure the order of the goog.requires matches the order of the imports.
     testModules(
-        "import 'other'; import 'yet_another';",
+        "import './other'; import './yet_another';",
         "goog.require('module$other'); goog.require('module$yet_another');");
   }
 

--- a/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
+++ b/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.rhino.Node;
 
 /** Unit tests for {@link RewriteJsonToModule} */
@@ -38,6 +39,7 @@ public final class RewriteJsonToModuleTest extends CompilerTestCase {
     CompilerOptions options = super.getOptions();
     // Trigger module processing after parsing.
     options.setProcessCommonJSModules(true);
+    options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
     return options;
   }
 

--- a/test/com/google/javascript/jscomp/deps/JsFileParserTest.java
+++ b/test/com/google/javascript/jscomp/deps/JsFileParserTest.java
@@ -207,7 +207,11 @@ public final class JsFileParserTest extends TestCase {
    */
   public void testParseEs6Module4() {
     ModuleLoader loader =
-        new ModuleLoader(null, ImmutableList.of("/foo"), ImmutableList.<DependencyInfo>of());
+        new ModuleLoader(
+            null,
+            ImmutableList.of("/foo"),
+            ImmutableList.<DependencyInfo>of(),
+            ModuleLoader.ResolutionMode.LEGACY);
 
     String contents = ""
         + "import './a';\n"

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -30,61 +30,48 @@ public final class ModuleLoaderTest extends TestCase {
 
   public void testWindowsAddresses() {
     ModuleLoader loader =
-        new ModuleLoader(null, ImmutableList.of("."), inputs("js\\a.js", "js\\b.js"));
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("js\\a.js", "js\\b.js"),
+            ModuleLoader.ResolutionMode.LEGACY);
     assertUri("js/a.js", loader.resolve("js\\a.js"));
-    assertUri("js/b.js", loader.resolve("js\\a.js").resolveEs6Module("./b"));
+    assertUri("js/b.js", loader.resolve("js\\a.js").resolveJsModule("./b"));
   }
 
-  public void testJsExtension() {
+  public void testJsExtensionLegacy() {
     ModuleLoader loader =
-        new ModuleLoader(null, ImmutableList.of("."), inputs("js/a.js", "js/b.js"));
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("js/a.js", "js/b.js"),
+            ModuleLoader.ResolutionMode.LEGACY);
     assertUri("js/a.js", loader.resolve("js/a.js"));
-    assertUri("js/b.js", loader.resolve("js/a.js").resolveEs6Module("./b"));
+    assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b"));
+    assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b.js"));
   }
 
-  public void testLocateCommonJs() throws Exception {
-    ModuleLoader loader = new ModuleLoader(
-        null, ImmutableList.of("."), inputs("A/index.js", "B/index.js", "app.js"));
+  public void testLocateJsLegacy() throws Exception {
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("A/index.js", "B/index.js", "app.js"),
+            ModuleLoader.ResolutionMode.LEGACY);
 
     CompilerInput inputA = input("A/index.js");
     CompilerInput inputB = input("B/index.js");
     CompilerInput inputApp = input("app.js");
     assertUri("A/index.js", loader.resolve("A/index.js"));
-    assertUri("A/index.js", loader.resolve("B/index.js").resolveCommonJsModule("../A"));
-    assertUri("A/index.js", loader.resolve("app.js").resolveCommonJsModule("./A"));
+    assertUri("A.js", loader.resolve("B/index.js").resolveJsModule("../A"));
+    assertUri("A/index.js", loader.resolve("B/index.js").resolveJsModule("../A/index"));
+    assertUri("A/index.js", loader.resolve("app.js").resolveJsModule("./A/index"));
+    assertUri("A/index.js", loader.resolve("app.js").resolveJsModule("A/index"));
+    assertUri("A/index.js", loader.resolve("folder/app.js").resolveJsModule("A/index"));
+    assertUri("index.js", loader.resolve("folder/app.js").resolveJsModule("index"));
   }
 
-  public void testNormalizeUris() throws Exception {
-    ModuleLoader loader = new ModuleLoader(null, ImmutableList.of("a", "b", "/c"), inputs());
-    assertUri("a.js", loader.resolve("a/a.js"));
-    assertUri("a.js", loader.resolve("a.js"));
-    assertUri("some.js", loader.resolve("some.js"));
-    assertUri("/x.js", loader.resolve("/x.js"));
-    assertUri("x-y.js", loader.resolve("x:y.js"));
-    assertUri("foo%20bar.js", loader.resolve("foo bar.js"));
-  }
-
-  public void testDuplicateUris() throws Exception {
-    try {
-      new ModuleLoader(null, ImmutableList.of("a", "b"), inputs("a/f.js", "b/f.js"));
-      fail("Expected error");
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage()).contains("Duplicate module path");
-    }
-  }
-
-  public void testCanonicalizePath() throws Exception {
-    assertEquals("a/b/c", ModuleNames.canonicalizePath("a/b/c"));
-    assertEquals("a/c", ModuleNames.canonicalizePath("a/b/../c"));
-    assertEquals("b/c", ModuleNames.canonicalizePath("a/b/../../b/c"));
-    assertEquals("c", ModuleNames.canonicalizePath("a/b/../../c"));
-    assertEquals("../a", ModuleNames.canonicalizePath("../a/b/.."));
-    assertEquals("/", ModuleNames.canonicalizePath("/a/b/../../.."));
-    assertEquals("/b", ModuleNames.canonicalizePath("/a/../../../b"));
-    assertEquals("/", ModuleNames.canonicalizePath("/a/.."));
-  }
-
-  public void testLocateCommonNodeModules() throws Exception {
+  public void testLocateNodeModuleLegacy() throws Exception {
     ImmutableList<CompilerInput> compilerInputs =
         inputs(
             "/A/index.js",
@@ -103,24 +90,229 @@ public final class ModuleLoaderTest extends TestCase {
             "/node_modules/B/package.json", "/node_modules/B/lib/b.js");
 
     ModuleLoader loader =
-        new ModuleLoader(null, (new ImmutableList.Builder<String>()).build(), compilerInputs);
+        new ModuleLoader(
+            null,
+            (new ImmutableList.Builder<String>()).build(),
+            compilerInputs,
+            ModuleLoader.ResolutionMode.LEGACY);
     loader.setPackageJsonMainEntries(packageJsonMainEntries);
 
-    assertUri("/A/index.js", loader.resolve("/foo.js").resolveCommonJsModule("/A"));
-    assertUri("/A/index.js", loader.resolve("/foo.js").resolveCommonJsModule("./A"));
-    assertUri("/A/index.json", loader.resolve("/foo.js").resolveCommonJsModule("/A/index.json"));
+    assertUri("/A.js", loader.resolve("/foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index.js"));
+    assertUri("/A.js", loader.resolve("/foo.js").resolveJsModule("./A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("./A/index.js"));
+    assertUri("/A.js", loader.resolve("/foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index"));
+    assertUri("/A/index.json.js", loader.resolve("/foo.js").resolveJsModule("/A/index.json"));
 
-    assertUri("/node_modules/A/index.js", loader.resolve("/foo.js").resolveCommonJsModule("A"));
-    assertUri(
-        "/node_modules/A/node_modules/A/index.json",
-        loader.resolve("/node_modules/A/foo.js").resolveCommonJsModule("A"));
+    assertUri("A.js", loader.resolve("/foo.js").resolveJsModule("A"));
+    assertUri("A.js", loader.resolve("/node_modules/A/foo.js").resolveJsModule("A"));
     assertUri(
         "/node_modules/A/foo.js",
-        loader.resolve("/node_modules/A/index.js").resolveCommonJsModule("./foo"));
+        loader.resolve("/node_modules/A/index.js").resolveJsModule("./foo"));
 
-    assertUri("/B/lib/b.js", loader.resolve("/app.js").resolveCommonJsModule("/B"));
+    assertUri("/B.js", loader.resolve("/app.js").resolveJsModule("/B"));
 
-    assertUri("/node_modules/B/lib/b.js", loader.resolve("/app.js").resolveCommonJsModule("B"));
+    assertUri("B.js", loader.resolve("/app.js").resolveJsModule("B"));
+  }
+
+  public void testJsExtensionNode() {
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("js/a.js", "js/b.js"),
+            ModuleLoader.ResolutionMode.NODE);
+    assertUri("js/a.js", loader.resolve("js/a.js"));
+    assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b"));
+    assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b.js"));
+  }
+
+  public void testLocateJsNode() throws Exception {
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("A/index.js", "B/index.js", "app.js"),
+            ModuleLoader.ResolutionMode.NODE);
+
+    CompilerInput inputA = input("A/index.js");
+    CompilerInput inputB = input("B/index.js");
+    CompilerInput inputApp = input("app.js");
+    assertUri("A/index.js", loader.resolve("A/index.js"));
+    assertUri("A/index.js", loader.resolve("B/index.js").resolveJsModule("../A"));
+    assertUri("A/index.js", loader.resolve("B/index.js").resolveJsModule("../A/index"));
+    assertUri("A/index.js", loader.resolve("app.js").resolveJsModule("./A/index"));
+    assertNull(loader.resolve("app.js").resolveJsModule("A/index"));
+    assertNull(loader.resolve("folder/app.js").resolveJsModule("A/index"));
+    assertNull(loader.resolve("folder/app.js").resolveJsModule("index"));
+  }
+
+  public void testLocateNodeModuleNode() throws Exception {
+    ImmutableList<CompilerInput> compilerInputs =
+        inputs(
+            "/A/index.js",
+            "/A/index.json",
+            "/node_modules/A/index.js",
+            "/node_modules/A/foo.js",
+            "/node_modules/A/node_modules/A/index.json",
+            "/B/package.json",
+            "/B/lib/b.js",
+            "/node_modules/B/package.json",
+            "/node_modules/B/lib/b.js");
+
+    ImmutableMap<String, String> packageJsonMainEntries =
+        ImmutableMap.of(
+            "/B/package.json", "/B/lib/b",
+            "/node_modules/B/package.json", "/node_modules/B/lib/b.js");
+
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            (new ImmutableList.Builder<String>()).build(),
+            compilerInputs,
+            ModuleLoader.ResolutionMode.NODE);
+    loader.setPackageJsonMainEntries(packageJsonMainEntries);
+
+    assertUri("/A/index.js", loader.resolve(" /foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index.js"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("./A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("./A/index.js"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index"));
+    assertUri("/A/index.json", loader.resolve("/foo.js").resolveJsModule("/A/index.json"));
+
+    assertUri("/node_modules/A/index.js", loader.resolve("/foo.js").resolveJsModule("A"));
+    assertUri(
+        "/node_modules/A/node_modules/A/index.json",
+        loader.resolve("/node_modules/A/foo.js").resolveJsModule("A"));
+    assertUri(
+        "/node_modules/A/foo.js",
+        loader.resolve("/node_modules/A/index.js").resolveJsModule("./foo"));
+
+    assertUri("/B/lib/b.js", loader.resolve("/app.js").resolveJsModule("/B"));
+
+    assertUri("/node_modules/B/lib/b.js", loader.resolve("/app.js").resolveJsModule("B"));
+  }
+
+  public void testJsExtensionBrowser() {
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("js/a.js", "js/b.js"),
+            ModuleLoader.ResolutionMode.BROWSER);
+    assertUri("js/a.js", loader.resolve("js/a.js"));
+    assertNull(loader.resolve("js/a.js").resolveJsModule("./b"));
+    assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b.js"));
+  }
+
+  public void testLocateJsBrowser() throws Exception {
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            ImmutableList.of("."),
+            inputs("A/index.js", "B/index.js", "app.js"),
+            ModuleLoader.ResolutionMode.BROWSER);
+
+    CompilerInput inputA = input("A/index.js");
+    CompilerInput inputB = input("B/index.js");
+    CompilerInput inputApp = input("app.js");
+    assertUri("A/index.js", loader.resolve("A/index.js"));
+    assertNull(loader.resolve("B/index.js").resolveJsModule("../A"));
+    assertNull(loader.resolve("B/index.js").resolveJsModule("../A/index"));
+    assertNull(loader.resolve("app.js").resolveJsModule("./A/index"));
+    assertNull(loader.resolve("app.js").resolveJsModule("A/index"));
+    assertNull(loader.resolve("folder/app.js").resolveJsModule("A/index"));
+    assertNull(loader.resolve("folder/app.js").resolveJsModule("index"));
+
+    assertNull(loader.resolve("B/index.js").resolveJsModule("../A"));
+    assertUri("A/index.js", loader.resolve("B/index.js").resolveJsModule("../A/index.js"));
+    assertUri("A/index.js", loader.resolve("app.js").resolveJsModule("./A/index.js"));
+    assertUri("A/index.js", loader.resolve("folder/app.js").resolveJsModule("../A/index.js"));
+    assertNull(loader.resolve("folder/app.js").resolveJsModule("index"));
+  }
+
+  public void testLocateNodeModuleBrowser() throws Exception {
+    ImmutableList<CompilerInput> compilerInputs =
+        inputs(
+            "/A/index.js",
+            "/A/index.json",
+            "/node_modules/A/index.js",
+            "/node_modules/A/foo.js",
+            "/node_modules/A/node_modules/A/index.json",
+            "/B/package.json",
+            "/B/lib/b.js",
+            "/node_modules/B/package.json",
+            "/node_modules/B/lib/b.js");
+
+    ImmutableMap<String, String> packageJsonMainEntries =
+        ImmutableMap.of(
+            "/B/package.json", "/B/lib/b",
+            "/node_modules/B/package.json", "/node_modules/B/lib/b.js");
+
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            (new ImmutableList.Builder<String>()).build(),
+            compilerInputs,
+            ModuleLoader.ResolutionMode.BROWSER);
+    loader.setPackageJsonMainEntries(packageJsonMainEntries);
+
+    assertNull(loader.resolve("/foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index.js"));
+    assertNull(loader.resolve("/foo.js").resolveJsModule("./A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("./A/index.js"));
+    assertNull(loader.resolve("/foo.js").resolveJsModule("/A"));
+    assertNull(loader.resolve("/foo.js").resolveJsModule("/A/index"));
+    assertUri("/A/index.json", loader.resolve("/foo.js").resolveJsModule("/A/index.json"));
+
+    assertNull(loader.resolve("/foo.js").resolveJsModule("A"));
+    assertNull(loader.resolve("/node_modules/A/foo.js").resolveJsModule("A"));
+    assertNull(loader.resolve("/node_modules/A/index.js").resolveJsModule("./foo"));
+    assertUri(
+        "/node_modules/A/foo.js",
+        loader.resolve("/node_modules/A/index.js").resolveJsModule("./foo.js"));
+
+    assertNull(loader.resolve("/app.js").resolveJsModule("/B"));
+
+    assertNull(loader.resolve("/app.js").resolveJsModule("B"));
+  }
+
+  public void testNormalizeUris() throws Exception {
+    ModuleLoader loader =
+        new ModuleLoader(
+            null, ImmutableList.of("a", "b", "/c"), inputs(), ModuleLoader.ResolutionMode.LEGACY);
+    assertUri("a.js", loader.resolve("a/a.js"));
+    assertUri("a.js", loader.resolve("a.js"));
+    assertUri("some.js", loader.resolve("some.js"));
+    assertUri("/x.js", loader.resolve("/x.js"));
+    assertUri("x-y.js", loader.resolve("x:y.js"));
+    assertUri("foo%20bar.js", loader.resolve("foo bar.js"));
+  }
+
+  public void testDuplicateUris() throws Exception {
+    try {
+      new ModuleLoader(
+          null,
+          ImmutableList.of("a", "b"),
+          inputs("a/f.js", "b/f.js"),
+          ModuleLoader.ResolutionMode.LEGACY);
+      fail("Expected error");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).contains("Duplicate module path");
+    }
+  }
+
+  public void testCanonicalizePath() throws Exception {
+    assertEquals("a/b/c", ModuleNames.canonicalizePath("a/b/c"));
+    assertEquals("a/c", ModuleNames.canonicalizePath("a/b/../c"));
+    assertEquals("b/c", ModuleNames.canonicalizePath("a/b/../../b/c"));
+    assertEquals("c", ModuleNames.canonicalizePath("a/b/../../c"));
+    assertEquals("../a", ModuleNames.canonicalizePath("../a/b/.."));
+    assertEquals("/", ModuleNames.canonicalizePath("/a/b/../../.."));
+    assertEquals("/b", ModuleNames.canonicalizePath("/a/../../../b"));
+    assertEquals("/", ModuleNames.canonicalizePath("/a/.."));
   }
 
   ImmutableList<CompilerInput> inputs(String... names) {
@@ -129,6 +321,53 @@ public final class ModuleLoaderTest extends TestCase {
       builder.add(input(name));
     }
     return builder.build();
+  }
+
+  public void testLocateNodeModulesNoLeadingSlash() throws Exception {
+    ImmutableList<CompilerInput> compilerInputs =
+        inputs(
+            "/A/index.js",
+            "/A/index.json",
+            "node_modules/A/index.js",
+            "node_modules/A/foo.js",
+            "node_modules/A/node_modules/A/index.json",
+            "/B/package.json",
+            "/B/lib/b.js",
+            "node_modules/B/package.json",
+            "node_modules/B/lib/b.js");
+
+    ImmutableMap<String, String> packageJsonMainEntries =
+        ImmutableMap.of(
+            "/B/package.json", "/B/lib/b",
+            "node_modules/B/package.json", "node_modules/B/lib/b.js");
+
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            (new ImmutableList.Builder<String>()).build(),
+            compilerInputs,
+            ModuleLoader.ResolutionMode.NODE);
+    loader.setPackageJsonMainEntries(packageJsonMainEntries);
+
+    assertUri("/A/index.js", loader.resolve(" /foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index.js"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("./A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("./A/index.js"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A"));
+    assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index"));
+    assertUri("/A/index.json", loader.resolve("/foo.js").resolveJsModule("/A/index.json"));
+
+    assertUri("node_modules/A/index.js", loader.resolve("/foo.js").resolveJsModule("A"));
+    assertUri(
+        "node_modules/A/node_modules/A/index.json",
+        loader.resolve("node_modules/A/foo.js").resolveJsModule("A"));
+    assertUri(
+        "node_modules/A/foo.js",
+        loader.resolve("node_modules/A/index.js").resolveJsModule("./foo"));
+
+    assertUri("/B/lib/b.js", loader.resolve("/app.js").resolveJsModule("/B"));
+
+    assertUri("node_modules/B/lib/b.js", loader.resolve("/app.js").resolveJsModule("B"));
   }
 
   CompilerInput input(String name) {


### PR DESCRIPTION
Adds a `--module_resolution` flag to allow users to opt-out of loading from node_modules registries. However the path-based algorithm still follows the node module loading spec with regard to file extension priority and utilizing package.json file main enteries for directories.

Adds JSON file support if any module processing is enabled.

Note that the JSParser attempts to resolve ES6 module paths and issue loading errors. This seems strange because similar functionality exists in the ProcessEs6Modules pass (which seems more appropriate). I'm not sure why this logic exists in the parser, but I didn't want to move that until I understood the implications.

Fixes #1897 - any file extension is now allowed for either CommonJS or ES6 modules