### PR TITLE
Prevent NO_TRANSPILE being set as input language

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1799,7 +1799,7 @@ public class CompilerOptions {
    * Sets ECMAScript version to use.
    */
   public void setLanguage(LanguageMode language) {
-    Preconditions.checkState(languageIn != LanguageMode.NO_TRANSPILE);
+    Preconditions.checkState(language != LanguageMode.NO_TRANSPILE);
     this.languageIn = language;
     this.languageOut = language;
   }


### PR DESCRIPTION
The #setLanguage(LanguageMode) method has a check that NO_TRANSPILE is not set as input language, but it checked the instance variable instead of checking the method parameter.