### PR TITLE
Prevent renaming of Polymer 2 static properties

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -435,6 +435,12 @@ public final class DefaultPassConfig extends PassConfig {
       checks.add(generateExports);
     }
 
+    if (options.polymerVersion != null
+        && options.polymerVersion > 1
+        && options.propertyRenaming != PropertyRenamingPolicy.OFF) {
+      checks.add(polymerProtectStaticProperties);
+    }
+
     checks.add(createEmptyPass("afterStandardChecks"));
 
     assertAllOneTimePasses(checks);
@@ -3068,6 +3074,15 @@ public final class DefaultPassConfig extends PassConfig {
         @Override
         protected FeatureSet featureSet() {
           return ES8;
+        }
+      };
+
+  /** Prevents renaming of static properties on Polymer Element classes */
+  private final PassFactory polymerProtectStaticProperties =
+      new PassFactory("polymerProtectStaticProperties", true) {
+        @Override
+        protected CompilerPass create(AbstractCompiler compiler) {
+          return new PolymerProtectStaticProperties(compiler);
         }
       };
 

--- a/src/com/google/javascript/jscomp/PolymerProtectStaticProperties.java
+++ b/src/com/google/javascript/jscomp/PolymerProtectStaticProperties.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import com.google.javascript.rhino.IR;
+import com.google.javascript.rhino.Node;
+
+/**
+ * Prevents renaming of the Polymer 2 static properties "is" and "config" by adding externs to the
+ * Function.prototype.
+ *
+ * <p>This pass must run after type checking since otherwise all functions would have an "is" and
+ * "config" property.
+ */
+class PolymerProtectStaticProperties implements CompilerPass {
+
+  private final AbstractCompiler compiler;
+
+  PolymerProtectStaticProperties(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    FindPolymerExterns findPolymerExterns = new FindPolymerExterns();
+    NodeTraversal.traverseEs6(compiler, externs, findPolymerExterns);
+
+    if (findPolymerExterns.hasPolymerElementExterns()) {
+      addExtern("is");
+      addExtern("properties");
+      addExtern("observers");
+    }
+  }
+
+  private void addExtern(String export) {
+    Node propstmt =
+        IR.exprResult(
+            IR.getprop(NodeUtil.newQName(compiler, "Function.prototype"), IR.string(export)));
+    propstmt.useSourceInfoFromForTree(getSynthesizedExternsRoot());
+    propstmt.setOriginalName(export);
+    getSynthesizedExternsRoot().addChildToBack(propstmt);
+    compiler.reportCodeChange();
+  }
+
+  /** Lazily create a "new" externs root for undeclared variables. */
+  private Node getSynthesizedExternsRoot() {
+    return compiler.getSynthesizedExternsInput().getAstRoot(compiler);
+  }
+
+  /** Traverse the externs to find references to Polymer.Element. */
+  class FindPolymerExterns implements NodeTraversal.Callback {
+    private boolean hasPolymerElementExterns_ = false;
+
+    public boolean hasPolymerElementExterns() {
+      return hasPolymerElementExterns_;
+    }
+
+    @Override
+    public boolean shouldTraverse(NodeTraversal nodeTraversal, Node n, Node parent) {
+      return true;
+    }
+
+    @Override
+    public void visit(NodeTraversal t, Node n, Node parent) {
+      if (t.inGlobalScope()) {
+        if (n.isAssign()
+            && n.getFirstChild().isGetProp()
+            && n.getFirstChild().matchesQualifiedName("Polymer.Element")) {
+          hasPolymerElementExterns_ = true;
+        }
+      }
+    }
+  }
+}

--- a/test/com/google/javascript/jscomp/PolymerProtectStaticPropertiesTest.java
+++ b/test/com/google/javascript/jscomp/PolymerProtectStaticPropertiesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+public final class PolymerProtectStaticPropertiesTest extends CompilerTestCase {
+
+  private static final String EXTERNS =
+      LINE_JOINER.join("var Polymer = {};", "Polymer.Element = function() {};");
+
+  public PolymerProtectStaticPropertiesTest() {
+    super(EXTERNS);
+  }
+
+  @Override
+  protected CompilerPass getProcessor(Compiler compiler) {
+    return new PolymerProtectStaticProperties(compiler);
+  }
+
+  @Override
+  protected int getNumRepetitions() {
+    // This pass only runs once.
+    return 1;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    allowExternsChanges();
+  }
+
+  public void testExternsAdded() {
+    this.disableCompareAsTree();
+    testExternChanges(
+        EXTERNS,
+        "",
+        LINE_JOINER.join(
+            "Function.prototype.is;",
+            "Function.prototype.properties;",
+            "Function.prototype.observers;",
+            EXTERNS));
+  }
+
+  public void testNoExternsAdded() {
+    this.disableCompareAsTree();
+    testExternChanges("", "", "");
+  }
+}


### PR DESCRIPTION
Polymer 2 classes define static getters. When Polymer is used as an external library, these properties must not be renamed. Since the type system doesn't model static properties on a constructor currently, this pass adds `is` and `config` properties to `Function.prototype`. This will block renaming of any `is` or `config` property when defined on a function.

cc @justinfagnani
