### PR TITLE
Unbreak the Travis build. Fixes #2154

### DIFF
--- a/pom-gwt.xml
+++ b/pom-gwt.xml
@@ -102,6 +102,20 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <!-- See <dependencyManagement> in pom.xml for <version> -->
+      <scope>test</scope>
+    </dependency>
+
     <!-- Ant is a provided scope as it is only needed to compile; ant will provide itself when using the jar -->
     <dependency>
       <groupId>org.apache.ant</groupId>
@@ -223,8 +237,12 @@
             <exclude>**/gwt/super/**</exclude>
             <exclude>**/super/**</exclude>
             <exclude>**/testing/**</exclude>
+            <exclude>**/transpile/**</exclude>
             <exclude>**/webservice/**</exclude>
           </excludes>
+          <testExcludes>
+            <testExclude>**/transpile/**</testExclude>
+          </testExcludes>
         </configuration>
       </plugin>
 

--- a/src/com/google/JsComp.gwt.xml
+++ b/src/com/google/JsComp.gwt.xml
@@ -20,7 +20,7 @@
   <inherits name="com.google.common.io.Io"/>
   <inherits name="com.google.gwt.json.JSON"/>
   <source path="debugging/sourcemap"/>
-  <source path="javascript/jscomp" excludes=".svn,.git,**/ant/**,**/refactoring/**,**/webservice/**,**/testing/**,**/linker/**"/>
+  <source path="javascript/jscomp" excludes=".svn,.git,**/ant/**,**/refactoring/**,**/webservice/**,**/testing/**,**/transpile/**,**/linker/**"/>
   <source path="javascript/rhino" excludes=".svn,.git,**/testing/**"/>
   <super-source path="javascript/jscomp/gwt/super"/>
   <super-source path="debugging/sourcemap/super"/>


### PR DESCRIPTION
Add missing deps and exclude the transpiile/ package from being compiled
with GWT (for now, though we may make some tweaks so it becomes
GWT-compatible later).