### PR TITLE
Fix asssorted compiler internal errors

### DIFF
--- a/src/com/google/javascript/jscomp/NewTypeInference.java
+++ b/src/com/google/javascript/jscomp/NewTypeInference.java
@@ -3213,7 +3213,9 @@ final class NewTypeInference implements CompilerPass {
           // retain Namespace instances after GTI instead of turning them into
           // ObjectTypes, and then update those with the summaries and stop
           // specializing here.
-          env = envPutType(env, objName, objType.withProperty(props, type));
+          if (objType != null) {
+            env = envPutType(env, objName, objType.withProperty(props, type));
+          }
         }
         return env;
       }

--- a/src/com/google/javascript/jscomp/newtypes/FunctionType.java
+++ b/src/com/google/javascript/jscomp/newtypes/FunctionType.java
@@ -114,7 +114,10 @@ public final class FunctionType {
       Preconditions.checkState(!formal.isBottom());
     }
     Preconditions.checkState(restFormals == null || !restFormals.isBottom());
-    Preconditions.checkNotNull(returnType);
+
+    if (!isLoose()) {
+      Preconditions.checkNotNull(returnType);
+    }
   }
 
   JSTypes getCommonTypes() {
@@ -970,24 +973,28 @@ public final class FunctionType {
       }
     }
     FunctionTypeBuilder builder = new FunctionTypeBuilder(this.commonTypes);
-    for (JSType reqFormal : this.requiredFormals) {
-      builder.addReqFormal(reqFormal.substituteGenerics(reducedMap));
+    if (!isTopFunction()) {
+      for (JSType reqFormal : this.requiredFormals) {
+        builder.addReqFormal(reqFormal.substituteGenerics(reducedMap));
+      }
+      for (JSType optFormal : this.optionalFormals) {
+        builder.addOptFormal(optFormal.substituteGenerics(reducedMap));
+      }
+      if (this.restFormals != null) {
+        builder.addRestFormals(restFormals.substituteGenerics(reducedMap));
+      }
+      builder.addRetType(this.returnType.substituteGenerics(reducedMap));
     }
-    for (JSType optFormal : this.optionalFormals) {
-      builder.addOptFormal(optFormal.substituteGenerics(reducedMap));
-    }
-    if (this.restFormals != null) {
-      builder.addRestFormals(restFormals.substituteGenerics(reducedMap));
-    }
-    builder.addRetType(this.returnType.substituteGenerics(reducedMap));
     if (isLoose()) {
       builder.addLoose();
     }
     builder.addNominalType(substGenericsInNomType(this.nominalType, typeMap));
     builder.addReceiverType(substGenericsInNomType(this.receiverType, typeMap));
     // TODO(blickly): Do we need instatiation here?
-    for (String var : this.outerVarPreconditions.keySet()) {
-      builder.addOuterVarPrecondition(var, this.outerVarPreconditions.get(var));
+    if (!isTopFunction()) {
+      for (String var : this.outerVarPreconditions.keySet()) {
+        builder.addOuterVarPrecondition(var, this.outerVarPreconditions.get(var));
+      }
     }
     builder.addTypeParameters(this.typeParameters);
     return builder.buildFunction();
@@ -998,16 +1005,18 @@ public final class FunctionType {
       return this;
     }
     FunctionTypeBuilder builder = new FunctionTypeBuilder(this.commonTypes);
-    for (JSType reqFormal : this.requiredFormals) {
-      builder.addReqFormal(reqFormal.substituteGenerics(typeMap));
+    if (!isTopFunction()) {
+      for (JSType reqFormal : this.requiredFormals) {
+        builder.addReqFormal(reqFormal.substituteGenerics(typeMap));
+      }
+      for (JSType optFormal : this.optionalFormals) {
+        builder.addOptFormal(optFormal.substituteGenerics(typeMap));
+      }
+      if (this.restFormals != null) {
+        builder.addRestFormals(restFormals.substituteGenerics(typeMap));
+      }
+      builder.addRetType(this.returnType.substituteGenerics(typeMap));
     }
-    for (JSType optFormal : this.optionalFormals) {
-      builder.addOptFormal(optFormal.substituteGenerics(typeMap));
-    }
-    if (this.restFormals != null) {
-      builder.addRestFormals(restFormals.substituteGenerics(typeMap));
-    }
-    builder.addRetType(this.returnType.substituteGenerics(typeMap));
     if (isLoose()) {
       builder.addLoose();
     }

--- a/src/com/google/javascript/jscomp/newtypes/JSType.java
+++ b/src/com/google/javascript/jscomp/newtypes/JSType.java
@@ -374,6 +374,9 @@ public abstract class JSType implements TypeI, FunctionTypeI, ObjectTypeI {
     if (isUnknown()) {
       return false;
     }
+    if (isBottom()) {
+      return false;
+    }
     Preconditions.checkState(!getObjs().isEmpty(),
         "Expected object type but found %s", this);
     for (ObjectType objType : getObjs()) {


### PR DESCRIPTION
I am hoping you might consider this pull request, which proposes fixes for various internal compiler errors I noticed when I switched on _newTypeInference_ when using a project that includes [react](https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-with-addons.js) and [react-dom](https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-dom.js) sources.  

I did up a demo github project [/rgpower/nti-fixes-demo](https://github.com/rgpower/nti-fixes-demo) that you can err... check out to see the fixes in action and provides a README which describes the motivations for each change.

Thanks for your time, and for the closure-compiler.
