### PR TITLE
Allow trailing comma in Array Pattern

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -3578,10 +3578,6 @@ public class Parser {
         } else if (peek(TokenType.COMMA)) {
           // Consume the comma separator
           eat(TokenType.COMMA);
-          if (peek(TokenType.CLOSE_SQUARE)) {
-            reportError("Array pattern may not end with a comma");
-            break;
-          }
         } else {
           // Otherwise we must be done
           break;

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -1400,13 +1400,6 @@ public final class ParserTest extends BaseJSTypeTestCase {
         "Only an identifier or destructuring pattern is allowed here.");
   }
 
-  public void testArrayDestructuringTrailingComma() {
-    mode = LanguageMode.ECMASCRIPT6;
-    strictMode = SLOPPY;
-    expectFeatures(Feature.DESTRUCTURING, Feature.TRAILING_COMMA);
-    parseError("var [x,] = ['x',];", "Array pattern may not end with a comma");
-  }
-
   public void testArrayDestructuringDeclarationRest() {
     mode = LanguageMode.ECMASCRIPT6;
     strictMode = SLOPPY;


### PR DESCRIPTION
It's allowed by ECMAScript 2015 spec.
See "13.3.3 Destructuring Binding Patterns".

The check was added in b0e9123ac763defb149359a9a99f8645b4b07977.
Are there any reasons why it should be there?