### PR TITLE
Treat any type annotation with a `/` character as a module reference

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -1101,7 +1101,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
       if (typeNode.isString()) {
         String name = typeNode.getString();
         // Type nodes can be module paths.
-        if (ModuleLoader.isRelativeIdentifier(name) || ModuleLoader.isAbsoluteIdentifier(name)) {
+        if (ModuleLoader.isPathIdentifier(name)) {
           int lastSlash = name.lastIndexOf('/');
           int endIndex = name.indexOf('.', lastSlash);
           String localTypeName = null;

--- a/src/com/google/javascript/jscomp/ProcessEs6Modules.java
+++ b/src/com/google/javascript/jscomp/ProcessEs6Modules.java
@@ -528,7 +528,7 @@ public final class ProcessEs6Modules extends AbstractPostOrderCallback {
     private void fixTypeNode(NodeTraversal t, Node typeNode) {
       if (typeNode.isString()) {
         String name = typeNode.getString();
-        if (ModuleLoader.isRelativeIdentifier(name) || ModuleLoader.isAbsoluteIdentifier(name)) {
+        if (ModuleLoader.isPathIdentifier(name)) {
           int lastSlash = name.lastIndexOf('/');
           int endIndex = name.indexOf('.', lastSlash);
           String localTypeName = null;

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -297,6 +297,9 @@ public final class ModuleLoader {
     return name.startsWith(MODULE_SLASH);
   }
 
+  /** Whether name is a path-based identifier (has a '/' character) */
+  public static boolean isPathIdentifier(String name) { return name.contains(MODULE_SLASH); }
+
   private static ImmutableList<String> createRootPaths(
       Iterable<String> roots, PathResolver resolver) {
     ImmutableList.Builder<String> builder = ImmutableList.builder();


### PR DESCRIPTION
Goes along (but does not require) #2094  and #2130.

When updating type node annotations during module rewriting, treat any type name with a `/` as a module identifier. Needed for named modules loaded from a registry.

Example `/** @type {!page/index.Context} */`