### PR TITLE
Add basic support for Polymer2 elements

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2799,11 +2799,11 @@ public final class DefaultPassConfig extends PassConfig {
   /** Rewrites Polymer({}) */
   private final HotSwapPassFactory polymerPass =
       new HotSwapPassFactory("polymerPass", true) {
-    @Override
-    protected HotSwapCompilerPass create(AbstractCompiler compiler) {
-      return new PolymerPass(compiler);
-    }
-  };
+        @Override
+        protected HotSwapCompilerPass create(AbstractCompiler compiler) {
+          return new PolymerPass(compiler, compiler.getOptions().polymerVersion);
+        }
+      };
 
   private final PassFactory chromePass = new PassFactory("chromePass", true) {
     @Override

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -2213,9 +2213,31 @@ public final class NodeUtil {
     return null;
   }
 
-  /**
-   * @return The first computed property in the objlit whose key matches {@code key}.
-   */
+  /** @return The first getter in the class members that matches the key. */
+  @Nullable
+  static Node getFirstGetterMatchingKey(Node n, String keyName) {
+    Preconditions.checkState(n.isClassMembers() || n.isObjectLit());
+    for (Node keyNode : n.children()) {
+      if (keyNode.isGetterDef() && keyNode.getString().equals(keyName)) {
+        return keyNode;
+      }
+    }
+    return null;
+  }
+
+  /** @return The first setter in the class members that matches the key. */
+  @Nullable
+  static Node getFirstSetterMatchingKey(Node n, String keyName) {
+    Preconditions.checkState(n.isClassMembers() || n.isObjectLit());
+    for (Node keyNode : n.children()) {
+      if (keyNode.isSetterDef() && keyNode.getString().equals(keyName)) {
+        return keyNode;
+      }
+    }
+    return null;
+  }
+
+  /** @return The first computed property in the objlit whose key matches {@code key}. */
   @Nullable
   static Node getFirstComputedPropMatchingKey(Node objlit, Node key) {
     Preconditions.checkState(objlit.isObjectLit());

--- a/src/com/google/javascript/jscomp/PolymerBehaviorExtractor.java
+++ b/src/com/google/javascript/jscomp/PolymerBehaviorExtractor.java
@@ -65,10 +65,11 @@ final class PolymerBehaviorExtractor {
     for (Node behaviorName : behaviorArray.children()) {
       if (behaviorName.isObjectLit()) {
         PolymerPassStaticUtils.switchDollarSignPropsToBrackets(behaviorName, compiler);
-        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorName);
+        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorName, compiler);
         behaviors.add(
             new BehaviorDefinition(
-                PolymerPassStaticUtils.extractProperties(behaviorName, compiler),
+                PolymerPassStaticUtils.extractProperties(
+                    behaviorName, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler),
                 getBehaviorFunctionsToCopy(behaviorName),
                 getNonPropertyMembersToCopy(behaviorName),
                 !NodeUtil.isInFunction(behaviorName),
@@ -118,10 +119,11 @@ final class PolymerBehaviorExtractor {
         behaviors.addAll(extractBehaviors(behaviorValue));
       } else if (behaviorValue.isObjectLit()) {
         PolymerPassStaticUtils.switchDollarSignPropsToBrackets(behaviorValue, compiler);
-        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorValue);
+        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorValue, compiler);
         behaviors.add(
             new BehaviorDefinition(
-                PolymerPassStaticUtils.extractProperties(behaviorValue, compiler),
+                PolymerPassStaticUtils.extractProperties(
+                    behaviorValue, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler),
                 getBehaviorFunctionsToCopy(behaviorValue),
                 getNonPropertyMembersToCopy(behaviorValue),
                 isGlobalDeclaration,

--- a/src/com/google/javascript/jscomp/PolymerClassDefinition.java
+++ b/src/com/google/javascript/jscomp/PolymerClassDefinition.java
@@ -33,6 +33,13 @@ import javax.annotation.Nullable;
  * class.
  */
 final class PolymerClassDefinition {
+  static enum DefinitionType {
+    ObjectLiteral,
+    ES6Class
+  }
+
+  /** The declaration style used for the Polymer definition */
+  final DefinitionType defType;
 
   /** The target node (LHS) for the Polymer element definition. */
   final Node target;
@@ -44,18 +51,19 @@ final class PolymerClassDefinition {
   final MemberDefinition constructor;
 
   /** The name of the native HTML element which this element extends. */
-  final String nativeBaseElement;
+  @Nullable final String nativeBaseElement;
 
   /** Properties declared in the Polymer "properties" block. */
   final List<MemberDefinition> props;
 
   /** Flattened list of behavior definitions used by this element. */
-  final ImmutableList<BehaviorDefinition> behaviors;
+  @Nullable final ImmutableList<BehaviorDefinition> behaviors;
 
   /** Language features that should be carried over to the extraction destination. */
-  final FeatureSet features;
+  @Nullable final FeatureSet features;
 
   PolymerClassDefinition(
+      DefinitionType defType,
       Node target,
       Node descriptor,
       JSDocInfo classInfo,
@@ -64,8 +72,9 @@ final class PolymerClassDefinition {
       List<MemberDefinition> props,
       ImmutableList<BehaviorDefinition> behaviors,
       FeatureSet features) {
+    this.defType = defType;
     this.target = target;
-    Preconditions.checkState(descriptor.isObjectLit());
+    Preconditions.checkState(descriptor == null || descriptor.isObjectLit());
     this.descriptor = descriptor;
     this.constructor = constructor;
     this.nativeBaseElement = nativeBaseElement;
@@ -134,7 +143,9 @@ final class PolymerClassDefinition {
       overwriteMembersIfPresent(allProperties, behavior.props);
     }
     overwriteMembersIfPresent(
-        allProperties, PolymerPassStaticUtils.extractProperties(descriptor, compiler));
+        allProperties,
+        PolymerPassStaticUtils.extractProperties(
+            descriptor, DefinitionType.ObjectLiteral, compiler));
 
     FeatureSet newFeatures = null;
     if (!behaviors.isEmpty()) {
@@ -145,6 +156,7 @@ final class PolymerClassDefinition {
     }
 
     return new PolymerClassDefinition(
+        DefinitionType.ObjectLiteral,
         target,
         descriptor,
         classInfo,
@@ -153,6 +165,80 @@ final class PolymerClassDefinition {
         allProperties,
         behaviors,
         newFeatures);
+  }
+
+  /**
+   * Validates the class definition and if valid, extracts the class definition from the AST. As
+   * opposed to the Polymer 1 extraction, this operation is non-destructive.
+   */
+  @Nullable
+  static PolymerClassDefinition extractFromClassNode(
+      Node classNode, AbstractCompiler compiler, GlobalNamespace globalNames) {
+    Preconditions.checkState(classNode != null && classNode.isClass());
+
+    // The supported case is for the config getter to return an object literal descriptor.
+    Node propertiesDescriptor = null;
+    Node propertiesGetter =
+        NodeUtil.getFirstGetterMatchingKey(NodeUtil.getClassMembers(classNode), "properties");
+    if (propertiesGetter != null) {
+      if (!propertiesGetter.isStaticMember()) {
+        // report bad class definition
+        compiler.report(
+            JSError.make(classNode, PolymerPassErrors.POLYMER_CLASS_PROPERTIES_NOT_STATIC));
+      } else {
+        for (Node child : NodeUtil.getFunctionBody(propertiesGetter.getFirstChild()).children()) {
+          if (child.isReturn()) {
+            if (child.hasChildren() && child.getFirstChild().isObjectLit()) {
+              propertiesDescriptor = child.getFirstChild();
+              break;
+            } else {
+              compiler.report(
+                  JSError.make(
+                      propertiesGetter, PolymerPassErrors.POLYMER_CLASS_PROPERTIES_INVALID));
+            }
+          }
+        }
+      }
+    }
+
+    Node target;
+    if (NodeUtil.isNameDeclaration(classNode.getGrandparent())) {
+      target = IR.name(classNode.getParent().getString());
+    } else if (classNode.getParent().isAssign()
+        && classNode.getParent().getFirstChild().isQualifiedName()) {
+      target = classNode.getParent().getFirstChild();
+    } else if (!classNode.getFirstChild().isEmpty()) {
+      target = classNode.getFirstChild();
+    } else {
+      // issue error - no name found
+      compiler.report(JSError.make(classNode, PolymerPassErrors.POLYMER_CLASS_UNNAMED));
+      return null;
+    }
+
+    JSDocInfo classInfo = NodeUtil.getBestJSDocInfo(classNode);
+
+    JSDocInfo ctorInfo = null;
+    Node constructor =
+        NodeUtil.getFirstPropMatchingKey(NodeUtil.getClassMembers(classNode), "constructor");
+    if (constructor != null) {
+      ctorInfo = NodeUtil.getBestJSDocInfo(constructor);
+    }
+
+    List<MemberDefinition> allProperties;
+    allProperties =
+        PolymerPassStaticUtils.extractProperties(
+            propertiesDescriptor, DefinitionType.ES6Class, compiler);
+
+    return new PolymerClassDefinition(
+        DefinitionType.ES6Class,
+        target,
+        propertiesDescriptor,
+        classInfo,
+        new MemberDefinition(ctorInfo, null, constructor),
+        null,
+        allProperties,
+        null,
+        null);
   }
 
   /**

--- a/src/com/google/javascript/jscomp/PolymerClassRewriter.java
+++ b/src/com/google/javascript/jscomp/PolymerClassRewriter.java
@@ -37,12 +37,14 @@ import java.util.Map;
 final class PolymerClassRewriter {
 
   private final AbstractCompiler compiler;
+  private final int polymerVersion;
 
   private Node polymerElementExterns;
 
-  PolymerClassRewriter(AbstractCompiler compiler, Node polymerElementExterns) {
+  PolymerClassRewriter(AbstractCompiler compiler, Node polymerElementExterns, int polymerVersion) {
     this.compiler = compiler;
     this.polymerElementExterns = polymerElementExterns;
+    this.polymerVersion = polymerVersion;
   }
 
   /**
@@ -53,8 +55,9 @@ final class PolymerClassRewriter {
    * @param cls The extracted {@link PolymerClassDefinition} for the Polymer element created by this
    *     call.
    */
-  void rewritePolymerClass(
+  void rewritePolymerCall(
       Node exprRoot, final PolymerClassDefinition cls, boolean isInGlobalScope) {
+    Preconditions.checkState(cls.descriptor != null);
     Node call = exprRoot.getFirstChild();
     if (call.isAssign()) {
       call = call.getSecondChild();
@@ -73,9 +76,9 @@ final class PolymerClassRewriter {
     objLitDoc.recordLends(cls.target.getQualifiedName() + ".prototype");
     objLit.setJSDocInfo(objLitDoc.build());
 
-    addTypesToFunctions(objLit, cls.target.getQualifiedName());
+    addTypesToFunctions(objLit, cls.target.getQualifiedName(), cls.defType);
     PolymerPassStaticUtils.switchDollarSignPropsToBrackets(objLit, compiler);
-    PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(objLit);
+    PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(cls.descriptor, compiler);
 
     for (MemberDefinition prop : cls.props) {
       if (prop.value.isObjectLit()) {
@@ -115,19 +118,21 @@ final class PolymerClassRewriter {
     appendBehaviorMembersToBlock(cls, block);
     ImmutableList<MemberDefinition> readOnlyProps = parseReadOnlyProperties(cls, block);
     addInterfaceExterns(cls, readOnlyProps);
-    removePropertyDocs(objLit);
+    removePropertyDocs(objLit, PolymerClassDefinition.DefinitionType.ObjectLiteral);
 
     Node statements = block.removeChildren();
     Node parent = exprRoot.getParent();
 
-    // If the call to Polymer() is not in the global scope and the assignment target is not
+    // For Polymer 1, If the call to Polymer() is not in the global scope and the assignment target is not
     // namespaced (which likely means it's exported to the global scope), put the type declaration
     // into the global scope at the start of the current script.
     //
     // This avoids unknown type warnings which are a result of the compiler's poor understanding of
     // types declared inside IIFEs or any non-global scope. We should revisit this decision after
     // moving to the new type inference system which should be able to infer these types better.
-    if (!isInGlobalScope && !cls.target.isGetProp()) {
+    //
+    // Since Polymer 2 class mixins only function with NTI, we do not force Polymer 2 types to be global.
+    if (this.polymerVersion == 1 && !isInGlobalScope && !cls.target.isGetProp()) {
       Node scriptNode = NodeUtil.getEnclosingScript(parent);
       scriptNode.addChildrenToFront(statements);
     } else {
@@ -157,9 +162,52 @@ final class PolymerClassRewriter {
   }
 
   /**
-   * Adds an @this annotation to all functions in the objLit.
+   * Rewrites a class which extends Polymer.Element to a set of declarations and assignments which
+   * can be understood by the compiler.
+   *
+   * @param clazz The class node
+   * @param cls The extracted {@link PolymerClassDefinition} for the Polymer element created by this
+   *     call.
    */
-  private void addTypesToFunctions(Node objLit, String thisType) {
+  void rewritePolymerClassDeclaration(
+      Node clazz, final PolymerClassDefinition cls, boolean isInGlobalScope) {
+
+    if (cls.descriptor != null) {
+      addTypesToFunctions(cls.descriptor, cls.target.getQualifiedName(), cls.defType);
+    }
+    PolymerPassStaticUtils.switchDollarSignPropsToBrackets(
+        NodeUtil.getClassMembers(clazz), compiler);
+
+    for (MemberDefinition prop : cls.props) {
+      if (prop.value.isObjectLit()) {
+        PolymerPassStaticUtils.switchDollarSignPropsToBrackets(prop.value, compiler);
+      }
+    }
+
+    // For simplicity add everything into a block, before adding it to the AST.
+    Node block = IR.block();
+
+    appendPropertiesToBlock(cls, block, cls.target.getQualifiedName() + ".prototype.");
+    ImmutableList<MemberDefinition> readOnlyProps = parseReadOnlyProperties(cls, block);
+    addInterfaceExterns(cls, readOnlyProps);
+
+    if (block.hasChildren()) {
+      removePropertyDocs(cls.descriptor, cls.defType);
+      Node statements = block.removeChildren();
+      Node expr = clazz;
+      while (!(expr.isExprResult() || expr.getParent().isScript())) {
+        expr = expr.getParent();
+      }
+
+      expr.getParent().addChildrenAfter(statements, expr);
+
+      compiler.reportCodeChange();
+    }
+  }
+
+  /** Adds an @this annotation to all functions in the objLit. */
+  private void addTypesToFunctions(
+      Node objLit, String thisType, PolymerClassDefinition.DefinitionType defType) {
     Preconditions.checkState(objLit.isObjectLit());
     for (Node keyNode : objLit.children()) {
       Node value = keyNode.getLastChild();
@@ -172,7 +220,8 @@ final class PolymerClassRewriter {
     }
 
     // Add @this and @return to default property values.
-    for (MemberDefinition property : PolymerPassStaticUtils.extractProperties(objLit, compiler)) {
+    for (MemberDefinition property :
+        PolymerPassStaticUtils.extractProperties(objLit, defType, compiler)) {
       if (!property.value.isObjectLit()) {
         continue;
       }
@@ -262,11 +311,11 @@ final class PolymerClassRewriter {
     }
   }
 
-  /**
-   * Remove all JSDocs from properties of a class definition
-   */
-  private void removePropertyDocs(final Node objLit) {
-    for (MemberDefinition prop : PolymerPassStaticUtils.extractProperties(objLit, compiler)) {
+  /** Remove all JSDocs from properties of a class definition */
+  private void removePropertyDocs(
+      final Node objLit, PolymerClassDefinition.DefinitionType defType) {
+    for (MemberDefinition prop :
+        PolymerPassStaticUtils.extractProperties(objLit, defType, compiler)) {
       prop.name.removeProp(Node.JSDOC_INFO_PROP);
     }
   }
@@ -380,7 +429,20 @@ final class PolymerClassRewriter {
     varNode.setJSDocInfo(info.build());
     block.addChildToBack(varNode);
 
-    appendPropertiesToBlock(cls, block, interfaceName + ".prototype.");
+    if (polymerVersion == 1) {
+      // For Polymer 1, all declared properties are non-renameable
+      appendPropertiesToBlock(cls, block, interfaceName + ".prototype.");
+    } else {
+      // For Polymer 2, only read-only properties are non-renameable.
+      // Other properties follow the ALL_UNQUOTED renaming rules.
+      PolymerClassDefinition tmpDef =
+          new PolymerClassDefinition(
+              cls.defType, cls.target, cls.descriptor, null, null, null, readOnlyProps, null, null);
+
+      // disallow renaming of readonly properties
+      appendPropertiesToBlock(tmpDef, block, interfaceName + ".prototype.");
+    }
+
     for (MemberDefinition prop : readOnlyProps) {
       // Add all _set* functions to avoid renaming.
       String propName = prop.name.getString();

--- a/src/com/google/javascript/jscomp/PolymerPass.java
+++ b/src/com/google/javascript/jscomp/PolymerPass.java
@@ -19,7 +19,6 @@ import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_DEC
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_EXTENDS;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_MISSING_EXTERNS;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
@@ -29,7 +28,6 @@ import com.google.javascript.rhino.JSDocInfoBuilder;
 import com.google.javascript.rhino.JSTypeExpression;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -50,21 +48,24 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
 
   private final AbstractCompiler compiler;
   private final Map<String, String> tagNameMap;
+  private final int polymerVersion;
 
   private Node polymerElementExterns;
+  private Node externsInsertionRef = null;
   private Set<String> nativeExternsAdded;
   private ImmutableList<Node> polymerElementProps;
   private GlobalNamespace globalNames;
+  private boolean warnedPolymer1ExternsMissing = false;
 
-  PolymerPass(AbstractCompiler compiler) {
+  PolymerPass(AbstractCompiler compiler, Integer polymerVersion) {
+    Preconditions.checkArgument(
+        polymerVersion == null || polymerVersion == 1 || polymerVersion == 2,
+        "Invalid Polymer version:",
+        polymerVersion);
     this.compiler = compiler;
     tagNameMap = TagNameToType.getMap();
     nativeExternsAdded = new HashSet<>();
-
-    if (compiler.getOptions().polymerVersion != 1) {
-      throw new IllegalStateException("Polymer version not supported: "
-          + compiler.getOptions().polymerVersion);
-    }
+    this.polymerVersion = polymerVersion == null ? 1 : polymerVersion;
   }
 
   @Override
@@ -74,7 +75,8 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
     polymerElementExterns = externsCallback.getPolymerElementExterns();
     polymerElementProps = externsCallback.getPolymerElementProps();
 
-    if (polymerElementExterns == null) {
+    if (polymerVersion == 1 && polymerElementExterns == null) {
+      this.warnedPolymer1ExternsMissing = true;
       compiler.report(JSError.make(externs, POLYMER_MISSING_EXTERNS));
       return;
     }
@@ -94,15 +96,22 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
 
   @Override
   public void visit(NodeTraversal traversal, Node node, Node parent) {
-    Preconditions.checkState(
-        polymerElementExterns != null && polymerElementProps != null && globalNames != null,
-        "Cannot call visit() before process()");
-    if (isPolymerCall(node)) {
-      rewriteClassDefinition(node, parent, traversal);
+    Preconditions.checkNotNull(globalNames, "Cannot call visit() before process()");
+
+    if (PolymerPassStaticUtils.isPolymerCall(node)) {
+      if (polymerElementExterns != null) {
+        rewritePolymer1ClassDefinition(node, parent, traversal);
+      } else if (!warnedPolymer1ExternsMissing) {
+        compiler.report(JSError.make(polymerElementExterns, POLYMER_MISSING_EXTERNS));
+        warnedPolymer1ExternsMissing = true;
+      }
+    } else if (PolymerPassStaticUtils.isPolymerClass(node)) {
+      rewritePolymer2ClassDefinition(node, parent, traversal);
     }
   }
 
-  private void rewriteClassDefinition(Node node, Node parent, NodeTraversal traversal) {
+  /** Polymer 1.x and Polymer 2 Legacy Element Definitions */
+  private void rewritePolymer1ClassDefinition(Node node, Node parent, NodeTraversal traversal) {
     Node grandparent = parent.getParent();
     if (grandparent.isConst()) {
       compiler.report(JSError.make(node, POLYMER_INVALID_DECLARATION));
@@ -114,13 +123,37 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
       if (def.nativeBaseElement != null) {
         appendPolymerElementExterns(def);
       }
-      PolymerClassRewriter rewriter = new PolymerClassRewriter(compiler, polymerElementExterns);
+      PolymerClassRewriter rewriter =
+          new PolymerClassRewriter(compiler, getExtensInsertionRef(), polymerVersion);
       if (NodeUtil.isNameDeclaration(grandparent) || parent.isAssign()) {
-        rewriter.rewritePolymerClass(grandparent, def, traversal.inGlobalScope());
+        rewriter.rewritePolymerCall(grandparent, def, traversal.inGlobalScope());
       } else {
-        rewriter.rewritePolymerClass(parent, def, traversal.inGlobalScope());
+        rewriter.rewritePolymerCall(parent, def, traversal.inGlobalScope());
       }
     }
+  }
+
+  /** Polymer 2.x Class Nodes */
+  private void rewritePolymer2ClassDefinition(Node node, Node parent, NodeTraversal traversal) {
+    PolymerClassDefinition def =
+        PolymerClassDefinition.extractFromClassNode(node, compiler, globalNames);
+    if (def != null) {
+      PolymerClassRewriter rewriter =
+          new PolymerClassRewriter(compiler, getExtensInsertionRef(), polymerVersion);
+      rewriter.rewritePolymerClassDeclaration(node, def, traversal.inGlobalScope());
+    }
+  }
+
+  private Node getExtensInsertionRef() {
+    if (this.polymerElementExterns != null) {
+      return this.polymerElementExterns;
+    }
+
+    if (this.externsInsertionRef == null) {
+      this.externsInsertionRef = compiler.getSynthesizedExternsInputAtEnd().getAstRoot(compiler);
+    }
+
+    return this.externsInsertionRef;
   }
 
   /**
@@ -168,17 +201,7 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
     compiler.reportCodeChange();
   }
 
-  /**
-   * @return Whether the call represents a call to the Polymer function.
-   */
-  @VisibleForTesting
-  public static boolean isPolymerCall(Node value) {
-    return value != null && value.isCall() && value.getFirstChild().matchesQualifiedName("Polymer");
-  }
-
-  /**
-   * Any member of a Polymer element or Behavior. These can be functions, properties, etc.
-   */
+  /** Any member of a Polymer element or Behavior. These can be functions, properties, etc. */
   static class MemberDefinition {
     /** Any {@link JSDocInfo} tied to this member. */
     final JSDocInfo info;

--- a/src/com/google/javascript/jscomp/PolymerPassErrors.java
+++ b/src/com/google/javascript/jscomp/PolymerPassErrors.java
@@ -20,10 +20,11 @@ package com.google.javascript.jscomp;
  */
 final class PolymerPassErrors {
   // TODO(jlklein): Switch back to an error when everyone is upgraded to Polymer 1.0
-  static final DiagnosticType POLYMER_DESCRIPTOR_NOT_VALID = DiagnosticType.warning(
-      "JSC_POLYMER_DESCRIPTOR_NOT_VALID",
-      "The argument to Polymer() is not an obj lit (perhaps because this is a pre-Polymer-1.0 "
-      + "call). Ignoring this call.");
+  static final DiagnosticType POLYMER_DESCRIPTOR_NOT_VALID =
+      DiagnosticType.warning(
+          "JSC_POLYMER_DESCRIPTOR_NOT_VALID",
+          "The argument to Polymer() is not an obj lit or the Polymer 2 class does not have a static getter"
+              + "named 'config'. Ignoring this definition.");
 
   // Disallow 'const Foo = Polymer(...)' because the code the PolymerPass outputs will reassign
   // Foo which is not allowed for 'const' variables.
@@ -63,6 +64,22 @@ final class PolymerPassErrors {
       DiagnosticType.error(
           "JSC_POLYMER_SHORTHAND_NOT_SUPPORTED",
           "Shorthand assignment in object literal is not allowed in Polymer call arguments");
+
+  static final DiagnosticType POLYMER_CLASS_PROPERTIES_INVALID =
+      DiagnosticType.error(
+          "JSC_POLYMER_CLASS_PROPERTIES_INVALID",
+          "The Polymer element class 'propertis' getter does not return an object literal. Ignoring this definition.");
+
+  static final DiagnosticType POLYMER_CLASS_PROPERTIES_NOT_STATIC =
+      DiagnosticType.error(
+          "JSC_POLYMER_CLASS_PROPERTIES_NOT_STATIC",
+          "The Polymer element class 'properties' getter is not declared static. Ignoring this definition.");
+
+  static final DiagnosticType POLYMER_CLASS_UNNAMED =
+      DiagnosticType.warning(
+          "JSC_POLYMER2_UNNAMED",
+          "Unable to locate a valid name for the Polymer element class."
+              + "Ignoring this definition.");
 
   private PolymerPassErrors() {}
 }

--- a/src/com/google/javascript/jscomp/PolymerPassSuppressBehaviors.java
+++ b/src/com/google/javascript/jscomp/PolymerPassSuppressBehaviors.java
@@ -82,7 +82,8 @@ final class PolymerPassSuppressBehaviors extends AbstractPostOrderCallback {
 
   private void stripPropertyTypes(Node behaviorValue) {
     List<MemberDefinition> properties =
-        PolymerPassStaticUtils.extractProperties(behaviorValue, compiler);
+        PolymerPassStaticUtils.extractProperties(
+            behaviorValue, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler);
     for (MemberDefinition property : properties) {
       property.name.removeProp(Node.JSDOC_INFO_PROP);
     }
@@ -90,7 +91,8 @@ final class PolymerPassSuppressBehaviors extends AbstractPostOrderCallback {
 
   private void suppressDefaultValues(Node behaviorValue) {
     for (MemberDefinition property :
-        PolymerPassStaticUtils.extractProperties(behaviorValue, compiler)) {
+        PolymerPassStaticUtils.extractProperties(
+            behaviorValue, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler)) {
       if (!property.value.isObjectLit()) {
         continue;
       }

--- a/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesInPolymerElementTest.java
+++ b/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesInPolymerElementTest.java
@@ -43,7 +43,7 @@ public final class CheckUnusedPrivatePropertiesInPolymerElementTest
     return new CompilerPass() {
       @Override
       public void process(Node externs, Node root) {
-        new PolymerPass(compiler).process(externs, root);
+        new PolymerPass(compiler, 1).process(externs, root);
         new CheckUnusedPrivateProperties(compiler).process(externs, root);
       }
     };

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -1296,7 +1296,7 @@ public abstract class CompilerTestCase extends TestCase {
 
         if (polymerPass && i == 0) {
           recentChange.reset();
-          new PolymerPass(compiler).process(externsRoot, mainRoot);
+          new PolymerPass(compiler, 1).process(externsRoot, mainRoot);
           hasCodeChanged = hasCodeChanged || recentChange.hasCodeChanged();
         }
 

--- a/test/com/google/javascript/jscomp/PolymerClassRewriterTest.java
+++ b/test/com/google/javascript/jscomp/PolymerClassRewriterTest.java
@@ -80,6 +80,14 @@ public final class PolymerClassRewriterTest extends CompilerTypeTestCase {
             "X = Polymer(/** @lends {X.prototype} */ {",
             "  is: 'x-element',",
             "});"));
+
+    setLanugageLevel(LanguageMode.ECMASCRIPT_2015);
+    testSame(
+        LINE_JOINER.join(
+            "var X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties { return { }; }",
+            "};"));
   }
 
   public void testDefaultTypeNameTarget() {
@@ -133,28 +141,46 @@ public final class PolymerClassRewriterTest extends CompilerTypeTestCase {
   }
 
   private void test(String originalCode, String expectedResult) {
-    parseAndRewrite(originalCode);
+    parseAndRewrite(originalCode, 1);
     Node expectedNode = compiler.parseSyntheticCode(expectedResult);
+    NodeSubject.assertNode(expectedNode).isEqualTo(rootNode);
+
+    parseAndRewrite(originalCode, 2);
+    expectedNode = compiler.parseSyntheticCode(expectedResult);
     NodeSubject.assertNode(expectedNode).isEqualTo(rootNode);
   }
 
-  private void parseAndRewrite(String code) {
+  private void testSame(String originalCode) {
+    parseAndRewrite(originalCode, 1);
+    Node expectedNode = compiler.parseSyntheticCode(originalCode);
+    NodeSubject.assertNode(expectedNode).isEqualTo(rootNode);
+
+    parseAndRewrite(originalCode, 2);
+    expectedNode = compiler.parseSyntheticCode(originalCode);
+    NodeSubject.assertNode(expectedNode).isEqualTo(rootNode);
+  }
+
+  private void parseAndRewrite(String code, int version) {
     rootNode = compiler.parseTestCode(code);
     globalNamespace =  new GlobalNamespace(compiler, rootNode);
     PolymerPassFindExterns findExternsCallback = new PolymerPassFindExterns();
     Node externs = compiler.parseTestCode(EXTERNS);
     NodeTraversal.traverseEs6(compiler, externs, findExternsCallback);
 
-    rewriter = new PolymerClassRewriter(compiler, findExternsCallback.getPolymerElementExterns());
+    rewriter =
+        new PolymerClassRewriter(compiler, findExternsCallback.getPolymerElementExterns(), version);
 
-    NodeUtil.visitPostOrder(rootNode, new NodeUtil.Visitor() {
-      @Override
-      public void visit(Node node) {
-        if (PolymerPass.isPolymerCall(node)) {
-          polymerCall = node;
-        }
-      }
-    }, Predicates.<Node>alwaysTrue());
+    NodeUtil.visitPostOrder(
+        rootNode,
+        new NodeUtil.Visitor() {
+          @Override
+          public void visit(Node node) {
+            if (PolymerPassStaticUtils.isPolymerCall(node)) {
+              polymerCall = node;
+            }
+          }
+        },
+        Predicates.<Node>alwaysTrue());
 
     assertNotNull(polymerCall);
     PolymerClassDefinition classDef =
@@ -163,9 +189,13 @@ public final class PolymerClassRewriterTest extends CompilerTypeTestCase {
     Node parent = polymerCall.getParent();
     Node grandparent = parent.getParent();
     if (NodeUtil.isNameDeclaration(grandparent) || parent.isAssign()) {
-      rewriter.rewritePolymerClass(grandparent, classDef, true);
+      rewriter.rewritePolymerCall(grandparent, classDef, true);
     } else {
-      rewriter.rewritePolymerClass(parent, classDef, true);
+      rewriter.rewritePolymerCall(parent, classDef, true);
     }
+  }
+
+  private void setLanugageLevel(LanguageMode mode) {
+    compiler.getOptions().setLanguageIn(mode);
   }
 }

--- a/test/com/google/javascript/jscomp/PolymerPassStaticUtilsTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassStaticUtilsTest.java
@@ -18,20 +18,37 @@ package com.google.javascript.jscomp;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.javascript.rhino.IR;
-
 import junit.framework.TestCase;
 
 public final class PolymerPassStaticUtilsTest extends TestCase {
 
   public void testGetPolymerElementType_noNativeElement() {
-    PolymerClassDefinition def = new PolymerClassDefinition(
-        null, IR.objectlit(), null, null, null, null, null, null);
+    PolymerClassDefinition def =
+        new PolymerClassDefinition(
+            PolymerClassDefinition.DefinitionType.ObjectLiteral,
+            null,
+            IR.objectlit(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertThat(PolymerPassStaticUtils.getPolymerElementType(def)).isEqualTo("PolymerElement");
   }
 
   public void testGetPolymerElementType_inputBaseElement() {
-    PolymerClassDefinition def = new PolymerClassDefinition(
-        null, IR.objectlit(), null, null, "input", null, null, null);
+    PolymerClassDefinition def =
+        new PolymerClassDefinition(
+            PolymerClassDefinition.DefinitionType.ES6Class,
+            null,
+            IR.objectlit(),
+            null,
+            null,
+            "input",
+            null,
+            null,
+            null);
     assertThat(PolymerPassStaticUtils.getPolymerElementType(def)).isEqualTo("PolymerInputElement");
   }
 

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -16,6 +16,8 @@
 package com.google.javascript.jscomp;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_CLASS_PROPERTIES_INVALID;
+import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_CLASS_PROPERTIES_NOT_STATIC;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_DESCRIPTOR_NOT_VALID;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_DECLARATION;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_EXTENDS;
@@ -121,31 +123,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
           "/** @interface */",
           "var PolymerXInputElementInterface = function() {};");
 
-  private static final String READONLY_EXTERNS =
-      EXTERNS
-          + LINE_JOINER.join(
-              "/** @interface */",
-              "var Polymera_BInterface = function() {};",
-              "/** @type {!Array<string>} */",
-              "Polymera_BInterface.prototype.pets;",
-              "/** @private {string} */",
-              "Polymera_BInterface.prototype.name_;",
-              "/** @param {!Array<string>} pets **/",
-              "Polymera_BInterface.prototype._setPets;");
-
-  private static final String BEHAVIOR_READONLY_EXTERNS =
-      EXTERNS
-          + LINE_JOINER.join(
-              "/** @interface */",
-              "var PolymerAInterface = function() {};",
-              "/** @type {boolean} */",
-              "PolymerAInterface.prototype.isFun;",
-              "/** @type {!Array} */",
-              "PolymerAInterface.prototype.pets;",
-              "/** @type {string} */",
-              "PolymerAInterface.prototype.name;",
-              "/** @param {boolean} isFun **/",
-              "PolymerAInterface.prototype._setIsFun;");
+  private int polymerVersion = 1;
 
   public PolymerPassTest() {
     super(EXTERNS);
@@ -153,7 +131,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
 
   @Override
   protected CompilerPass getProcessor(Compiler compiler) {
-    return new PolymerPass(compiler);
+    return new PolymerPass(compiler, polymerVersion);
   }
 
   @Override
@@ -184,9 +162,19 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "X = Polymer(/** @lends {X.prototype} */ {",
             "  is: 'x-element',",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testSameEs6(
+        LINE_JOINER.join(
+            "var X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return { }; }",
+            "};"));
   }
 
   public void testLetTarget() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testEs6(
         LINE_JOINER.join(
@@ -201,15 +189,32 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             " */",
             "var X = function() {};",
             "X = Polymer(/** @lends {X.prototype} */ {is:'x-element'});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testSameEs6(
+        LINE_JOINER.join(
+            "let X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return { }; }",
+            "};"));
   }
 
   public void testConstTarget() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testErrorEs6(
         LINE_JOINER.join(
             "const X = Polymer({",
             "  is: 'x-element',",
             "});"), POLYMER_INVALID_DECLARATION);
+
+    testSameEs6(
+        LINE_JOINER.join(
+            "const X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return { }; }",
+            "};"));
   }
 
   public void testDefaultTypeNameTarget() {
@@ -245,9 +250,20 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "x.Z = Polymer(/** @lends {x.Z.prototype} */ {",
             "  is: 'x-element',",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testSameEs6(
+        LINE_JOINER.join(
+            "const x = {};",
+            "x.Z = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return { }; }",
+            "};"));
   }
 
   public void testComputedPropName() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck(); // TypeCheck cannot grab a name from a complicated computedPropName
     testEs6("var X = Polymer({is:'x-element', [name + (() => 42)]: function() {return 42;}});",
         LINE_JOINER.join(
@@ -288,6 +304,18 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testSameEs6(
+        LINE_JOINER.join(
+            "const x = {};",
+            "(function() {",
+            "  x.Z = class extends Polymer.Element {",
+            "    static get is() { return 'x-element'; }",
+            "    static get properties() { return { }; }",
+            "  };",
+            "})();"));
   }
 
   /**
@@ -297,6 +325,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
    */
   public void testIIFEExtractionNoAssignmentTarget() {
     test(
+        1,
         LINE_JOINER.join(
             "(function() {",
             "  Polymer({",
@@ -304,7 +333,6 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"),
-
         LINE_JOINER.join(
             "/**",
             " * @constructor @extends {PolymerElement}",
@@ -318,6 +346,40 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"));
+
+    test(
+        2,
+        LINE_JOINER.join(
+            "(function() {",
+            "  Polymer({",
+            "    is: 'x',",
+            "    sayHi: function() { alert('hi'); },",
+            "  });",
+            "})()"),
+        LINE_JOINER.join(
+            "(function() {",
+            "  /**",
+            "   * @constructor @extends {PolymerElement}",
+            "   * @implements {PolymerXElementInterface}",
+            "   */",
+            "  var XElement = function() {};",
+            "  Polymer(/** @lends {XElement.prototype} */ {",
+            "    is: 'x',",
+            "    /** @this {XElement} */",
+            "    sayHi: function() { alert('hi'); },",
+            "  });",
+            "})()"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testSameEs6(
+        LINE_JOINER.join(
+            "(function() {",
+            "  const X = class extends Polymer.Element {",
+            "    static get is() { return 'x-element'; }",
+            "    static get properties() { return { }; }",
+            "  };",
+            "})();"));
   }
 
   /**
@@ -327,6 +389,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
    */
   public void testIIFEExtractionVarTarget() {
     test(
+        1,
         LINE_JOINER.join(
             "(function() {",
             "  var FooThing = Polymer({",
@@ -334,7 +397,6 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"),
-
         LINE_JOINER.join(
             "/**",
             " * @constructor @extends {PolymerElement}",
@@ -427,6 +489,28 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    alert('Thank you for clicking');",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testEs6(
+        LINE_JOINER.join(
+            "class X extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return {}; }",
+            "",
+            "  handleClick(e) {",
+            "    alert('Thank you for clicking');",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "class X extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return {}; }",
+            "",
+            "  handleClick(e) {",
+            "    alert('Thank you for clicking');",
+            "  }",
+            "}"));
   }
 
   public void testListenersAndHostAttributeKeysQuoted() {
@@ -495,6 +579,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
   }
 
   public void testExtendNonExistentElement() {
+    polymerVersion = 1;
     String js = LINE_JOINER.join(
         "Polymer({",
         "  is: 'x-input',",
@@ -570,9 +655,59 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    thingToDo: Function,",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testEs6(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "/** @type {!Function} */",
+            "a.B.prototype.thingToDo;"));
   }
 
   public void testPropertiesObjLitShorthand() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testErrorEs6(
         LINE_JOINER.join(
@@ -582,6 +717,35 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    name,",
             "  },",
             "});"),
+        POLYMER_SHORTHAND_NOT_SUPPORTED);
+
+    testErrorEs6(
+        LINE_JOINER.join(
+            "var XElem = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      name",
+            "    };",
+            "  }",
+            "};"),
+        POLYMER_SHORTHAND_NOT_SUPPORTED);
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testErrorEs6(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      name,",
+            "    };",
+            "  }",
+            "};"),
         POLYMER_SHORTHAND_NOT_SUPPORTED);
   }
 
@@ -637,6 +801,61 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    name: String,",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testEs6(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: {",
+            "        type: Object,",
+            "        value: function() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        value: function() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      user_: {",
+            "        type: Object,",
+            "        /** @this {a.B} @return {!User} */",
+            "        value: function() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        /** @this {a.B} @return {!Array} */",
+            "        value: function() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;"));
   }
 
   public void testPropertiesDefaultValueShortHandFunction() {
@@ -675,6 +894,61 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    },",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testEs6(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: {",
+            "        type: Object,",
+            "        value() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        value() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      user_: {",
+            "        type: Object,",
+            "        /** @this {a.B} @return {!User} */",
+            "        value() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        /** @this {a.B} @return {!Array} */",
+            "        value() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;"));
   }
 
   public void testReadOnlyPropertySetters() {
@@ -695,6 +969,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "});");
 
     test(
+        1,
         js,
         LINE_JOINER.join(
             "var a = {};",
@@ -717,7 +992,57 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "  },",
             "});"));
 
-    testExternChanges(EXTERNS, js, READONLY_EXTERNS);
+    testExternChanges(
+        1,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var Polymera_BInterface = function() {};",
+            "/** @type {!Array<string>} */",
+            "Polymera_BInterface.prototype.pets;",
+            "/** @private {string} */",
+            "Polymera_BInterface.prototype.name_;",
+            "/** @param {!Array<string>} pets **/",
+            "Polymera_BInterface.prototype._setPets;"));
+
+    test(
+        2,
+        js,
+        LINE_JOINER.join(
+            "var a = {};",
+            "/** @constructor @extends {PolymerElement} @implements {Polymera_BInterface} */",
+            "a.B = function() {};",
+            "/** @type {!Array<string>} */",
+            "a.B.prototype.pets;",
+            "/** @private {string} */",
+            "a.B.prototype.name_;",
+            "/** @override */",
+            "a.B.prototype._setPets = function(pets) {};",
+            "a.B = Polymer(/** @lends {a.B.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    pets: {",
+            "      type: Array,",
+            "      readOnly: true,",
+            "    },",
+            "    name_: String,",
+            "  },",
+            "});"));
+
+    testExternChanges(
+        2,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var Polymera_BInterface = function() {};",
+            "/** @type {!Array<string>} */",
+            "Polymera_BInterface.prototype.pets;",
+            "/** @param {!Array<string>} pets **/",
+            "Polymera_BInterface.prototype._setPets;"));
   }
 
   public void testShorthandFunctionDefinition() {
@@ -862,6 +1187,29 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    alert('Hello, ' + name);",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testSameEs6(
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return {}; }",
+            "  sayHi() {",
+            "    alert('hi');",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.sayHelloTo_('Tester');",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    alert('Hello, ' + name);",
+            "  }",
+            "}"));
   }
 
   public void testDollarSignPropsConvertedToBrackets() {
@@ -935,6 +1283,66 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    this.$['otherThing'].touch();",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testEs6(
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!HTMLElement} */",
+            "      propName: {",
+            "        type: Object,",
+            "        value: function() { return this.$.id; },",
+            "      }",
+            "    };",
+            "  }",
+            "  sayHi() {",
+            "    this.$.checkbox.toggle();",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.$.radioButton.switch();",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    this.$.otherThing.touch();",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      propName: {",
+            "        type: Object,",
+            "        /** @this {Foo} @return {!HTMLElement} */",
+            "        value: function() { return this.$['id']; },",
+            "      }",
+            "    };",
+            "  }",
+            "  sayHi() {",
+            "    this.$['checkbox'].toggle();",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.$['radioButton'].switch();",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    this.$['otherThing'].touch();",
+            "  }",
+            "}",
+            "/** @type {!HTMLElement} */",
+            "Foo.prototype.propName;"));
   }
 
   public void testDollarSignPropsInShorthandFunctionConvertedToBrackets() {
@@ -1167,53 +1575,56 @@ public class PolymerPassTest extends Es6CompilerTestCase {
   /** If a behavior method is {@code @protected} there is no visibility warning. */
   public void testBehaviorWithProtectedMethod() {
     enableCheckAccessControls(true);
-    test(
-        new String[] {
-          LINE_JOINER.join(
-              "/** @polymerBehavior */",
-              "var FunBehavior = {",
-              "  /** @protected */",
-              "  doSomethingFun: function() {},",
-              "};"),
-          LINE_JOINER.join(
-              "var A = Polymer({",
-              "  is: 'x-element',",
-              "  callBehaviorMethod: function() {",
-              "    this.doSomethingFun();",
-              "  },",
-              "  behaviors: [ FunBehavior ],",
-              "});"),
-        },
-        new String[] {
-          LINE_JOINER.join(
-              "/** @polymerBehavior @nocollapse */",
-              "var FunBehavior = {",
-              "  /**",
-              "   * @suppress {checkTypes|globalThis|visibility}",
-              "   */",
-              "  doSomethingFun: function() {},",
-              "};"),
-          LINE_JOINER.join(
-              "/**",
-              " * @constructor",
-              " * @extends {PolymerElement}",
-              " * @implements {PolymerAInterface}",
-              " */",
-              "var A = function() {};",
-              "",
-              "/**",
-              " * @public",
-              " * @suppress {unusedPrivateMembers}",
-              " */",
-              "A.prototype.doSomethingFun = function(){};",
-              "",
-              "A = Polymer(/** @lends {A.prototype} */ {",
-              "  is: 'x-element',",
-              "  /** @this {A} */",
-              "  callBehaviorMethod: function(){ this.doSomethingFun(); },",
-              "  behaviors: [FunBehavior],",
-              "})"),
-        });
+    for (int i = 1; i <= 2; i++) {
+      this.polymerVersion = i;
+      test(
+          new String[] {
+            LINE_JOINER.join(
+                "/** @polymerBehavior */",
+                "var FunBehavior = {",
+                "  /** @protected */",
+                "  doSomethingFun: function() {},",
+                "};"),
+            LINE_JOINER.join(
+                "var A = Polymer({",
+                "  is: 'x-element',",
+                "  callBehaviorMethod: function() {",
+                "    this.doSomethingFun();",
+                "  },",
+                "  behaviors: [ FunBehavior ],",
+                "});"),
+          },
+          new String[] {
+            LINE_JOINER.join(
+                "/** @polymerBehavior @nocollapse */",
+                "var FunBehavior = {",
+                "  /**",
+                "   * @suppress {checkTypes|globalThis|visibility}",
+                "   */",
+                "  doSomethingFun: function() {},",
+                "};"),
+            LINE_JOINER.join(
+                "/**",
+                " * @constructor",
+                " * @extends {PolymerElement}",
+                " * @implements {PolymerAInterface}",
+                " */",
+                "var A = function() {};",
+                "",
+                "/**",
+                " * @public",
+                " * @suppress {unusedPrivateMembers}",
+                " */",
+                "A.prototype.doSomethingFun = function(){};",
+                "",
+                "A = Polymer(/** @lends {A.prototype} */ {",
+                "  is: 'x-element',",
+                "  /** @this {A} */",
+                "  callBehaviorMethod: function(){ this.doSomethingFun(); },",
+                "  behaviors: [FunBehavior],",
+                "})"),
+          });
+    }
   }
 
   /** If a behavior method is {@code @private} there is a visibility warning. */
@@ -1922,7 +2333,35 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "  behaviors: [ FunBehavior ],",
             "});"));
 
-    testExternChanges(EXTERNS, js, BEHAVIOR_READONLY_EXTERNS);
+    testExternChanges(
+        1,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var PolymerAInterface = function() {};",
+            "/** @type {boolean} */",
+            "PolymerAInterface.prototype.isFun;",
+            "/** @type {!Array} */",
+            "PolymerAInterface.prototype.pets;",
+            "/** @type {string} */",
+            "PolymerAInterface.prototype.name;",
+            "/** @param {boolean} isFun **/",
+            "PolymerAInterface.prototype._setIsFun;"));
+
+    testExternChanges(
+        2,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var PolymerAInterface = function() {};",
+            "/** @type {boolean} */",
+            "PolymerAInterface.prototype.isFun;",
+            "/** @param {boolean} isFun **/",
+            "PolymerAInterface.prototype._setIsFun;"));
   }
 
   /**
@@ -2120,6 +2559,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
   }
 
   public void testInvalid1() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testWarning("var x = Polymer('blah');", POLYMER_DESCRIPTOR_NOT_VALID);
     testWarning("var x = Polymer('foo-bar', {});", POLYMER_DESCRIPTOR_NOT_VALID);
@@ -2128,6 +2568,22 @@ public class PolymerPassTest extends Es6CompilerTestCase {
     testErrorEs6("var x = Polymer({is});", POLYMER_MISSING_IS);
     testErrorEs6("var x = Polymer({is: 'x-element', shortHand,});",
         POLYMER_SHORTHAND_NOT_SUPPORTED);
+
+    testErrorEs6(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return '' }",
+            "};"),
+        POLYMER_CLASS_PROPERTIES_INVALID);
+
+    testErrorEs6(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  get properties() { return {} }",
+            "};"),
+        POLYMER_CLASS_PROPERTIES_NOT_STATIC);
   }
 
   public void testInvalidProperties() {
@@ -2166,6 +2622,49 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    },",
             "  },",
             "});"),
+        POLYMER_INVALID_PROPERTY);
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testErrorEs6(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      isHappy: true,",
+            "    };",
+            "  }",
+            "};"),
+        POLYMER_INVALID_PROPERTY);
+
+    testErrorEs6(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      isHappy: {",
+            "        value: true,",
+            "      }",
+            "    };",
+            "  }",
+            "};"),
+        POLYMER_INVALID_PROPERTY);
+
+    testErrorEs6(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      isHappy: {",
+            "        type: foo.Bar,",
+            "        value: true,",
+            "      }",
+            "    };",
+            "  }",
+            "};"),
         POLYMER_INVALID_PROPERTY);
   }
 
@@ -2268,6 +2767,7 @@ public class PolymerPassTest extends Es6CompilerTestCase {
   }
 
   public void testES6FeaturesInFunctionBody() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testEs6(
         LINE_JOINER.join(
@@ -2303,5 +2803,79 @@ public class PolymerPassTest extends Es6CompilerTestCase {
             "    var [eins, zwei, drei] = arr;",
             "  },",
             "});"));
+  }
+
+  @Override
+  public void test(String js, String expected) {
+    polymerVersion = 1;
+    super.test(js, expected);
+
+    polymerVersion = 2;
+    super.test(js, expected);
+  }
+
+  public void test(int polymerVersion, String js, String expected) {
+    this.polymerVersion = polymerVersion;
+    super.test(js, expected);
+  }
+
+  @Override
+  protected void testExternChanges(String extern, String input, String expectedExtern) {
+    polymerVersion = 1;
+    super.testExternChanges(extern, input, expectedExtern);
+
+    polymerVersion = 2;
+    super.testExternChanges(extern, input, expectedExtern);
+  }
+
+  protected void testExternChanges(
+      int polymerVersion, String extern, String input, String expectedExtern) {
+    this.polymerVersion = polymerVersion;
+    super.testExternChanges(extern, input, expectedExtern);
+  }
+
+  @Override
+  public void testEs6(String js, String expected) {
+    polymerVersion = 1;
+    super.testEs6(js, expected);
+
+    polymerVersion = 2;
+    super.testEs6(js, expected);
+  }
+
+  @Override
+  public void testSameEs6(String js) {
+    polymerVersion = 1;
+    super.testSameEs6(js);
+
+    polymerVersion = 2;
+    super.testSameEs6(js);
+  }
+
+  @Override
+  public void testErrorEs6(String js, DiagnosticType error) {
+    polymerVersion = 1;
+    super.testErrorEs6(js, error);
+
+    polymerVersion = 2;
+    super.testErrorEs6(js, error);
+  }
+
+  @Override
+  public void testError(String js, DiagnosticType error) {
+    polymerVersion = 1;
+    super.testError(js, error);
+
+    polymerVersion = 2;
+    super.testError(js, error);
+  }
+
+  @Override
+  public void testWarning(String js, DiagnosticType error) {
+    polymerVersion = 1;
+    super.testWarning(js, error);
+
+    polymerVersion = 2;
+    super.testWarning(js, error);
   }
 }


### PR DESCRIPTION
Part one of addressing #2087 

This adds basic rewriting support for Polymer2 classes. This should support most `SIMPLE` mode uses, but does not yet support `ADVANCED` mode for Polymer2 elements.

Notes:

 * Synthetic externs are not used
 * Class names are not forced to be globally defined
 * Only supports classes which directly extend `Polymer.Element`. Other cases will be added in a separate PR.
 * Polymer2 elements do not currently require extern definitions for the compiler.

cc @jklein24, @MatrixFrog, @justinfagnani 