### PR TITLE
Always inline IIFEs

### DIFF
--- a/src/com/google/javascript/jscomp/InlineFunctions.java
+++ b/src/com/google/javascript/jscomp/InlineFunctions.java
@@ -22,7 +22,6 @@ import com.google.javascript.jscomp.FunctionInjector.InliningMode;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.NodeTraversal.Callback;
 import com.google.javascript.rhino.Node;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -327,7 +326,7 @@ class InlineFunctions implements CompilerPass {
           // TODO(johnlenz): this can be improved by looking at the possible
           // values for locals.  If there are simple values, or constants
           // we could still inline.
-          if (!assumeMinimumCapture && hasLocalNames(fnNode)) {
+          if (!assumeMinimumCapture && hasLocalNames(fnNode) && !NodeUtil.isIIFE(fnNode)) {
             fs.setInline(false);
           }
         }

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -2362,6 +2362,14 @@ public final class NodeUtil {
         && n.getFirstChild().isCall();
   }
 
+  static boolean isIIFE(Node n) {
+    Node parent = n.getParent();
+    return n.isFunction()
+        && parent.isCall()
+        && parent.getFirstChild() == n
+        && parent.getParent().isExprResult();
+  }
+
   static boolean isVanillaFunction(Node n) {
     return n.isFunction() && !n.isArrowFunction();
   }

--- a/test/com/google/javascript/jscomp/InlineFunctionsTest.java
+++ b/test/com/google/javascript/jscomp/InlineFunctionsTest.java
@@ -802,7 +802,7 @@ public final class InlineFunctionsTest extends CompilerTestCase {
          "function foo(){return a}" +
          "(function(){var a=5;(function(){foo()})()})()",
          "var a=3;" +
-         "{var a$jscomp$inline_0=5;{a}}"
+         "{var a$jscomp$inline_1=5;{a}}"
          );
 
     assumeMinimumCapture = true;
@@ -899,7 +899,7 @@ public final class InlineFunctionsTest extends CompilerTestCase {
          "function foo(){return a}" +
          "(function(){var a=5;(function(){foo()})()})()",
          "var a=3;" +
-         "{var a$jscomp$inline_0=5;{a}}"
+         "{var a$jscomp$inline_1=5;{a}}"
          );
 
     assumeMinimumCapture = true;
@@ -1589,8 +1589,11 @@ public final class InlineFunctionsTest extends CompilerTestCase {
     assumeMinimumCapture = false;
 
     // Don't inline if local names might be captured.
-    testSame("(function(){" +
-        "var f = function(a){call(function(){return a})};f()})()");
+    test("(function(){" +
+        "var f = function(a){call(function(){return a})};f()})()",
+        "{var f$jscomp$inline_0=function(a$jscomp$inline_1){" +
+            "call(function(){return a$jscomp$inline_1})};f$jscomp$inline_0()}"
+        );
 
     assumeMinimumCapture = true;
 
@@ -2202,16 +2205,15 @@ public final class InlineFunctionsTest extends CompilerTestCase {
             "  }",
             "})(jQuery)"),
         LINE_JOINER.join(
-            "(function($){",
-            "  $.fn.multicheck=function(options$jscomp$1) {",
+            "{",
+            "  var $$jscomp$inline_0 = jQuery;",
+            "  $$jscomp$inline_0.fn.multicheck = function(options$jscomp$inline_4) {",
             "    {",
-            "      options$jscomp$1.checkboxes=$(this).siblings(':checkbox');",
-            "      {",
-            "        $(this).data('checkboxes');",
-            "      }",
+            "      options$jscomp$inline_4.checkboxes = $$jscomp$inline_0(this).siblings(':checkbox');",
+            "      { $$jscomp$inline_0(this).data('checkboxes'); }",
             "    }",
             "  }",
-            "})(jQuery)"));
+            "}"));
   }
 
   public void testIssue423_minCap() {
@@ -2262,9 +2264,9 @@ public final class InlineFunctionsTest extends CompilerTestCase {
   public void testAnonymous1() {
     assumeMinimumCapture = false;
     test("(function(){var a=10;(function(){var b=a;a++;alert(b)})()})();",
-         "{var a$jscomp$inline_0=10;" +
-         "{var b$jscomp$inline_1=a$jscomp$inline_0;" +
-         "a$jscomp$inline_0++;alert(b$jscomp$inline_1)}}");
+         "{var a$jscomp$inline_2=10;" +
+         "{var b$jscomp$inline_0=a$jscomp$inline_2;" +
+         "a$jscomp$inline_2++;alert(b$jscomp$inline_0)}}");
 
     assumeMinimumCapture = true;
     test("(function(){var a=10;(function(){var b=a;a++;alert(b)})()})();",
@@ -2288,7 +2290,9 @@ public final class InlineFunctionsTest extends CompilerTestCase {
   public void testAnonymous3() {
     // Introducing a new value into is tricky
     assumeMinimumCapture = false;
-    testSame("(function(){var a=10;(function(){arguments;})()})();");
+    test("(function(){var a=10;(function(){arguments;})()})();",
+        "{var a$jscomp$inline_0=10;(function(){arguments})()}"
+        );
 
     assumeMinimumCapture = true;
     test("(function(){var a=10;(function(){arguments;})()})();",

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -2743,8 +2743,7 @@ public final class IntegrationTest extends IntegrationTestCase {
         "x.bar();";
     String expected =
         "var x = new function() {};" +
-        "/** @this {F} */" +
-        "(function (y) { y.bar = function() { alert(3); }; })(x);" +
+        "x.bar = function(){ alert(3); };" +
         "x.bar();";
 
     CompilerOptions options = createCompilerOptions();


### PR DESCRIPTION
This is a rollforward of 0660acdb. I fully expect this to be rolled back again, but we don't know what cases triggered the original rollback.

IIFEs blocking optimizations are frequently coming up - and they are generated by Typescript.

 * #2100 
 * #2103 
 * http://stackoverflow.com/a/41986846/1211524

If someone can get me test cases that break, I'll update this optimization to address them.