### PR TITLE
Add restrictions for property name generation for Angular and Polymer

### DIFF
--- a/src/com/google/javascript/jscomp/AngularPass.java
+++ b/src/com/google/javascript/jscomp/AngularPass.java
@@ -71,6 +71,8 @@ import java.util.List;
  */
 class AngularPass extends AbstractPostOrderCallback
     implements HotSwapCompilerPass {
+  static final char[] PROPERTY_RESERVED_FIRST_CHARS = {'$'};
+
   final AbstractCompiler compiler;
 
   /** Nodes annotated with @ngInject */

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.primitives.Chars;
 import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.jscomp.parsing.Config;
 import com.google.javascript.rhino.IR;
@@ -3216,5 +3217,35 @@ public class CompilerOptions {
   public CompilerOptions setStrictModeInput(boolean isStrictModeInput) {
     this.isStrictModeInput = isStrictModeInput;
     return this;
+  }
+
+  public char[] getPropertyReservedNamingFirstChars() {
+    char[] reservedChars = anonymousFunctionNaming.getReservedCharacters();
+    if (polymerVersion != null && polymerVersion > 1) {
+      if (reservedChars == null) {
+        reservedChars = PolymerPass.PROPERTY_RESERVED_FIRST_CHARS;
+      } else {
+        reservedChars = Chars.concat(reservedChars, PolymerPass.PROPERTY_RESERVED_FIRST_CHARS);
+      }
+    } else if (angularPass) {
+      if (reservedChars == null) {
+        reservedChars = AngularPass.PROPERTY_RESERVED_FIRST_CHARS;
+      } else {
+        reservedChars = Chars.concat(reservedChars, AngularPass.PROPERTY_RESERVED_FIRST_CHARS);
+      }
+    }
+    return reservedChars;
+  }
+
+  public char[] getPropertyReservedNamingNonFirstChars() {
+    char[] reservedChars = anonymousFunctionNaming.getReservedCharacters();
+    if (polymerVersion != null && polymerVersion > 1) {
+      if (reservedChars == null) {
+        reservedChars = PolymerPass.PROPERTY_RESERVED_NON_FIRST_CHARS;
+      } else {
+        reservedChars = Chars.concat(reservedChars, PolymerPass.PROPERTY_RESERVED_NON_FIRST_CHARS);
+      }
+    }
+    return reservedChars;
   }
 }

--- a/src/com/google/javascript/jscomp/DefaultNameGenerator.java
+++ b/src/com/google/javascript/jscomp/DefaultNameGenerator.java
@@ -106,20 +106,30 @@ final class DefaultNameGenerator implements NameGenerator {
     reset(reservedNames, "", null);
   }
 
+  public DefaultNameGenerator(
+      Set<String> reservedNames, String prefix, @Nullable char[] reservedCharacters) {
+    this(reservedNames, prefix, reservedCharacters, reservedCharacters);
+  }
+
   /**
    * Creates a DefaultNameGenerator.
    *
-   * @param reservedNames set of names that are reserved; generated names will
-   *   not include these names. This set is referenced rather than copied,
-   *   so changes to the set will be reflected in how names are generated.
+   * @param reservedNames set of names that are reserved; generated names will not include these
+   *     names. This set is referenced rather than copied, so changes to the set will be reflected
+   *     in how names are generated.
    * @param prefix all generated names begin with this prefix.
-   * @param reservedCharacters If specified these characters won't be used in
-   *   generated names
+   * @param reservedFirstCharacters If specified these characters won't be used in generated names
+   *     for the first character
+   * @param reservedNonFirstCharacters If specified these characters won't be used in generated
+   *     names for characters after the first
    */
-  public DefaultNameGenerator(Set<String> reservedNames, String prefix,
-      @Nullable char[] reservedCharacters) {
+  public DefaultNameGenerator(
+      Set<String> reservedNames,
+      String prefix,
+      @Nullable char[] reservedFirstCharacters,
+      @Nullable char[] reservedNonFirstCharacters) {
     buildPriorityLookupMap();
-    reset(reservedNames, prefix, reservedCharacters);
+    reset(reservedNames, prefix, reservedFirstCharacters, reservedNonFirstCharacters);
   }
 
   private DefaultNameGenerator(Set<String> reservedNames, String prefix,
@@ -134,7 +144,7 @@ final class DefaultNameGenerator implements NameGenerator {
       this.priorityLookupMap.put(entry.getKey(), entry.getValue().clone());
     }
 
-    reset(reservedNames, prefix, reservedCharacters);
+    reset(reservedNames, prefix, reservedCharacters, reservedCharacters);
   }
 
   private void buildPriorityLookupMap() {
@@ -146,26 +156,31 @@ final class DefaultNameGenerator implements NameGenerator {
     }
   }
 
+  @Override
+  public void reset(Set<String> reservedNames, String prefix, @Nullable char[] reservedCharacters) {
+    reset(reservedNames, prefix, reservedCharacters, reservedCharacters);
+  }
+
   /**
-   * Note that the history of what characters are most used in the program
-   * (set through calls to 'favor') is not deleted. Upon 'reset', that history
-   * is taken into account for the names that will be generated later: it
-   * re-calculates how characters are prioritized based on how often the they
-   * appear in the final output.
+   * Note that the history of what characters are most used in the program (set through calls to
+   * 'favor') is not deleted. Upon 'reset', that history is taken into account for the names that
+   * will be generated later: it re-calculates how characters are prioritized based on how often the
+   * they appear in the final output.
    */
   @Override
   public void reset(
       Set<String> reservedNames,
       String prefix,
-      @Nullable char[] reservedCharacters) {
+      @Nullable char[] reservedFirstCharacters,
+      @Nullable char[] reservedNonFirstCharacters) {
 
     this.reservedNames = reservedNames;
     this.prefix = prefix;
     this.nameCount = 0;
 
     // build the character arrays to use
-    this.firstChars = reserveCharacters(FIRST_CHAR, reservedCharacters);
-    this.nonFirstChars = reserveCharacters(NONFIRST_CHAR, reservedCharacters);
+    this.firstChars = reserveCharacters(FIRST_CHAR, reservedFirstCharacters);
+    this.nonFirstChars = reserveCharacters(NONFIRST_CHAR, reservedNonFirstCharacters);
     Arrays.sort(firstChars);
     Arrays.sort(nonFirstChars);
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2559,17 +2559,19 @@ public final class DefaultPassConfig extends PassConfig {
   };
 
   /**
-   * Renames properties so that the two properties that never appear on
-   * the same object get the same name.
+   * Renames properties so that the two properties that never appear on the same object get the same
+   * name.
    */
   private final PassFactory ambiguateProperties =
       new PassFactory("ambiguateProperties", true) {
-    @Override
-    protected CompilerPass create(AbstractCompiler compiler) {
-      return new AmbiguateProperties(
-          compiler, options.anonymousFunctionNaming.getReservedCharacters());
-    }
-  };
+        @Override
+        protected CompilerPass create(AbstractCompiler compiler) {
+          return new AmbiguateProperties(
+              compiler,
+              options.getPropertyReservedNamingFirstChars(),
+              options.getPropertyReservedNamingNonFirstChars());
+        }
+      };
 
   /**
    * Mark the point at which the normalized AST assumptions no longer hold.
@@ -2603,25 +2605,24 @@ public final class DefaultPassConfig extends PassConfig {
     }
   };
 
-  /**
-   * Renames properties.
-   */
+  /** Renames properties. */
   private final PassFactory renameProperties =
       new PassFactory("renameProperties", true) {
         @Override
         protected CompilerPass create(final AbstractCompiler compiler) {
           Preconditions.checkState(options.propertyRenaming == PropertyRenamingPolicy.ALL_UNQUOTED);
           final VariableMap prevPropertyMap = options.inputPropertyMap;
+
           return new CompilerPass() {
             @Override
             public void process(Node externs, Node root) {
-              char[] reservedChars = options.anonymousFunctionNaming.getReservedCharacters();
               RenameProperties rprop =
                   new RenameProperties(
                       compiler,
                       options.generatePseudoNames,
                       prevPropertyMap,
-                      reservedChars,
+                      options.getPropertyReservedNamingFirstChars(),
+                      options.getPropertyReservedNamingNonFirstChars(),
                       options.nameGenerator);
               rprop.process(externs, root);
               propertyMap = rprop.getPropertyMap();

--- a/src/com/google/javascript/jscomp/NameGenerator.java
+++ b/src/com/google/javascript/jscomp/NameGenerator.java
@@ -17,27 +17,41 @@
 package com.google.javascript.jscomp;
 
 import java.util.Set;
-
 import javax.annotation.Nullable;
 
 /**
  * A class that generates unique JavaScript variable/property names.
  */
 interface NameGenerator {
+
   /**
    * Reconfigures this NameGenerator, and resets it to the initial state.
    *
-   * @param reservedNames set of names that are reserved; generated names will
-   *   not include these names. This set is referenced rather than copied,
-   *   so changes to the set will be reflected in how names are generated.
+   * @param reservedNames set of names that are reserved; generated names will not include these
+   *     names. This set is referenced rather than copied, so changes to the set will be reflected
+   *     in how names are generated.
    * @param prefix all generated names begin with this prefix.
-   * @param reservedCharacters If specified these characters won't be used in
-   *   generated names
+   * @param reservedCharacters If specified these characters won't be used in generated names
+   */
+  void reset(Set<String> reservedNames, String prefix, @Nullable char[] reservedCharacters);
+
+  /**
+   * Reconfigures this NameGenerator, and resets it to the initial state.
+   *
+   * @param reservedNames set of names that are reserved; generated names will not include these
+   *     names. This set is referenced rather than copied, so changes to the set will be reflected
+   *     in how names are generated.
+   * @param prefix all generated names begin with this prefix.
+   * @param reservedFirstCharacters If specified these characters won't be used as the first
+   *     character in generated names
+   * @param reservedNonFirstCharacters If specified these characters won't be used for characters
+   *     (after the first) in generated names
    */
   void reset(
       Set<String> reservedNames,
       String prefix,
-      @Nullable char[] reservedCharacters);
+      @Nullable char[] reservedFirstCharacters,
+      @Nullable char[] reservedNonFirstCharacters);
 
   /**
    * Returns a clone of this NameGenerator, reconfigured and reset.

--- a/src/com/google/javascript/jscomp/PolymerPass.java
+++ b/src/com/google/javascript/jscomp/PolymerPass.java
@@ -29,7 +29,6 @@ import com.google.javascript.rhino.JSDocInfoBuilder;
 import com.google.javascript.rhino.JSTypeExpression;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +46,8 @@ import java.util.Set;
 final class PolymerPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
 
   static final String VIRTUAL_FILE = "<PolymerPass.java>";
+  static final char[] PROPERTY_RESERVED_FIRST_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ$".toCharArray();
+  static final char[] PROPERTY_RESERVED_NON_FIRST_CHARS = "_$".toCharArray();
 
   private final AbstractCompiler compiler;
   private final Map<String, String> tagNameMap;

--- a/src/com/google/javascript/jscomp/RandomNameGenerator.java
+++ b/src/com/google/javascript/jscomp/RandomNameGenerator.java
@@ -24,14 +24,12 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.Chars;
 import com.google.javascript.rhino.TokenStream;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 
 /**
@@ -110,18 +108,6 @@ public final class RandomNameGenerator implements NameGenerator {
     reset(new HashSet<String>(), "", null);
   }
 
-  /**
-   * Creates a RandomNameGenerator.
-   *
-   * @param reservedNames set of names that are reserved; generated names will
-   *   not include these names. This set is referenced rather than copied,
-   *   so changes to the set will be reflected in how names are generated
-   * @param prefix all generated names begin with this prefix (a name
-   *   consisting of only this prefix, with no suffix, will not be generated)
-   * @param reservedCharacters if specified these characters won't be used in
-   *   generated names
-   * @param random source of randomness when generating random names
-   */
   RandomNameGenerator(
       Set<String> reservedNames,
       String prefix,
@@ -131,18 +117,51 @@ public final class RandomNameGenerator implements NameGenerator {
     reset(reservedNames, prefix, reservedCharacters);
   }
 
+  /**
+   * Creates a RandomNameGenerator.
+   *
+   * @param reservedNames set of names that are reserved; generated names will not include these
+   *     names. This set is referenced rather than copied, so changes to the set will be reflected
+   *     in how names are generated
+   * @param prefix all generated names begin with this prefix (a name consisting of only this
+   *     prefix, with no suffix, will not be generated)
+   * @param reservedFirstCharacters if specified these characters won't be used in generated names
+   *     for the first character
+   * @param reservedNonFirstCharacters if specified these characters won't be used in generated
+   *     names for characters after the first
+   * @param random source of randomness when generating random names
+   */
+  RandomNameGenerator(
+      Set<String> reservedNames,
+      String prefix,
+      @Nullable char[] reservedFirstCharacters,
+      @Nullable char[] reservedNonFirstCharacters,
+      Random random) {
+    this.random = random;
+    reset(reservedNames, prefix, reservedFirstCharacters, reservedNonFirstCharacters);
+  }
+
   @Override
   public void reset(
       Set<String> reservedNames,
       String prefix,
       @Nullable char[] reservedCharacters) {
+    reset(reservedNames, prefix, reservedCharacters, reservedCharacters);
+  }
+
+  @Override
+  public void reset(
+      Set<String> reservedNames,
+      String prefix,
+      @Nullable char[] reservedFirstCharacters,
+      @Nullable char[] reservedNonFirstCharacters) {
     this.reservedNames = reservedNames;
     this.prefix = prefix;
     nameCount = 0;
 
     // Build the character arrays to use
-    this.firstChars = reserveCharacters(FIRST_CHAR, reservedCharacters);
-    this.nonFirstChars = reserveCharacters(NONFIRST_CHAR, reservedCharacters);
+    this.firstChars = reserveCharacters(FIRST_CHAR, reservedFirstCharacters);
+    this.nonFirstChars = reserveCharacters(NONFIRST_CHAR, reservedNonFirstCharacters);
 
     checkPrefix(prefix);
     shuffleAlphabets(random);

--- a/test/com/google/javascript/jscomp/AmbiguatePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/AmbiguatePropertiesTest.java
@@ -18,7 +18,6 @@ package com.google.javascript.jscomp;
 
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.rhino.Node;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,8 +50,8 @@ public final class AmbiguatePropertiesTest extends CompilerTestCase {
     return new CompilerPass() {
       @Override
       public void process(Node externs, Node root) {
-        lastPass = AmbiguateProperties.makePassForTesting(
-            compiler, new char[]{'$'});
+        lastPass =
+            AmbiguateProperties.makePassForTesting(compiler, new char[] {'$'}, new char[] {'$'});
         lastPass.process(externs, root);
       }
     };


### PR DESCRIPTION
Both Angular and Polymer place restrictions on property names. Angular ignores properties beginning with '$' in equality checks. Polymer serializes DOM attributes to properties and thus requires names to match their restrictions (Only alpha-numeric chars and must begin with a lowercase alpha).

This restricts the property renaming passes to the set of characters permitted by the frameworks.

cc @mprobst, @justinfagnani 

Fixes #1371