### PR TITLE
Make EventInit record type and add composed property

### DIFF
--- a/externs/browser/w3c_event.js
+++ b/externs/browser/w3c_event.js
@@ -76,12 +76,20 @@ EventListener.prototype.handleEvent = function(evt) {};
 // https://dvcs.w3.org/hg/d4e/raw-file/tip/source_respec.htm#event-constructors
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined)
- * }}
+ * @record
+ * @see https://dom.spec.whatwg.org/#dictdef-eventinit
  */
-var EventInit;
+function EventInit() {};
+
+/** @type {(undefined|boolean)} */
+EventInit.prototype.bubbles;
+
+/** @type {(undefined|boolean)} */
+EventInit.prototype.cancelable;
+
+/** @type {(undefined|boolean)} */
+EventInit.prototype.composed;
+
 
 /**
  * @constructor


### PR DESCRIPTION
See: https://dom.spec.whatwg.org/#dictdef-eventinit

If this gets in I will also convert all `*EventInit` typedefs to the `@record` type which will simplify current externs and will also help with writing new externs because `EventInit` is extended everytime a new event is specced.