### PR TITLE
getComputedStyle returns a non-null value

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -896,7 +896,8 @@ BoxObject.prototype.width;
 /**
  * @param {Element} element
  * @param {?string=} pseudoElt
- * @return {CSSStyleDeclaration}
+ * @return {?CSSStyleDeclaration}
  * @nosideeffects
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=548397
  */
 function getComputedStyle(element, pseudoElt) {}

--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -914,8 +914,9 @@ function ViewCSS() {}
  * @param {?string=} opt_pseudoElt This argument is required according to the
  *     CSS2 specification, but optional in all major browsers. See the note at
  *     https://developer.mozilla.org/en-US/docs/Web/API/Window.getComputedStyle
- * @return {CSSStyleDeclaration}
+ * @return {?CSSStyleDeclaration}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSview-getComputedStyle
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=548397
  */
 ViewCSS.prototype.getComputedStyle = function(elt, opt_pseudoElt) {};
 


### PR DESCRIPTION
See:
https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle
https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-OverrideAndComputed
https://drafts.csswg.org/cssom/#extensions-to-the-window-interface