### PR TITLE
Convert the --polymer_pass flag from a boolean to an optional integer

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -532,10 +532,13 @@ public class CommandLineRunner extends
         + "annotated with @ngInject")
     private boolean angularPass = false;
 
-    @Option(name = "--polymer_pass",
-        handler = BooleanOptionHandler.class,
-        usage = "Rewrite Polymer classes to be compiler-friendly.")
-    private boolean polymerPass = false;
+    @Option(
+      name = "--polymer_pass",
+      handler = OptIntegerOptionHandler.class,
+      usage =
+          "Rewrite Polymer classes to be compiler-friendly. Specify Polymer major version: 1 or 2."
+    )
+    private Integer polymerPass = null;
 
     @Option(name = "--chrome_pass",
         handler = BooleanOptionHandler.class,
@@ -1085,6 +1088,46 @@ public class CommandLineRunner extends
       }
     }
 
+    // Our own option parser to be backwards-compatible.
+    // It needs to be public because of the crazy reflection that args4j does.
+    public static class OptIntegerOptionHandler extends OptionHandler<Integer> {
+      private static final String ERR_MESSAGE = "Bad value for %s: %s";
+
+      public OptIntegerOptionHandler(
+          CmdLineParser parser, OptionDef option, Setter<? super Integer> setter) {
+        super(parser, option, setter);
+      }
+
+      @Override
+      public int parseArguments(Parameters params) throws CmdLineException {
+        String param = null;
+        int version = 1;
+        try {
+          param = params.getParameter(0);
+        } catch (CmdLineException e) {
+          param = null; // to stop linter complaints
+        }
+
+        if (param == null) {
+          setter.addValue(version);
+          return 0;
+        } else {
+          try {
+            version = Integer.parseInt(param);
+          } catch (NumberFormatException e) {
+            throw new CmdLineException("Bad value for " + option.toString() + ": " + param);
+          }
+          setter.addValue(version);
+          return 1;
+        }
+      }
+
+      @Override
+      public String getDefaultMetaVariable() {
+        return null;
+      }
+    }
+
     // Our own parser for warning guards that preserves the original order
     // of the flags.
     public static class WarningGuardErrorOptionHandler
@@ -1412,6 +1455,10 @@ public class CommandLineRunner extends
       reportError("--output_wrapper and --isolation_mode may not be used together.");
     }
 
+    if (flags.polymerPass != null && (flags.polymerPass < 1 || flags.polymerPass > 2)) {
+      reportError("--polymer_pass may only have a value of 1 or 2.");
+    }
+
     if (flags.isolationMode == IsolationMode.IIFE) {
       flags.outputWrapper = "(function(){%output%}).call(this);";
     }
@@ -1633,7 +1680,7 @@ public class CommandLineRunner extends
 
     options.angularPass = flags.angularPass;
 
-    options.polymerPass = flags.polymerPass;
+    options.polymerVersion = flags.polymerPass;
 
     options.chromePass = flags.chromePass;
 

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Compiler options
@@ -717,7 +718,7 @@ public class CompilerOptions {
   boolean angularPass;
 
   /** Processes Polymer calls */
-  boolean polymerPass;
+  @Nullable Integer polymerVersion;
 
   /** Processes cr.* functions */
   boolean chromePass;
@@ -1200,7 +1201,7 @@ public class CompilerOptions {
     preserveGoogProvidesAndRequires = false;
     jqueryPass = false;
     angularPass = false;
-    polymerPass = false;
+    polymerVersion = null;
     dartPass = false;
     j2clPassMode = J2clPassMode.OFF;
     removeAbstractMethods = false;
@@ -1669,8 +1670,8 @@ public class CompilerOptions {
     this.angularPass = angularPass;
   }
 
-  public void setPolymerPass(boolean polymerPass) {
-    this.polymerPass = polymerPass;
+  public void setPolymerVersion(Integer polymerPassVersion) {
+    this.polymerVersion = polymerPassVersion;
   }
 
   public void setDartPass(boolean dartPass) {
@@ -2785,7 +2786,7 @@ public class CompilerOptions {
                 "parentModuleCanSeeSymbolsDeclaredInChildren",
                 parentModuleCanSeeSymbolsDeclaredInChildren)
             .add("parseJsDocDocumentation", isParseJsDocDocumentation())
-            .add("polymerPass", polymerPass)
+            .add("polymerVersion", polymerVersion)
             .add("preferLineBreakAtEndOfFile", preferLineBreakAtEndOfFile)
             .add("preferSingleQuotes", preferSingleQuotes)
             .add("preferStableNames", preferStableNames)

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -338,7 +338,7 @@ public final class DefaultPassConfig extends PassConfig {
 
     // It's important that the PolymerPass run *after* the ClosurePrimitives and ChromePass rewrites
     // and *before* the suspicious code checks. This is enforced in the assertValidOrder method.
-    if (options.polymerPass) {
+    if (options.polymerVersion != null) {
       checks.add(polymerPass);
     }
 
@@ -946,7 +946,7 @@ public final class DefaultPassConfig extends PassConfig {
         // getters/setters for many properties in compiled code. Dead property assignment
         // elimination is only safe when it knows about getters/setters. Therefore, we skip
         // it if the polymer pass is enabled.
-        if (!options.polymerPass) {
+        if (options.polymerVersion == null) {
           passes.add(deadPropertyAssignmentElimination);
         }
       }

--- a/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesInPolymerElementTest.java
+++ b/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesInPolymerElementTest.java
@@ -56,7 +56,7 @@ public final class CheckUnusedPrivatePropertiesInPolymerElementTest
     options.setWarningLevel(DiagnosticGroups.MISSING_PROPERTIES, CheckLevel.OFF);
     // Global this is used deliberately to refer to Window in these tests
     options.setWarningLevel(new DiagnosticGroup(NewTypeInference.GLOBAL_THIS), CheckLevel.OFF);
-    options.setPolymerPass(true);
+    options.setPolymerVersion(1);
     return options;
   }
 

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -379,7 +379,7 @@ public final class IntegrationTest extends IntegrationTestCase {
 
   public void testConstPolymerNotAllowed() {
     CompilerOptions options = createCompilerOptions();
-    options.setPolymerPass(true);
+    options.setPolymerVersion(1);
     options.setLanguageIn(LanguageMode.ECMASCRIPT6_STRICT);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
 


### PR DESCRIPTION
Convert the `--polymer_pass` flag from a boolean to an optional integer. When used without a value (like a boolean flag), the flag defaults to "1".

Example: `--polymer_pass` is equivalent to `--polymer_pass=1`

Also switches the CompilerOption polymerPass field to polymerVersion.

This allows users to specify whether they want Polymer 1 or Polymer 2 behavior.

I'm not sure if something similar can be done with the internal command line runner or not.

Fixes #2288