### PR TITLE
Better definition of webkitPersistentStorage and webkitTemporaryStorage

### DIFF
--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -1003,3 +1003,16 @@ StorageQuota.prototype.requestQuota = function(size, opt_successCallback,
  */
 StorageQuota.prototype.queryUsageAndQuota = function(successCallback,
     opt_errorCallback) {};
+
+
+/**
+ * @type {!StorageQuota}
+ * @see https://developer.chrome.com/apps/offline_storage
+ */
+Navigator.prototype.webkitPersistentStorage;
+
+/**
+ * @type {!StorageQuota}
+ * @see https://developer.chrome.com/apps/offline_storage
+ */
+Navigator.prototype.webkitTemporaryStorage;

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -4165,30 +4165,6 @@ Navigator.prototype.plugins;
  */
 Navigator.prototype.javaEnabled = function() {};
 
-/**
- * @type {Object}
- */
-Navigator.prototype.webkitPersistentStorage;
-/**
- * @param {number} newQuotaInBytes
- * @param {!Function=} opt_quotaCallback
- * @param {!Function=} opt_errorCallback
- *
- * @return {undefined}
- * @see https://developer.chrome.com/apps/offline_storage#method_overview
- */
-Navigator.prototype.webkitPersistentStorage.requestQuota = function(
-    newQuotaInBytes, opt_quotaCallback, opt_errorCallback) {};
-
-/**
- * @param {!Function=} opt_successCallback
- * @param {!Function=} opt_errorCallback
- *
- * @return {undefined}
- * @see https://developer.chrome.com/apps/offline_storage#method_overview
- */
-Navigator.prototype.webkitPersistentStorage.queryUsageAndQuota = function(
-    opt_successCallback, opt_errorCallback) {};
 
 /**
  * @constructor


### PR DESCRIPTION
I had these methods defined on my own in my project but after the commit 3f385f8f7c4205ba6084aec7000b59d72e19632c I see errors like this:
```
Property queryUsageAndQuota never defined on navigator.webkitPersistentStorage of type Object
```

As you can see `StorageQuota` is well defined in [fileapi.js](https://github.com/google/closure-compiler/blob/master/externs/browser/fileapi.js#L984). Maybe these methods should be moved there but I know you don't like moving things between externs files. :)
