### PR TITLE
Fixing angular's $q.Promise.finally externs

### DIFF
--- a/contrib/externs/angular-1.5-q_templated.js
+++ b/contrib/externs/angular-1.5-q_templated.js
@@ -71,9 +71,11 @@ angular.$q.Promise.prototype.catch = function(callback) {};
 
 /**
  * @param {?function(?)} callback
+ * @param {?(function(?): ?)=} opt_notifyCallback
  * @return {!angular.$q.Promise.<T>}
  */
-angular.$q.Promise.prototype.finally = function(callback) {};
+angular.$q.Promise.prototype.finally = 
+    function(callback, opt_notifyCallback) {};
 
 /**
  * @constructor


### PR DESCRIPTION
Externs for .finally() is missing the second argument for notifyCallback