### PR TITLE
Add angular.$q.prototype.resolve definition to 1.5

### DIFF
--- a/contrib/externs/angular-1.5-q_templated.js
+++ b/contrib/externs/angular-1.5-q_templated.js
@@ -148,3 +148,10 @@ angular.$q.prototype.reject = function(opt_reason) {};
  * @template RESULT
  */
 angular.$q.prototype.when = function(value) {};
+
+/**
+ * @param {RESULT} value
+ * @return {!angular.$q.Promise.<RESULT>}
+ * @template RESULT
+ */
+angular.$q.prototype.resolve = function(value) {};


### PR DESCRIPTION
Per https://code.angularjs.org/1.5.9/docs/api/ng/service/$q, resolve is an alias of when so I just copied the definition here. For some reason, those typedefs do not include several optional parameters but I'll keep this change light just in case there's good reasons to have it like that.