### PR TITLE
Expose the RenamePrefix compiler option as a command line argument.

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -623,6 +623,10 @@ public class CommandLineRunner extends
         handler = BooleanOptionHandler.class,
         usage = "Checks for type errors using the new type inference algorithm.")
     private boolean useNewTypeInference = false;
+    
+    @Option(name = "--rename_prefix",
+        usage = "Specifies a prefix that will be prepended to all variables.")
+    private String renamePrefix = null;
 
     @Option(name = "--rename_prefix_namespace",
         usage = "Specifies the name of an object that will be used to store all "
@@ -1609,6 +1613,8 @@ public class CommandLineRunner extends
             "Unknown J2clPassMode `" + flags.j2clPassMode + "' specified.");
       }
     }
+
+    options.renamePrefix = flags.renamePrefix;
 
     options.renamePrefixNamespace = flags.renamePrefixNamespace;
 


### PR DESCRIPTION
This allows for consumers of the closure compiler to set the renamePrefix compiler option from the command line interface. 