### PR TITLE
Remove <string> from Object.entries() return type

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -1387,7 +1387,7 @@ Object.values = function(obj) {};
 
 /**
  * @param {!Object<T>} obj
- * @return {!Array<!Array<(string|T)>>} entries
+ * @return {!Array<!Array<(string)>>} entries
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
  * @throws {Error}
  * @template T


### PR DESCRIPTION
Going through https://tc39.github.io/ecma262/#sec-object.entries, I don't see where the <string> type is coming from, or why it should be appended to the template type.