### PR TITLE
Copy JSDoc annotations during CommonJS module rewriting

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -898,22 +898,35 @@ public final class ProcessCommonJSModules implements CompilerPass {
           if (newNameIsQualified) {
             // Refactor a var declaration to a getprop assignment
             Node getProp = NodeUtil.newQName(compiler, newName, nameRef, originalName);
+            JSDocInfo info = parent.getJSDocInfo();
+            if (info != null) {
+              parent.setJSDocInfo(null);
+              getProp.setJSDocInfo(info);
+            }
+
             if (nameRef.hasChildren()) {
               Node expr =
                   IR.exprResult(IR.assign(getProp, nameRef.getFirstChild().detachFromParent()))
                       .useSourceInfoIfMissingFromForTree(nameRef);
               parent.getParent().replaceChild(parent, expr);
             } else {
-              parent.getParent().replaceChild(parent, getProp);
+              parent.getParent().replaceChild(parent, IR.exprResult(getProp).useSourceInfoFrom(getProp));
             }
           } else if (newNameDeclaration != null) {
             // Variable is already defined. Convert this to an assignment.
             Node name = NodeUtil.newName(compiler, newName, nameRef, originalName);
+            Node assign = IR.assign(name, nameRef.getFirstChild().detachFromParent());
+            JSDocInfo info = parent.getJSDocInfo();
+            if (info != null) {
+              parent.setJSDocInfo(null);
+              assign.setJSDocInfo(info);
+            }
+
             parent
                 .getParent()
                 .replaceChild(
                     parent,
-                    IR.exprResult(IR.assign(name, nameRef.getFirstChild().detachFromParent()))
+                    IR.exprResult(assign)
                         .useSourceInfoFromForTree(nameRef));
           } else {
             nameRef.setString(newName);
@@ -921,36 +934,28 @@ public final class ProcessCommonJSModules implements CompilerPass {
           }
           break;
 
-        case GETPROP:
-          {
-            Node name =
-                newNameIsQualified
-                    ? NodeUtil.newQName(compiler, newName, nameRef, originalName)
-                    : NodeUtil.newName(compiler, newName, nameRef, originalName);
-            parent.replaceChild(nameRef, name);
-            moveChildrenToNewNode(nameRef, name);
-
-            break;
-        }
         default:
           {
             Node name =
                 newNameIsQualified
                     ? NodeUtil.newQName(compiler, newName, nameRef, originalName)
                     : NodeUtil.newName(compiler, newName, nameRef, originalName);
+
+            JSDocInfo info = nameRef.getJSDocInfo();
+            if (info != null) {
+              nameRef.setJSDocInfo(null);
+              name.setJSDocInfo(info);
+            }
             parent.replaceChild(nameRef, name);
-            moveChildrenToNewNode(nameRef, name);
+            if (nameRef.hasChildren()) {
+              name.addChildrenToFront(nameRef.removeChildren());
+            }
+
             break;
           }
       }
 
       compiler.reportCodeChange();
-    }
-
-    private void moveChildrenToNewNode(Node oldNode, Node newNode) {
-      while (oldNode.hasChildren()) {
-        newNode.addChildToBack(oldNode.getFirstChild().detachFromParent());
-      }
     }
 
     /**

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -486,4 +486,19 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "const {foo, bar} = module$other;",
             "var baz = module$other.foo + module$other.bar;"));
   }
+
+  public void testAnnotationsCopied() {
+    setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6, CompilerOptions.LanguageMode.ECMASCRIPT5);
+    setFilename("test");
+    testModules(
+        LINE_JOINER.join(
+            "/** @interface */ var a;",
+            "/** @type {string} */ a.prototype.foo;",
+            "module.exports.a = a;"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "/** @const */ var module$test = {};",
+            "/** @interface */ module$test.a;",
+            "/** @type {string} */ module$test.a.prototype.foo;"));
+  }
 }


### PR DESCRIPTION
JSDoc info was being lost during module rewriting. This change moves any JSDoc to the new rewritten nodes.