### PR TITLE
Convert *EventInit typedefs to record types

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2249,29 +2249,23 @@ DataTransfer.prototype.addElement = function(elem) {};
 MouseEvent.prototype.dataTransfer;
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   screenX: (number|undefined),
- *   screenY: (number|undefined),
- *   clientX: (number|undefined),
- *   clientY: (number|undefined),
- *   ctrlKey: (boolean|undefined),
- *   shiftKey: (boolean|undefined),
- *   altKey: (boolean|undefined),
- *   metaKey: (boolean|undefined),
- *   button: (number|undefined),
- *   buttons: (number|undefined),
- *   relatedTarget: (EventTarget|undefined),
- *   deltaX: (number|undefined),
- *   deltaY: (number|undefined),
- *   deltaZ: (number|undefined),
- *   deltaMode: (number|undefined)
- * }}
+ * @record
+ * @extends {MouseEventInit}
+ * @see https://w3c.github.io/uievents/#idl-wheeleventinit
  */
-var WheelEventInit;
+function WheelEventInit() {};
+
+/** @type {undefined|number} */
+WheelEventInit.prototype.deltaX;
+
+/** @type {undefined|number} */
+WheelEventInit.prototype.deltaY;
+
+/** @type {undefined|number} */
+WheelEventInit.prototype.deltaZ;
+
+/** @type {undefined|number} */
+WheelEventInit.prototype.deltaMode;
 
 /**
  * @param {string} type
@@ -2388,26 +2382,14 @@ DataTransferItemList.prototype.clear = function() {};
 DataTransfer.prototype.items;
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   screenX: (number|undefined),
- *   screenY: (number|undefined),
- *   clientX: (number|undefined),
- *   clientY: (number|undefined),
- *   ctrlKey: (boolean|undefined),
- *   shiftKey: (boolean|undefined),
- *   altKey: (boolean|undefined),
- *   metaKey: (boolean|undefined),
- *   button: (number|undefined),
- *   buttons: (number|undefined),
- *   relatedTarget: (EventTarget|undefined),
- *   dataTransfer: (DataTransfer|undefined)
- * }}
+ * @record
+ * @extends {MouseEventInit}
+ * @see http://w3c.github.io/html/editing.html#dictdef-drageventinit
  */
-var DragEventInit;
+function DragEventInit() {};
+
+/** @type {undefined|?DataTransfer} */
+DragEventInit.prototype.dataTransfer;
 
 
 /**
@@ -2424,13 +2406,20 @@ DragEvent.prototype.dataTransfer;
 
 
 /**
- * @typedef {{
- *   lengthComputable: (boolean|undefined),
- *   loaded: (number|undefined),
- *   total: (number|undefined)
- * }}
+ * @record
+ * @extends {EventInit}
+ * @see https://www.w3.org/TR/progress-events/#progresseventinit
  */
-var ProgressEventInit;
+function ProgressEventInit() {};
+
+/** @type {undefined|boolean} */
+ProgressEventInit.prototype.lengthComputable;
+
+/** @type {undefined|number} */
+ProgressEventInit.prototype.loaded;
+
+/** @type {undefined|number} */
+ProgressEventInit.prototype.total;
 
 /**
  * @constructor
@@ -3620,19 +3609,26 @@ ErrorEvent.prototype.error;
 
 
 /**
- * @see http://www.w3.org/TR/html5/webappapis.html#the-errorevent-interface
- *
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   message: string,
- *   filename: string,
- *   lineno: number,
- *   colno: number,
- *   error: *
- * }}
+ * @record
+ * @extends {EventInit}
+ * @see https://www.w3.org/TR/html5/webappapis.html#erroreventinit
  */
- var ErrorEventInit;
+function ErrorEventInit() {};
+
+/** @type {undefined|string} */
+ErrorEventInit.prototype.message;
+
+/** @type {undefined|string} */
+ErrorEventInit.prototype.filename;
+
+/** @type {undefined|number} */
+ErrorEventInit.prototype.lineno;
+
+/** @type {undefined|number} */
+ErrorEventInit.prototype.colno;
+
+/** @type {*} */
+ErrorEventInit.prototype.error;
 
 
 /**

--- a/externs/browser/w3c_event.js
+++ b/externs/browser/w3c_event.js
@@ -170,13 +170,14 @@ Event.prototype.preventDefault = function() {};
 Event.prototype.initEvent = function(eventTypeArg, canBubbleArg, cancelableArg) {};
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   detail: *
- * }}
+ * @record
+ * @extends {EventInit}
+ * @see https://dom.spec.whatwg.org/#dictdef-customeventinit
  */
-var CustomEventInit;
+function CustomEventInit() {};
+
+/** @type {*} */
+CustomEventInit.prototype.detail;
 
 /**
  * @constructor
@@ -214,14 +215,17 @@ function DocumentEvent() {}
 DocumentEvent.prototype.createEvent = function(eventType) {};
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined)
- * }}
+ * @record
+ * @extends {EventInit}
+ * @see https://w3c.github.io/uievents/#idl-uieventinit
  */
-var UIEventInit;
+function UIEventInit() {};
+
+/** @type {undefined|?Window} */
+UIEventInit.prototype.view;
+
+/** @type {undefined|number} */
+UIEventInit.prototype.detail;
 
 /**
  * @constructor
@@ -246,25 +250,81 @@ UIEvent.prototype.initUIEvent = function(typeArg, canBubbleArg, cancelableArg,
     viewArg, detailArg) {};
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   screenX: (number|undefined),
- *   screenY: (number|undefined),
- *   clientX: (number|undefined),
- *   clientY: (number|undefined),
- *   ctrlKey: (boolean|undefined),
- *   shiftKey: (boolean|undefined),
- *   altKey: (boolean|undefined),
- *   metaKey: (boolean|undefined),
- *   button: (number|undefined),
- *   buttons: (number|undefined),
- *   relatedTarget: (EventTarget|undefined)
- * }}
+ * @record
+ * @extends {UIEventInit}
+ * @see https://w3c.github.io/uievents/#dictdef-eventmodifierinit
  */
-var MouseEventInit;
+function EventModifierInit() {};
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.ctrlKey;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.shiftKey;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.altKey;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.metaKey;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierAltGraph;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierCapsLock;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierFn;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierFnLock;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierHyper;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierNumLock;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierScrollLock;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierSuper;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierSymbol;
+
+/** @type {undefined|boolean} */
+EventModifierInit.prototype.modifierSymbolLock;
+
+/**
+ * @record
+ * @extends {EventModifierInit}
+ * @see https://w3c.github.io/uievents/#idl-mouseeventinit
+ */
+function MouseEventInit() {};
+
+/** @type {undefined|number} */
+MouseEventInit.prototype.screenX;
+
+/** @type {undefined|number} */
+MouseEventInit.prototype.screenY;
+
+/** @type {undefined|number} */
+MouseEventInit.prototype.clientX;
+
+/** @type {undefined|number} */
+MouseEventInit.prototype.clientY;
+
+/** @type {undefined|number} */
+MouseEventInit.prototype.button;
+
+/** @type {undefined|number} */
+MouseEventInit.prototype.buttons;
+
+/** @type {undefined|?EventTarget} */
+MouseEventInit.prototype.relatedTarget;
 
 /**
  * @constructor
@@ -342,24 +402,32 @@ MutationEvent.prototype.initMutationEvent = function(typeArg, canBubbleArg, canc
 
 // DOM3
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   char: (string|undefined),
- *   key: (string|undefined),
- *   code: (string|undefined),
- *   location: (number|undefined),
- *   ctrlKey: (boolean|undefined),
- *   shiftKey: (boolean|undefined),
- *   altKey: (boolean|undefined),
- *   metaKey: (boolean|undefined),
- *   repeat: (boolean|undefined),
- *   locale: (string|undefined)
- * }}
+ * @record
+ * @extends {EventModifierInit}
+ * @see https://w3c.github.io/uievents/#idl-keyboardeventinit
  */
-var KeyboardEventInit;
+function KeyboardEventInit() {};
+
+/** @type {undefined|string} */
+KeyboardEventInit.prototype.key;
+
+/** @type {undefined|string} */
+KeyboardEventInit.prototype.code;
+
+/** @type {undefined|number} */
+KeyboardEventInit.prototype.location;
+
+/** @type {undefined|boolean} */
+KeyboardEventInit.prototype.repeat;
+
+/** @type {undefined|boolean} */
+KeyboardEventInit.prototype.isComposing;
+
+/** @type {undefined|string} */
+KeyboardEventInit.prototype.char;
+
+/** @type {undefined|string} */
+KeyboardEventInit.prototype.locale;
 
 /**
  * @constructor
@@ -391,15 +459,14 @@ KeyboardEvent.prototype.metaKey;
 KeyboardEvent.prototype.getModifierState = function(keyIdentifierArg) {};
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   relatedTarget: (EventTarget|undefined)
- * }}
+ * @record
+ * @extends {UIEventInit}
+ * @see https://w3c.github.io/uievents/#idl-focuseventinit
  */
-var FocusEventInit;
+function FocusEventInit() {};
+
+/** @type {undefined|?EventTarget} */
+FocusEventInit.prototype.relatedTarget;
 
 
 /**
@@ -441,18 +508,24 @@ AddEventListenerOptions.prototype.passive;
 AddEventListenerOptions.prototype.once;
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   data: (string|undefined),
- *   isComposed: (boolean|undefined),
- *   inputType: (string|undefined),
- *   dataTransfer: (DataTransfer|undefined)
- * }}
+ * @record
+ * @extends {UIEventInit}
+ * @see https://w3c.github.io/uievents/#idl-inputeventinit
+ * @see https://w3c.github.io/input-events/#interface-InputEvent
  */
-var InputEventInit;
+function InputEventInit() {};
+
+/** @type {undefined|?string} */
+InputEventInit.prototype.data;
+
+/** @type {undefined|boolean} */
+InputEventInit.prototype.isComposing;
+
+/** @type {undefined|string} */
+InputEventInit.prototype.inputType;
+
+/** @type {undefined|?DataTransfer} */
+InputEventInit.prototype.dataTransfer;
 
 
 // TODO(charleyroy): Add getTargetRanges() once a consensus has been made

--- a/externs/browser/w3c_midi.js
+++ b/externs/browser/w3c_midi.js
@@ -261,12 +261,17 @@ MIDIMessageEvent.prototype.data;
 
 
 /**
- * @typedef {{
- *   receivedTime: number,
- *   data: !Uint8Array
- * }}
+ * @record
+ * @extends {EventInit}
+ * @see https://www.w3.org/TR/webmidi/#midimessageeventinit-interface
  */
-var MIDIMessageEventInit;
+function MIDIMessageEventInit() {};
+
+/** @type {undefined|number} */
+MIDIMessageEventInit.prototype.receivedTime;
+
+/** @type {undefined|!Uint8Array} */
+MIDIMessageEventInit.prototype.data;
 
 
 
@@ -286,8 +291,11 @@ MIDIConnectionEvent.prototype.port;
 
 
 /**
- * @typedef {{
- *   port: !MIDIPort
- * }}
+ * @record
+ * @extends {EventInit}
+ * @see https://www.w3.org/TR/webmidi/#idl-def-MIDIConnectionEventInit
  */
-var MIDIConnectionEventInit;
+function MIDIConnectionEventInit() {};
+
+/** @type {undefined|!MIDIPort} */
+MIDIConnectionEventInit.prototype.port;

--- a/externs/browser/w3c_pointer_events.js
+++ b/externs/browser/w3c_pointer_events.js
@@ -43,33 +43,35 @@ Navigator.prototype.maxTouchPoints;
 
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   screenX: (number|undefined),
- *   screenY: (number|undefined),
- *   clientX: (number|undefined),
- *   clientY: (number|undefined),
- *   ctrlKey: (boolean|undefined),
- *   shiftKey: (boolean|undefined),
- *   altKey: (boolean|undefined),
- *   metaKey: (boolean|undefined),
- *   button: (number|undefined),
- *   buttons: (number|undefined),
- *   relatedTarget: (EventTarget|undefined),
- *   pointerId: (number|undefined),
- *   width: (number|undefined),
- *   height: (number|undefined),
- *   pressure: (number|undefined),
- *   tiltX: (number|undefined),
- *   tiltY: (number|undefined),
- *   pointerType: (string|undefined),
- *   isPrimary: (boolean|undefined)
- * }}
+ * @record
+ * @extends {MouseEventInit}
+ * @see https://www.w3.org/TR/pointerevents/#idl-def-PointerEventInit
  */
-var PointerEventInit;
+function PointerEventInit() {};
+
+/** @type {undefined|number} */
+PointerEventInit.prototype.pointerId;
+
+/** @type {undefined|number} */
+PointerEventInit.prototype.width;
+
+/** @type {undefined|number} */
+PointerEventInit.prototype.height;
+
+/** @type {undefined|number} */
+PointerEventInit.prototype.pressure;
+
+/** @type {undefined|number} */
+PointerEventInit.prototype.tiltX;
+
+/** @type {undefined|number} */
+PointerEventInit.prototype.tiltY;
+
+/** @type {undefined|string} */
+PointerEventInit.prototype.pointerType;
+
+/** @type {undefined|boolean} */
+PointerEventInit.prototype.isPrimary;
 
 /**
  * @constructor

--- a/externs/browser/w3c_touch_event.js
+++ b/externs/browser/w3c_touch_event.js
@@ -175,18 +175,22 @@ TouchList.prototype.identifiedTouch = function(identifier) {};
 Document.prototype.createTouchList = function(touches) {};
 
 /**
- * @typedef {{
- *   bubbles: (boolean|undefined),
- *   cancelable: (boolean|undefined),
- *   view: (Window|undefined),
- *   detail: (number|undefined),
- *   relatedTarget: (EventTarget|undefined),
- *   touches: (!Array<Touch>|undefined),
- *   targetTouches: (!Array<Touch>|undefined),
- *   changedTouches: (!Array<Touch>|undefined)
- * }}
+ * @record
+ * @extends {UIEventInit}
  */
-var TouchEventInit;
+function TouchEventInit() {};
+
+/** @type {undefined|?EventTarget} */
+TouchEventInit.prototype.relatedTarget;
+
+/** @type {undefined|!Array<Touch>} */
+TouchEventInit.prototype.touches;
+
+/** @type {undefined|!Array<Touch>} */
+TouchEventInit.prototype.targetTouches;
+
+/** @type {undefined|!Array<Touch>} */
+TouchEventInit.prototype.changedTouches;
 
 /**
  * The TouchEvent class encapsulates information about a touch event.


### PR DESCRIPTION
1) Added `EventModifierInit` type.
See https://w3c.github.io/uievents/#dictdef-eventmodifierinit

2) `isComposed` property in `InputEventInit` was renamed to `isComposing`.
See https://w3c.github.io/uievents/#idl-inputeventinit

Missing changes for ServiceWorker `*EventInit`s are part of this PR #1972