### PR TITLE
createImageData and getImageData always return ImageData

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -478,7 +478,7 @@ CanvasRenderingContext2D.prototype.drawImage = function(
 /**
  * @param {number} sw
  * @param {number} sh
- * @return {ImageData}
+ * @return {!ImageData}
  * @nosideeffects
  */
 CanvasRenderingContext2D.prototype.createImageData = function(sw, sh) {};
@@ -488,7 +488,7 @@ CanvasRenderingContext2D.prototype.createImageData = function(sw, sh) {};
  * @param {number} sy
  * @param {number} sw
  * @param {number} sh
- * @return {ImageData}
+ * @return {!ImageData}
  * @throws {Error}
  */
 CanvasRenderingContext2D.prototype.getImageData = function(sx, sy, sw, sh) {};


### PR DESCRIPTION
My reading of the HTML5 spec is that these two methods will always return an `ImageData` if they didn't throw an exception, so `null` isn't a valid return type. Relevant parts of the spec quoted and linked below (emphasis mine).

> [When the createImageData() method is invoked with two numeric arguments sw and sh, **it must create an ImageData object**, with parameter pixelsPerRow set to the absolute magnitude of sw, and parameter rows set to the absolute magnitude of sh. Initialize the image data of the new ImageData object to transparent black. If both sw and sh are non-zero, then return the new ImageData object. If one or both of sw and sh are zero, then throw an "IndexSizeError" DOMException instead.](https://html.spec.whatwg.org/multipage/scripting.html#dom-context-2d-createimagedata)

> [The getImageData(sx, sy, sw, sh) method, when invoked, must, if either the sw or sh arguments are zero, throw an "IndexSizeError" DOMException; otherwise, if the CanvasRenderingContext2D's origin-clean flag is set to false, it must throw a "SecurityError" DOMException; otherwise, **it must create an ImageData object**, with parameter pixelsPerRow set to sw, and parameter rows set to sh.](https://html.spec.whatwg.org/multipage/scripting.html#dom-context-2d-getimagedata)

