### PR TITLE
Supporting `@struct` annotation for `@typedef` in NTI

### DIFF
--- a/src/com/google/javascript/jscomp/GlobalTypeInfo.java
+++ b/src/com/google/javascript/jscomp/GlobalTypeInfo.java
@@ -1006,7 +1006,7 @@ class GlobalTypeInfo implements CompilerPass, TypeIRegistry {
         return;
       }
       JSDocInfo jsdoc = NodeUtil.getBestJSDocInfo(qnameNode);
-      Typedef td = Typedef.make(jsdoc.getTypedefType());
+      Typedef td = Typedef.make(jsdoc.getTypedefType(), jsdoc.makesStructs());
       currentScope.addTypedef(qnameNode, td);
     }
 

--- a/src/com/google/javascript/jscomp/newtypes/JSTypeCreatorFromJSDoc.java
+++ b/src/com/google/javascript/jscomp/newtypes/JSTypeCreatorFromJSDoc.java
@@ -116,6 +116,11 @@ public final class JSTypeCreatorFromJSDoc {
         "JSC_NTI_CIRCULAR_TYPEDEF_ENUM",
         "Circular typedefs/enums are not allowed");
 
+  public static final DiagnosticType COMPLEX_TYPEDEF_STRUCT =
+    DiagnosticType.warning(
+        "JSC_NTI_COMPLEX_TYPEDEF_STRUCT",
+        "Typedefs with struct are only allowed for simple record types");
+
   public static final DiagnosticType ENUM_WITH_TYPEVARS =
     DiagnosticType.warning(
         "JSC_NTI_ENUM_WITH_TYPEVARS",
@@ -168,6 +173,7 @@ public final class JSTypeCreatorFromJSDoc {
   public static final DiagnosticGroup COMPATIBLE_DIAGNOSTICS = new DiagnosticGroup(
       BAD_ARRAY_TYPE_SYNTAX,
       CIRCULAR_TYPEDEF_ENUM,
+      COMPLEX_TYPEDEF_STRUCT,
       CONFLICTING_EXTENDED_TYPE,
       CONFLICTING_IMPLEMENTED_TYPE,
       EXTENDS_NON_INTERFACE,
@@ -478,6 +484,15 @@ public final class JSTypeCreatorFromJSDoc {
       tdType = this.commonTypes.UNKNOWN;
     } else {
       tdType = getTypeFromJSTypeExpression(texp, registry, null);
+      if (td.isStruct()) {
+        if (tdType.isSingletonObj()) {
+          ObjectType ot = tdType.getObjTypeIfSingletonObj().withObjectKind(ObjectKind.STRUCT);
+          tdType = JSType.fromObjectType(ot);
+        } else {
+          warnings.add(JSError.make(
+              td.getTypeExprForErrorReporting().getRoot(), COMPLEX_TYPEDEF_STRUCT));
+        }
+      }
     }
     td.resolveTypedef(tdType);
   }

--- a/src/com/google/javascript/jscomp/newtypes/ObjectType.java
+++ b/src/com/google/javascript/jscomp/newtypes/ObjectType.java
@@ -270,6 +270,13 @@ final class ObjectType implements TypeWithProperties {
         this.commonTypes, this.nominalType, newProps, fn, null, true, this.objectKind);
   }
 
+  ObjectType withObjectKind(ObjectKind ok) {
+    Preconditions.checkState(this.objectKind.isUnrestricted());
+    return makeObjectType(
+        this.commonTypes, this.nominalType, this.props,
+        this.fn, this.ns, this.isLoose, ok);
+  }
+
   ObjectType withFunction(FunctionType ft, NominalType fnNominal) {
     Preconditions.checkState(this.isNamespace());
     Preconditions.checkState(!ft.isLoose() || ft.isQmarkFunction());
@@ -638,6 +645,16 @@ final class ObjectType implements TypeWithProperties {
     }
     if (!arePropertiesSubtypes(other, otherPropNames, subSuperMap, boxedInfo)) {
       return false;
+    }
+    
+    if (otherNt.isBuiltinObject() && other.isStruct()) {
+      if (!otherPropNames.containsAll(this.props.keySet())) {
+        return false;
+      }
+      if (!otherPropNames.containsAll(thisNt.getAllOwnClassProps())) {
+        // also verify assigning a nominal type to a struct typedef
+        return false;
+      }
     }
 
     if (other.fn == null) {

--- a/src/com/google/javascript/jscomp/newtypes/Typedef.java
+++ b/src/com/google/javascript/jscomp/newtypes/Typedef.java
@@ -35,18 +35,20 @@ public final class Typedef {
   private State state;
   private JSTypeExpression typeExpr;
   private JSType type;
+  private final boolean struct;
 
-  private Typedef(JSTypeExpression typeExpr) {
+  private Typedef(JSTypeExpression typeExpr, boolean struct) {
     Preconditions.checkNotNull(typeExpr);
     this.state = State.NOT_RESOLVED;
     // Non-null iff the typedef is resolved
     this.type = null;
     // Non-null iff the typedef is not resolved
     this.typeExpr = typeExpr;
+    this.struct = struct;
   }
 
-  public static Typedef make(JSTypeExpression typeExpr) {
-    return new Typedef(typeExpr);
+  public static Typedef make(JSTypeExpression typeExpr, boolean struct) {
+    return new Typedef(typeExpr, struct);
   }
 
   public boolean isResolved() {
@@ -83,5 +85,9 @@ public final class Typedef {
     state = State.RESOLVED;
     typeExpr = null;
     type = t;
+  }
+  
+  boolean isStruct() {
+    return struct;
   }
 }

--- a/src/com/google/javascript/rhino/JSDocInfoBuilder.java
+++ b/src/com/google/javascript/rhino/JSDocInfoBuilder.java
@@ -974,7 +974,8 @@ public final class JSDocInfoBuilder {
    * if it was already defined or it was incompatible with the existing flags
    */
   public boolean recordStruct() {
-    if (hasAnySingletonTypeTags()
+    // typedef is now compatible with struct:
+    if ((hasAnySingletonTypeTags() && !currentInfo.hasTypedefType())
         || currentInfo.makesDicts() || currentInfo.makesStructs()
         || currentInfo.makesUnrestricted()) {
       return false;


### PR DESCRIPTION
Generating an NTI warning if there are additional unknown properties.

This is a first attempt to solve a requirement of mine and other users - the ability to defined a restricted typedef such that unknown properties generate warnings. This is needed for at least 2 real-world cases of mine:

1. Using React with Closure Compiler, where the createElement takes a props object which we type in externs using a typedef. 
2. Using object literals to rapidly build new instances of types without using classes and the syntactic overhead of designing, instantiating and configuring them.

In both cases a typo in the properties will go undetected without this PR. Here's a React example, showing this PR's approach of annotationg the `@typedef` with `@struct`:
``` javascript
/**
 * @struct @typedef {{
 *      opt: (number|undefined),
 *      mand: string
 * }}
 */
var PropTypeDef;

/** @extends {React.Component<PropTypeDef>} */
class TestPropTypes extends React.Component {
    constructor(props) {
        super(props);
    }
}

// JSX conversion result of <TestPropTypes opt={5} mand="a" bad={true} />:
React.createElement(TestPropTypes, { 
    opt: 5, // can be omitted, but if present, the type must match (existing typecheck)
    mand: "a", // mandatory property, cannot be omitted (existing typecheck)
    bad: true // illegal property, e.g. typo (new typecheck)
});
```
with externs (simplified):
``` javascript
/**
 * @constructor
 * @template P
 * @param {P} props
 */
React.Component = function(props) {};

/** @constructor */
React.Element = function() {};

/**
 * @template PP
 * @param {!function(new:React.Component<PP>, PP)} tag
 * @param {?PP} props
 * @return {React.Element}
 */
React.createElement = function(tag, props) {};
```

In https://github.com/google/closure-compiler/issues/1804#issuecomment-221020830, @dimvar mentioned:

>  It's a grey area in the semantics and we haven't quite decided what we want to do there.

Unfortunately I could not wait, and have gone ahead with this change in a fork. I wanted to share it for others to see even if if is rejected. If you do think this approach (perhaps with some feedback) will be accepted, I'll rebase against the latest tip (this fork is against a month-old tip).

This PR addresses:
* https://github.com/google/closure-compiler/issues/1811
* https://github.com/google/closure-compiler/issues/1696

Also see 
* https://github.com/google/closure-compiler/issues/1804
* https://github.com/google/closure-compiler/issues/1150
