### PR TITLE
Handle exceptions when a property can't be inherited

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/util/inherits.js
+++ b/src/com/google/javascript/jscomp/js/es6/util/inherits.js
@@ -62,7 +62,11 @@ $jscomp.inherits = function(childCtor, parentCtor) {
     if (Object.defineProperties) {
       var descriptor = Object.getOwnPropertyDescriptor(parentCtor, p);
       if (descriptor) {
-        Object.defineProperty(childCtor, p, descriptor);
+        try {
+          Object.defineProperty(childCtor, p, descriptor);
+        } catch (err) {
+          console.error('Property ' + p + ' can\'t be inherited: ' + err);
+        }
       }
     } else {
       // Pre-ES5 browser. Just copy with an assignment.


### PR DESCRIPTION
Prevent code from breaking on Safari with ```TypeError: Attempting to change attribute of unconfigurable property.```