### PR TITLE
Replace property reflection calls with the property string in SIMPLE mode

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2080,11 +2080,13 @@ public final class DefaultPassConfig extends PassConfig {
   /** Special case optimizations for closure functions. */
   private final PassFactory closureOptimizePrimitives =
       new PassFactory("closureOptimizePrimitives", true) {
-    @Override
-    protected CompilerPass create(final AbstractCompiler compiler) {
-      return new ClosureOptimizePrimitives(compiler);
-    }
-  };
+        @Override
+        protected CompilerPass create(final AbstractCompiler compiler) {
+          return new ClosureOptimizePrimitives(
+              compiler,
+              compiler.getOptions().propertyRenaming == PropertyRenamingPolicy.ALL_UNQUOTED);
+        }
+      };
 
   /** Puts global symbols into a single object. */
   private final PassFactory rescopeGlobalSymbols =

--- a/test/com/google/javascript/jscomp/ClosureOptimizePrimitivesTest.java
+++ b/test/com/google/javascript/jscomp/ClosureOptimizePrimitivesTest.java
@@ -25,8 +25,10 @@ import static com.google.javascript.jscomp.ClosureOptimizePrimitives.DUPLICATE_S
  */
 public final class ClosureOptimizePrimitivesTest extends CompilerTestCase {
 
+  private boolean propertyRenamingEnabled = true;
+
   @Override public CompilerPass getProcessor(final Compiler compiler) {
-    return new ClosureOptimizePrimitives(compiler);
+    return new ClosureOptimizePrimitives(compiler, propertyRenamingEnabled);
   }
 
   public void testObjectCreateNonConstKey() {
@@ -93,5 +95,16 @@ public final class ClosureOptimizePrimitivesTest extends CompilerTestCase {
     test("goog$dom$createDom(goog$dom$TagName$A)", "goog$dom$createDom('A')");
     test("goog.dom.createDom(goog.dom.TagName.A + 'REA')", "goog.dom.createDom('A' + 'REA')");
     test("goog.dom.TagName.function__new_goog_dom_TagName__string___undefined$DIV", "'DIV'");
+  }
+
+  public void testPropertyReflectionSimple() {
+    propertyRenamingEnabled = false;
+    test("goog.reflect.objectProperty('push', [])", "'push'");
+    test("JSCompiler_renameProperty('push', [])", "'push'");
+  }
+
+  public void testPropertyReflectionAdvanced() {
+    test("goog.reflect.objectProperty('push', [])", "JSCompiler_renameProperty('push', [])");
+    testSame("JSCompiler_renameProperty('push', [])");
   }
 }


### PR DESCRIPTION
Fixes #2141

Replaces calls to `goog.reflect.objectProperty` and friends with the 1st argument when property renaming is disabled.