### PR TITLE
Optional useCapture parameter

### DIFF
--- a/externs/browser/w3c_event.js
+++ b/externs/browser/w3c_event.js
@@ -35,7 +35,7 @@ function EventTarget() {}
  *
  * @param {string} type
  * @param {EventListener|function(!Event):(boolean|undefined)} listener
- * @param {boolean} useCapture
+ * @param {boolean} [useCapture=false]
  * @return {undefined}
  */
 EventTarget.prototype.addEventListener = function(type, listener, useCapture)
@@ -44,7 +44,7 @@ EventTarget.prototype.addEventListener = function(type, listener, useCapture)
 /**
  * @param {string} type
  * @param {EventListener|function(!Event):(boolean|undefined)} listener
- * @param {boolean} useCapture
+ * @param {boolean} [useCapture=false]
  * @return {undefined}
  */
 EventTarget.prototype.removeEventListener = function(type, listener, useCapture)


### PR DESCRIPTION
According to the [W3C Spec](http://www.w3.org/TR/dom/#eventtarget), [mdn](https://developer.mozilla.org/hu/docs/Web/API/EventTarget) and web browser practices, the useCapture parameters of `addEventListener` and `removeEventListener` are optional, and their default value is false. This is an attempt with respect to fix the given extern file.

```
[Exposed=(Window,Worker)]
interface EventTarget {
  void addEventListener(DOMString type, EventListener? callback, optional boolean capture = false);
  void removeEventListener(DOMString type, EventListener? callback, optional boolean capture = false);
  boolean dispatchEvent(Event event);
};

callback interface EventListener {
  void handleEvent(Event event);
};
```