### PR TITLE
Allow suppressing of conformance violations

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
+++ b/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
@@ -152,6 +152,7 @@ jsdoc.suppressions =\
     checkTypes,\
     checkVars,\
     closureDepMethodUsageChecks,\
+    conformanceViolations,\
     const,\
     constantProperty,\
     deprecated,\


### PR DESCRIPTION
Currently `@suppress {conformanceViolations}` is working but it raises
another warning: `Parse error. unknown @suppress parameter:
conformanceViolations`