### PR TITLE
Update Mockito version to 2.2.19

### DIFF
--- a/pom-gwt.xml
+++ b/pom-gwt.xml
@@ -104,8 +104,8 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.2.19</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom-main.xml
+++ b/pom-main.xml
@@ -126,8 +126,8 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.2.19</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Mockito 2 should be fully compatible with the current code base and is up-to-date for more recent Java versions.