### PR TITLE
Update the PolymerPass to support Polymer 2 in ADVANCED mode.

### DIFF
--- a/src/com/google/javascript/jscomp/ClosureCodingConvention.java
+++ b/src/com/google/javascript/jscomp/ClosureCodingConvention.java
@@ -381,8 +381,9 @@ public final class ClosureCodingConvention extends CodingConventions.Proxy {
     }
 
     Node callName = callNode.getFirstChild();
-    if (!callName.matchesQualifiedName("goog.reflect.object") ||
-        callNode.getChildCount() != 3) {
+    if (!(callName.matchesQualifiedName("goog.reflect.object")
+            || callName.matchesQualifiedName("$jscomp.reflectObject"))
+        || callNode.getChildCount() != 3) {
       return null;
     }
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -3094,7 +3094,10 @@ public final class DefaultPassConfig extends PassConfig {
       new HotSwapPassFactory("polymerPass", true) {
         @Override
         protected HotSwapCompilerPass create(AbstractCompiler compiler) {
-          return new PolymerPass(compiler);
+          return new PolymerPass(
+              compiler,
+              compiler.getOptions().polymerVersion,
+              compiler.getOptions().propertyRenaming == PropertyRenamingPolicy.ALL_UNQUOTED);
         }
 
         @Override

--- a/src/com/google/javascript/jscomp/JSDocInfoPrinter.java
+++ b/src/com/google/javascript/jscomp/JSDocInfoPrinter.java
@@ -69,6 +69,9 @@ public final class JSDocInfoPrinter {
     //   implicitCast
     //   suppress
     //   deprecated
+    //   polymer
+    //   polymerBehavior
+    //   mixinFunction
     parts.add("/**");
 
     if (info.isExport()) {
@@ -219,6 +222,27 @@ public final class JSDocInfoPrinter {
     if (info.isDeprecated()) {
       parts.add("@deprecated " + info.getDeprecationReason());
       multiline = true;
+    }
+
+    if (info.isPolymer()) {
+      multiline = true;
+      parts.add("@polymer");
+    }
+    if (info.isPolymerBehavior()) {
+      multiline = true;
+      parts.add("@polymerBehavior");
+    }
+    if (info.isMixinFunction()) {
+      multiline = true;
+      parts.add("@mixinFunction");
+    }
+    if (info.isMixinClass()) {
+      multiline = true;
+      parts.add("@mixinClass");
+    }
+    if (info.isCustomElement()) {
+      multiline = true;
+      parts.add("@customElement");
     }
 
     parts.add("*/");

--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -2231,9 +2231,31 @@ public final class NodeUtil {
     return null;
   }
 
-  /**
-   * @return The first computed property in the objlit whose key matches {@code key}.
-   */
+  /** @return The first getter in the class members that matches the key. */
+  @Nullable
+  static Node getFirstGetterMatchingKey(Node n, String keyName) {
+    Preconditions.checkState(n.isClassMembers() || n.isObjectLit());
+    for (Node keyNode : n.children()) {
+      if (keyNode.isGetterDef() && keyNode.getString().equals(keyName)) {
+        return keyNode;
+      }
+    }
+    return null;
+  }
+
+  /** @return The first setter in the class members that matches the key. */
+  @Nullable
+  static Node getFirstSetterMatchingKey(Node n, String keyName) {
+    Preconditions.checkState(n.isClassMembers() || n.isObjectLit());
+    for (Node keyNode : n.children()) {
+      if (keyNode.isSetterDef() && keyNode.getString().equals(keyName)) {
+        return keyNode;
+      }
+    }
+    return null;
+  }
+
+  /** @return The first computed property in the objlit whose key matches {@code key}. */
   @Nullable
   static Node getFirstComputedPropMatchingKey(Node objlit, Node key) {
     checkState(objlit.isObjectLit());

--- a/src/com/google/javascript/jscomp/PolymerBehaviorExtractor.java
+++ b/src/com/google/javascript/jscomp/PolymerBehaviorExtractor.java
@@ -66,10 +66,11 @@ final class PolymerBehaviorExtractor {
     for (Node behaviorName : behaviorArray.children()) {
       if (behaviorName.isObjectLit()) {
         PolymerPassStaticUtils.switchDollarSignPropsToBrackets(behaviorName, compiler);
-        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorName);
+        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorName, compiler);
         behaviors.add(
             new BehaviorDefinition(
-                PolymerPassStaticUtils.extractProperties(behaviorName, compiler),
+                PolymerPassStaticUtils.extractProperties(
+                    behaviorName, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler),
                 getBehaviorFunctionsToCopy(behaviorName),
                 getNonPropertyMembersToCopy(behaviorName),
                 !NodeUtil.isInFunction(behaviorName),
@@ -119,10 +120,11 @@ final class PolymerBehaviorExtractor {
         behaviors.addAll(extractBehaviors(behaviorValue));
       } else if (behaviorValue.isObjectLit()) {
         PolymerPassStaticUtils.switchDollarSignPropsToBrackets(behaviorValue, compiler);
-        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorValue);
+        PolymerPassStaticUtils.quoteListenerAndHostAttributeKeys(behaviorValue, compiler);
         behaviors.add(
             new BehaviorDefinition(
-                PolymerPassStaticUtils.extractProperties(behaviorValue, compiler),
+                PolymerPassStaticUtils.extractProperties(
+                    behaviorValue, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler),
                 getBehaviorFunctionsToCopy(behaviorValue),
                 getNonPropertyMembersToCopy(behaviorValue),
                 isGlobalDeclaration,

--- a/src/com/google/javascript/jscomp/PolymerClassDefinition.java
+++ b/src/com/google/javascript/jscomp/PolymerClassDefinition.java
@@ -34,6 +34,16 @@ import javax.annotation.Nullable;
  * class.
  */
 final class PolymerClassDefinition {
+  static enum DefinitionType {
+    ObjectLiteral,
+    ES6Class
+  }
+
+  /** The declaration style used for the Polymer definition */
+  final DefinitionType defType;
+
+  /** The Polymer call or class node which defines the Element. */
+  final Node definition;
 
   /** The target node (LHS) for the Polymer element definition. */
   final Node target;
@@ -45,18 +55,20 @@ final class PolymerClassDefinition {
   final MemberDefinition constructor;
 
   /** The name of the native HTML element which this element extends. */
-  final String nativeBaseElement;
+  @Nullable final String nativeBaseElement;
 
   /** Properties declared in the Polymer "properties" block. */
   final List<MemberDefinition> props;
 
   /** Flattened list of behavior definitions used by this element. */
-  final ImmutableList<BehaviorDefinition> behaviors;
+  @Nullable final ImmutableList<BehaviorDefinition> behaviors;
 
   /** Language features that should be carried over to the extraction destination. */
-  final FeatureSet features;
+  @Nullable final FeatureSet features;
 
   PolymerClassDefinition(
+      DefinitionType defType,
+      Node definition,
       Node target,
       Node descriptor,
       JSDocInfo classInfo,
@@ -65,8 +77,10 @@ final class PolymerClassDefinition {
       List<MemberDefinition> props,
       ImmutableList<BehaviorDefinition> behaviors,
       FeatureSet features) {
+    this.defType = defType;
+    this.definition = definition;
     this.target = target;
-    checkState(descriptor.isObjectLit());
+    checkState(descriptor == null || descriptor.isObjectLit());
     this.descriptor = descriptor;
     this.constructor = constructor;
     this.nativeBaseElement = nativeBaseElement;
@@ -139,7 +153,9 @@ final class PolymerClassDefinition {
       overwriteMembersIfPresent(allProperties, behavior.props);
     }
     overwriteMembersIfPresent(
-        allProperties, PolymerPassStaticUtils.extractProperties(descriptor, compiler));
+        allProperties,
+        PolymerPassStaticUtils.extractProperties(
+            descriptor, DefinitionType.ObjectLiteral, compiler));
 
     FeatureSet newFeatures = null;
     if (!behaviors.isEmpty()) {
@@ -150,6 +166,8 @@ final class PolymerClassDefinition {
     }
 
     return new PolymerClassDefinition(
+        DefinitionType.ObjectLiteral,
+        callNode,
         target,
         descriptor,
         classInfo,
@@ -158,6 +176,80 @@ final class PolymerClassDefinition {
         allProperties,
         behaviors,
         newFeatures);
+  }
+
+  /**
+   * Validates the class definition and if valid, extracts the class definition from the AST. As
+   * opposed to the Polymer 1 extraction, this operation is non-destructive.
+   */
+  @Nullable
+  static PolymerClassDefinition extractFromClassNode(
+      Node classNode, AbstractCompiler compiler, GlobalNamespace globalNames) {
+    checkState(classNode != null && classNode.isClass());
+
+    // The supported case is for the config getter to return an object literal descriptor.
+    Node propertiesDescriptor = null;
+    Node propertiesGetter =
+        NodeUtil.getFirstGetterMatchingKey(NodeUtil.getClassMembers(classNode), "properties");
+    if (propertiesGetter != null) {
+      if (!propertiesGetter.isStaticMember()) {
+        // report bad class definition
+        compiler.report(
+            JSError.make(classNode, PolymerPassErrors.POLYMER_CLASS_PROPERTIES_NOT_STATIC));
+      } else {
+        for (Node child : NodeUtil.getFunctionBody(propertiesGetter.getFirstChild()).children()) {
+          if (child.isReturn()) {
+            if (child.hasChildren() && child.getFirstChild().isObjectLit()) {
+              propertiesDescriptor = child.getFirstChild();
+              break;
+            } else {
+              compiler.report(
+                  JSError.make(
+                      propertiesGetter, PolymerPassErrors.POLYMER_CLASS_PROPERTIES_INVALID));
+            }
+          }
+        }
+      }
+    }
+
+    Node target;
+    if (NodeUtil.isNameDeclaration(classNode.getGrandparent())) {
+      target = IR.name(classNode.getParent().getString());
+    } else if (classNode.getParent().isAssign()
+        && classNode.getParent().getFirstChild().isQualifiedName()) {
+      target = classNode.getParent().getFirstChild();
+    } else if (!classNode.getFirstChild().isEmpty()) {
+      target = classNode.getFirstChild();
+    } else {
+      // issue error - no name found
+      compiler.report(JSError.make(classNode, PolymerPassErrors.POLYMER_CLASS_UNNAMED));
+      return null;
+    }
+
+    JSDocInfo classInfo = NodeUtil.getBestJSDocInfo(classNode);
+
+    JSDocInfo ctorInfo = null;
+    Node constructor =
+        NodeUtil.getFirstPropMatchingKey(NodeUtil.getClassMembers(classNode), "constructor");
+    if (constructor != null) {
+      ctorInfo = NodeUtil.getBestJSDocInfo(constructor);
+    }
+
+    List<MemberDefinition> allProperties =
+        PolymerPassStaticUtils.extractProperties(
+            propertiesDescriptor, DefinitionType.ES6Class, compiler);
+
+    return new PolymerClassDefinition(
+        DefinitionType.ES6Class,
+        classNode,
+        target,
+        propertiesDescriptor,
+        classInfo,
+        new MemberDefinition(ctorInfo, null, constructor),
+        null,
+        allProperties,
+        null,
+        null);
   }
 
   /**

--- a/src/com/google/javascript/jscomp/PolymerPass.java
+++ b/src/com/google/javascript/jscomp/PolymerPass.java
@@ -15,12 +15,12 @@
  */
 package com.google.javascript.jscomp;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_DECLARATION;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_EXTENDS;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_MISSING_EXTERNS;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.rhino.IR;
@@ -49,21 +49,27 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
 
   private final AbstractCompiler compiler;
   private final Map<String, String> tagNameMap;
+  private final int polymerVersion;
+  private final boolean propertyRenamingEnabled;
 
   private Node polymerElementExterns;
+  private Node externsInsertionRef = null;
   private Set<String> nativeExternsAdded;
   private ImmutableList<Node> polymerElementProps;
   private GlobalNamespace globalNames;
+  private boolean warnedPolymer1ExternsMissing = false;
+  private boolean objectReflectionDefinitionInjected = false;
 
-  PolymerPass(AbstractCompiler compiler) {
+  PolymerPass(AbstractCompiler compiler, Integer polymerVersion, boolean propertyRenamingEnabled) {
+    checkArgument(
+        polymerVersion == null || polymerVersion == 1 || polymerVersion == 2,
+        "Invalid Polymer version:",
+        polymerVersion);
     this.compiler = compiler;
     tagNameMap = TagNameToType.getMap();
     nativeExternsAdded = new HashSet<>();
-
-    if (compiler.getOptions().polymerVersion != 1) {
-      throw new IllegalStateException("Polymer version not supported: "
-          + compiler.getOptions().polymerVersion);
-    }
+    this.polymerVersion = polymerVersion == null ? 1 : polymerVersion;
+    this.propertyRenamingEnabled = propertyRenamingEnabled;
   }
 
   @Override
@@ -73,9 +79,14 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
     polymerElementExterns = externsCallback.getPolymerElementExterns();
     polymerElementProps = externsCallback.getPolymerElementProps();
 
-    if (polymerElementExterns == null) {
+    if (polymerVersion == 1 && polymerElementExterns == null) {
+      this.warnedPolymer1ExternsMissing = true;
       compiler.report(JSError.make(externs, POLYMER_MISSING_EXTERNS));
       return;
+    }
+
+    if (polymerVersion > 1 && propertyRenamingEnabled) {
+      compiler.ensureLibraryInjected("util/reflectobject", false);
     }
 
     globalNames = new GlobalNamespace(compiler, externs, root);
@@ -93,15 +104,22 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
 
   @Override
   public void visit(NodeTraversal traversal, Node node, Node parent) {
-    checkState(
-        polymerElementExterns != null && polymerElementProps != null && globalNames != null,
-        "Cannot call visit() before process()");
-    if (isPolymerCall(node)) {
-      rewriteClassDefinition(node, parent, traversal);
+    checkNotNull(globalNames, "Cannot call visit() before process()");
+
+    if (PolymerPassStaticUtils.isPolymerCall(node)) {
+      if (polymerElementExterns != null) {
+        rewritePolymer1ClassDefinition(node, parent, traversal);
+      } else if (!warnedPolymer1ExternsMissing) {
+        compiler.report(JSError.make(polymerElementExterns, POLYMER_MISSING_EXTERNS));
+        warnedPolymer1ExternsMissing = true;
+      }
+    } else if (PolymerPassStaticUtils.isPolymerClass(node)) {
+      rewritePolymer2ClassDefinition(node, parent, traversal);
     }
   }
 
-  private void rewriteClassDefinition(Node node, Node parent, NodeTraversal traversal) {
+  /** Polymer 1.x and Polymer 2 Legacy Element Definitions */
+  private void rewritePolymer1ClassDefinition(Node node, Node parent, NodeTraversal traversal) {
     Node grandparent = parent.getParent();
     if (grandparent.isConst()) {
       compiler.report(JSError.make(node, POLYMER_INVALID_DECLARATION));
@@ -113,13 +131,39 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
       if (def.nativeBaseElement != null) {
         appendPolymerElementExterns(def);
       }
-      PolymerClassRewriter rewriter = new PolymerClassRewriter(compiler, polymerElementExterns);
+      PolymerClassRewriter rewriter =
+          new PolymerClassRewriter(
+              compiler, getExtensInsertionRef(), polymerVersion, this.propertyRenamingEnabled);
       if (NodeUtil.isNameDeclaration(grandparent) || parent.isAssign()) {
-        rewriter.rewritePolymerClass(grandparent, def, traversal.inGlobalScope());
+        rewriter.rewritePolymerCall(grandparent, def, traversal.inGlobalScope());
       } else {
-        rewriter.rewritePolymerClass(parent, def, traversal.inGlobalScope());
+        rewriter.rewritePolymerCall(parent, def, traversal.inGlobalScope());
       }
     }
+  }
+
+  /** Polymer 2.x Class Nodes */
+  private void rewritePolymer2ClassDefinition(Node node, Node parent, NodeTraversal traversal) {
+    PolymerClassDefinition def =
+        PolymerClassDefinition.extractFromClassNode(node, compiler, globalNames);
+    if (def != null) {
+      PolymerClassRewriter rewriter =
+          new PolymerClassRewriter(
+              compiler, getExtensInsertionRef(), polymerVersion, this.propertyRenamingEnabled);
+      rewriter.rewritePolymerClassDeclaration(node, def, traversal.inGlobalScope());
+    }
+  }
+
+  private Node getExtensInsertionRef() {
+    if (this.polymerElementExterns != null) {
+      return this.polymerElementExterns;
+    }
+
+    if (this.externsInsertionRef == null) {
+      this.externsInsertionRef = compiler.getSynthesizedExternsInputAtEnd().getAstRoot(compiler);
+    }
+
+    return this.externsInsertionRef;
   }
 
   /**
@@ -167,17 +211,7 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
     compiler.reportChangeToEnclosingScope(stmts);
   }
 
-  /**
-   * @return Whether the call represents a call to the Polymer function.
-   */
-  @VisibleForTesting
-  public static boolean isPolymerCall(Node value) {
-    return value != null && value.isCall() && value.getFirstChild().matchesQualifiedName("Polymer");
-  }
-
-  /**
-   * Any member of a Polymer element or Behavior. These can be functions, properties, etc.
-   */
+  /** Any member of a Polymer element or Behavior. These can be functions, properties, etc. */
   static class MemberDefinition {
     /** Any {@link JSDocInfo} tied to this member. */
     final JSDocInfo info;

--- a/src/com/google/javascript/jscomp/PolymerPassErrors.java
+++ b/src/com/google/javascript/jscomp/PolymerPassErrors.java
@@ -20,10 +20,11 @@ package com.google.javascript.jscomp;
  */
 final class PolymerPassErrors {
   // TODO(jlklein): Switch back to an error when everyone is upgraded to Polymer 1.0
-  static final DiagnosticType POLYMER_DESCRIPTOR_NOT_VALID = DiagnosticType.warning(
-      "JSC_POLYMER_DESCRIPTOR_NOT_VALID",
-      "The argument to Polymer() is not an obj lit (perhaps because this is a pre-Polymer-1.0 "
-      + "call). Ignoring this call.");
+  static final DiagnosticType POLYMER_DESCRIPTOR_NOT_VALID =
+      DiagnosticType.warning(
+          "JSC_POLYMER_DESCRIPTOR_NOT_VALID",
+          "The argument to Polymer() is not an obj lit or the Polymer 2 class does not have a static getter"
+              + "named 'config'. Ignoring this definition.");
 
   // Disallow 'const Foo = Polymer(...)' because the code the PolymerPass outputs will reassign
   // Foo which is not allowed for 'const' variables.
@@ -63,6 +64,22 @@ final class PolymerPassErrors {
       DiagnosticType.error(
           "JSC_POLYMER_SHORTHAND_NOT_SUPPORTED",
           "Shorthand assignment in object literal is not allowed in Polymer call arguments");
+
+  static final DiagnosticType POLYMER_CLASS_PROPERTIES_INVALID =
+      DiagnosticType.error(
+          "JSC_POLYMER_CLASS_PROPERTIES_INVALID",
+          "The Polymer element class 'propertis' getter does not return an object literal. Ignoring this definition.");
+
+  static final DiagnosticType POLYMER_CLASS_PROPERTIES_NOT_STATIC =
+      DiagnosticType.error(
+          "JSC_POLYMER_CLASS_PROPERTIES_NOT_STATIC",
+          "The Polymer element class 'properties' getter is not declared static. Ignoring this definition.");
+
+  static final DiagnosticType POLYMER_CLASS_UNNAMED =
+      DiagnosticType.warning(
+          "JSC_POLYMER2_UNNAMED",
+          "Unable to locate a valid name for the Polymer element class."
+              + "Ignoring this definition.");
 
   private PolymerPassErrors() {}
 }

--- a/src/com/google/javascript/jscomp/PolymerPassSuppressBehaviors.java
+++ b/src/com/google/javascript/jscomp/PolymerPassSuppressBehaviors.java
@@ -82,7 +82,8 @@ final class PolymerPassSuppressBehaviors extends AbstractPostOrderCallback {
 
   private void stripPropertyTypes(Node behaviorValue) {
     List<MemberDefinition> properties =
-        PolymerPassStaticUtils.extractProperties(behaviorValue, compiler);
+        PolymerPassStaticUtils.extractProperties(
+            behaviorValue, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler);
     for (MemberDefinition property : properties) {
       property.name.removeProp(Node.JSDOC_INFO_PROP);
     }
@@ -90,7 +91,8 @@ final class PolymerPassSuppressBehaviors extends AbstractPostOrderCallback {
 
   private void suppressDefaultValues(Node behaviorValue) {
     for (MemberDefinition property :
-        PolymerPassStaticUtils.extractProperties(behaviorValue, compiler)) {
+        PolymerPassStaticUtils.extractProperties(
+            behaviorValue, PolymerClassDefinition.DefinitionType.ObjectLiteral, compiler)) {
       if (!property.value.isObjectLit()) {
         continue;
       }

--- a/src/com/google/javascript/jscomp/js/util/reflectobject.js
+++ b/src/com/google/javascript/jscomp/js/util/reflectobject.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'require base';
+
+/**
+ * Definition for object reflection. See goog.reflect.object.
+ *
+ * @param {!Function} type Type to cast to.
+ * @param {Object} object Object literal to cast.
+ * @return {Object} The object literal.
+ */
+$jscomp.reflectObject = function(type, object) {
+  return object;
+};

--- a/src/com/google/javascript/jscomp/parsing/Annotation.java
+++ b/src/com/google/javascript/jscomp/parsing/Annotation.java
@@ -27,6 +27,7 @@ enum Annotation {
   NG_INJECT,
   ABSTRACT,
   AUTHOR,
+  CUSTOM_ELEMENT,
   CONSISTENTIDGENERATOR,
   CONSTANT,
   CONSTRUCTOR,
@@ -56,6 +57,8 @@ enum Annotation {
   LENDS,
   LICENSE, // same as preserve
   MEANING,
+  MIXIN_CLASS,
+  MIXIN_FUNCTION,
   MODIFIES,
   NO_ALIAS,
   NO_COLLAPSE,
@@ -65,6 +68,7 @@ enum Annotation {
   OVERRIDE,
   PACKAGE,
   PARAM,
+  POLYMER,
   POLYMER_BEHAVIOR,
   PRESERVE, // same as license
   PRIVATE,
@@ -85,69 +89,73 @@ enum Annotation {
   WIZACTION;
 
   static final Map<String, Annotation> recognizedAnnotations =
-      new ImmutableMap.Builder<String, Annotation>().
-      put("ngInject", Annotation.NG_INJECT).
-      put("abstract", Annotation.ABSTRACT).
-      put("argument", Annotation.PARAM).
-      put("author", Annotation.AUTHOR).
-      put("consistentIdGenerator", Annotation.CONSISTENTIDGENERATOR).
-      put("const", Annotation.CONSTANT).
-      put("constant", Annotation.CONSTANT).
-      put("constructor", Annotation.CONSTRUCTOR).
-      put("copyright", Annotation.LICENSE).
-      put("define", Annotation.DEFINE).
-      put("deprecated", Annotation.DEPRECATED).
-      put("desc", Annotation.DESC).
-      put("dict", Annotation.DICT).
-      put("disposes", Annotation.DISPOSES).
-      put("enum", Annotation.ENUM).
-      put("export", Annotation.EXPORT).
-      put("expose", Annotation.EXPOSE).
-      put("extends", Annotation.EXTENDS).
-      put("externs", Annotation.EXTERNS).
-      put("fileoverview", Annotation.FILE_OVERVIEW).
-      put("final", Annotation.FINAL).
-      put("hidden", Annotation.HIDDEN).
-      put("idGenerator", Annotation.IDGENERATOR).
-      put("implements", Annotation.IMPLEMENTS).
-      put("implicitCast", Annotation.IMPLICIT_CAST).
-      put("inheritDoc", Annotation.INHERIT_DOC).
-      put("interface", Annotation.INTERFACE).
-      put("record", Annotation.RECORD).
-      put("jaggerInject", Annotation.JAGGER_INJECT).
-      put("jaggerModule", Annotation.JAGGER_MODULE).
-      put("jaggerProvidePromise", Annotation.JAGGER_PROVIDE_PROMISE).
-      put("jaggerProvide", Annotation.JAGGER_PROVIDE).
-      put("lends", Annotation.LENDS).
-      put("license", Annotation.LICENSE).
-      put("meaning", Annotation.MEANING).
-      put("modifies", Annotation.MODIFIES).
-      put("noalias", Annotation.NO_ALIAS).
-      put("nocollapse", Annotation.NO_COLLAPSE).
-      put("nocompile", Annotation.NO_COMPILE).
-      put("nosideeffects", Annotation.NO_SIDE_EFFECTS).
-      put("override", Annotation.OVERRIDE).
-      put("owner", Annotation.AUTHOR).
-      put("package", Annotation.PACKAGE).
-      put("param", Annotation.PARAM).
-      put("polymerBehavior", Annotation.POLYMER_BEHAVIOR).
-      put("preserve", Annotation.PRESERVE).
-      put("private", Annotation.PRIVATE).
-      put("protected", Annotation.PROTECTED).
-      put("public", Annotation.PUBLIC).
-      put("return", Annotation.RETURN).
-      put("returns", Annotation.RETURN).
-      put("see", Annotation.SEE).
-      put("stableIdGenerator", Annotation.STABLEIDGENERATOR).
-      put("struct", Annotation.STRUCT).
-      put("suppress", Annotation.SUPPRESS).
-      put("template", Annotation.TEMPLATE).
-      put("this", Annotation.THIS).
-      put("throws", Annotation.THROWS).
-      put("type", Annotation.TYPE).
-      put("typedef", Annotation.TYPEDEF).
-      put("unrestricted", Annotation.UNRESTRICTED).
-      put("version", Annotation.VERSION).
-      put("wizaction", Annotation.WIZACTION).
-      build();
+      new ImmutableMap.Builder<String, Annotation>()
+          .put("ngInject", Annotation.NG_INJECT)
+          .put("abstract", Annotation.ABSTRACT)
+          .put("argument", Annotation.PARAM)
+          .put("author", Annotation.AUTHOR)
+          .put("consistentIdGenerator", Annotation.CONSISTENTIDGENERATOR)
+          .put("const", Annotation.CONSTANT)
+          .put("constant", Annotation.CONSTANT)
+          .put("constructor", Annotation.CONSTRUCTOR)
+          .put("customElement", Annotation.CUSTOM_ELEMENT)
+          .put("copyright", Annotation.LICENSE)
+          .put("define", Annotation.DEFINE)
+          .put("deprecated", Annotation.DEPRECATED)
+          .put("desc", Annotation.DESC)
+          .put("dict", Annotation.DICT)
+          .put("disposes", Annotation.DISPOSES)
+          .put("enum", Annotation.ENUM)
+          .put("export", Annotation.EXPORT)
+          .put("expose", Annotation.EXPOSE)
+          .put("extends", Annotation.EXTENDS)
+          .put("externs", Annotation.EXTERNS)
+          .put("fileoverview", Annotation.FILE_OVERVIEW)
+          .put("final", Annotation.FINAL)
+          .put("hidden", Annotation.HIDDEN)
+          .put("idGenerator", Annotation.IDGENERATOR)
+          .put("implements", Annotation.IMPLEMENTS)
+          .put("implicitCast", Annotation.IMPLICIT_CAST)
+          .put("inheritDoc", Annotation.INHERIT_DOC)
+          .put("interface", Annotation.INTERFACE)
+          .put("record", Annotation.RECORD)
+          .put("jaggerInject", Annotation.JAGGER_INJECT)
+          .put("jaggerModule", Annotation.JAGGER_MODULE)
+          .put("jaggerProvidePromise", Annotation.JAGGER_PROVIDE_PROMISE)
+          .put("jaggerProvide", Annotation.JAGGER_PROVIDE)
+          .put("lends", Annotation.LENDS)
+          .put("license", Annotation.LICENSE)
+          .put("meaning", Annotation.MEANING)
+          .put("mixinClass", Annotation.MIXIN_CLASS)
+          .put("mixinFunction", Annotation.MIXIN_FUNCTION)
+          .put("modifies", Annotation.MODIFIES)
+          .put("noalias", Annotation.NO_ALIAS)
+          .put("nocollapse", Annotation.NO_COLLAPSE)
+          .put("nocompile", Annotation.NO_COMPILE)
+          .put("nosideeffects", Annotation.NO_SIDE_EFFECTS)
+          .put("override", Annotation.OVERRIDE)
+          .put("owner", Annotation.AUTHOR)
+          .put("package", Annotation.PACKAGE)
+          .put("param", Annotation.PARAM)
+          .put("polymer", Annotation.POLYMER)
+          .put("polymerBehavior", Annotation.POLYMER_BEHAVIOR)
+          .put("preserve", Annotation.PRESERVE)
+          .put("private", Annotation.PRIVATE)
+          .put("protected", Annotation.PROTECTED)
+          .put("public", Annotation.PUBLIC)
+          .put("return", Annotation.RETURN)
+          .put("returns", Annotation.RETURN)
+          .put("see", Annotation.SEE)
+          .put("stableIdGenerator", Annotation.STABLEIDGENERATOR)
+          .put("struct", Annotation.STRUCT)
+          .put("suppress", Annotation.SUPPRESS)
+          .put("template", Annotation.TEMPLATE)
+          .put("this", Annotation.THIS)
+          .put("throws", Annotation.THROWS)
+          .put("type", Annotation.TYPE)
+          .put("typedef", Annotation.TYPEDEF)
+          .put("unrestricted", Annotation.UNRESTRICTED)
+          .put("version", Annotation.VERSION)
+          .put("wizaction", Annotation.WIZACTION)
+          .build();
 }

--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -724,11 +724,43 @@ public final class JsDocInfoParser {
           }
           return eatUntilEOLIfNotAnnotation();
 
+        case POLYMER:
+          if (jsdocBuilder.isPolymerRecorded()) {
+            addParserWarning("msg.jsdoc.polymer.extra");
+          } else {
+            jsdocBuilder.recordPolymer();
+          }
+          return eatUntilEOLIfNotAnnotation();
+
         case POLYMER_BEHAVIOR:
           if (jsdocBuilder.isPolymerBehaviorRecorded()) {
             addParserWarning("msg.jsdoc.polymerBehavior.extra");
           } else {
             jsdocBuilder.recordPolymerBehavior();
+          }
+          return eatUntilEOLIfNotAnnotation();
+
+        case CUSTOM_ELEMENT:
+          if (jsdocBuilder.isCustomElementRecorded()) {
+            addParserWarning("msg.jsdoc.customElement.extra");
+          } else {
+            jsdocBuilder.recordCustomElement();
+          }
+          return eatUntilEOLIfNotAnnotation();
+
+        case MIXIN_CLASS:
+          if (jsdocBuilder.isMixinClassRecorded()) {
+            addParserWarning("msg.jsdoc.mixinClass.extra");
+          } else {
+            jsdocBuilder.recordMixinClass();
+          }
+          return eatUntilEOLIfNotAnnotation();
+
+        case MIXIN_FUNCTION:
+          if (jsdocBuilder.isMixinFunctionRecorded()) {
+            addParserWarning("msg.jsdoc.mixinFunction.extra");
+          } else {
+            jsdocBuilder.recordMixinFunction();
           }
           return eatUntilEOLIfNotAnnotation();
 

--- a/src/com/google/javascript/rhino/JSDocInfo.java
+++ b/src/com/google/javascript/rhino/JSDocInfo.java
@@ -94,16 +94,21 @@ public class JSDocInfo implements Serializable {
   // Bitfield property indicies.
   static class Property {
     static final int
-      NG_INJECT = 0,
-      WIZ_ACTION = 1,
+        NG_INJECT = 0,
+        WIZ_ACTION = 1,
 
-       // Flags for Jagger dependency injection prototype
-      JAGGER_INJECT = 2,
-      JAGGER_MODULE = 3,
-      JAGGER_PROVIDE_PROMISE = 4,
-      JAGGER_PROVIDE = 5,
+        // Flags for Jagger dependency injection prototype
+        JAGGER_INJECT = 2,
+        JAGGER_MODULE = 3,
+        JAGGER_PROVIDE_PROMISE = 4,
+        JAGGER_PROVIDE = 5,
 
-      POLYMER_BEHAVIOR = 6;
+        // Polymer specific
+        POLYMER_BEHAVIOR = 6,
+        POLYMER = 7,
+        CUSTOM_ELEMENT = 8,
+        MIXIN_CLASS = 9,
+        MIXIN_FUNCTION = 10;
   }
 
   private static final class LazilyInitializedInfo implements Serializable {
@@ -1737,9 +1742,47 @@ public class JSDocInfo implements Serializable {
     info.setBit(Property.POLYMER_BEHAVIOR, polymerBehavior);
   }
 
-  /**
-   * Returns whether JSDoc is annotated with {@code @disposes} annotation.
-   */
+  /** Returns whether JSDoc is annotated with {@code @polymer} annotation. */
+  public boolean isPolymer() {
+    return (info != null) && info.isBitSet(Property.POLYMER);
+  }
+
+  void setPolymer(boolean polymer) {
+    lazyInitInfo();
+    info.setBit(Property.POLYMER, polymer);
+  }
+
+  /** Returns whether JSDoc is annotated with {@code @customElement} annotation. */
+  public boolean isCustomElement() {
+    return (info != null) && info.isBitSet(Property.CUSTOM_ELEMENT);
+  }
+
+  void setCustomElement(boolean customElement) {
+    lazyInitInfo();
+    info.setBit(Property.CUSTOM_ELEMENT, customElement);
+  }
+
+  /** Returns whether JSDoc is annotated with {@code @mixinClass} annotation. */
+  public boolean isMixinClass() {
+    return (info != null) && info.isBitSet(Property.MIXIN_CLASS);
+  }
+
+  void setMixinClass(boolean mixinClass) {
+    lazyInitInfo();
+    info.setBit(Property.MIXIN_CLASS, mixinClass);
+  }
+
+  /** Returns whether JSDoc is annotated with {@code @mixinFunction} annotation. */
+  public boolean isMixinFunction() {
+    return (info != null) && info.isBitSet(Property.MIXIN_FUNCTION);
+  }
+
+  void setMixinFunction(boolean mixinFunction) {
+    lazyInitInfo();
+    info.setBit(Property.MIXIN_FUNCTION, mixinFunction);
+  }
+
+  /** Returns whether JSDoc is annotated with {@code @disposes} annotation. */
   public boolean isDisposes() {
     return (info == null) ? false : info.disposedParameters != null;
   }

--- a/src/com/google/javascript/rhino/JSDocInfoBuilder.java
+++ b/src/com/google/javascript/rhino/JSDocInfoBuilder.java
@@ -1346,6 +1346,68 @@ public final class JSDocInfoBuilder {
     }
   }
 
+  /** Returns whether current JSDoc is annotated with {@code @polymer}. */
+  public boolean isPolymerRecorded() {
+    return currentInfo.isPolymer();
+  }
+
+  /** Records that this method is to be exposed as a polymer element. */
+  public boolean recordPolymer() {
+    if (!isPolymerRecorded()) {
+      currentInfo.setPolymer(true);
+      populated = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /** Returns whether current JSDoc is annotated with {@code @customElement}. */
+  public boolean isCustomElementRecorded() {
+    return currentInfo.isCustomElement();
+  }
+
+  /** Records that this method is to be exposed as a customElement. */
+  public boolean recordCustomElement() {
+    if (!isCustomElementRecorded()) {
+      currentInfo.setCustomElement(true);
+      populated = true;
+      return true;
+    } else {
+      return false;
+    }
+  }/** Returns whether current JSDoc is annotated with {@code @mixinClass}. */
+  public boolean isMixinClassRecorded() {
+    return currentInfo.isMixinClass();
+  }
+
+  /** Records that this method is to be exposed as a mixinClass. */
+  public boolean recordMixinClass() {
+    if (!isMixinClassRecorded()) {
+      currentInfo.setMixinClass(true);
+      populated = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /** Returns whether current JSDoc is annotated with {@code @mixinFunction}. */
+  public boolean isMixinFunctionRecorded() {
+    return currentInfo.isMixinFunction();
+  }
+
+  /** Records that this method is to be exposed as a mixinFunction. */
+  public boolean recordMixinFunction() {
+    if (!isMixinFunctionRecorded()) {
+      currentInfo.setMixinFunction(true);
+      populated = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   public void mergePropertyBitfieldFrom(JSDocInfo other) {
     currentInfo.mergePropertyBitfieldFrom(other);
   }

--- a/src/com/google/javascript/rhino/Messages.properties
+++ b/src/com/google/javascript/rhino/Messages.properties
@@ -277,6 +277,18 @@ msg.jsdoc.modifies.unknown =\
 msg.jsdoc.polymerBehavior.extra =\
     extra @polymerBehavior tag
 
+msg.jsdoc.polymer.extra =\
+    extra @polymer tag
+
+msg.jsdoc.customElement.extra =\
+    extra @customElement tag
+
+msg.jsdoc.mixinClass.extra =\
+    extra @mixinClass tag
+
+msg.jsdoc.mixinFunction.extra =\
+    extra @mixinFunction tag
+
 msg.jsdoc.stableidgen =\
     extra @stableIdGenerator tag
 

--- a/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesInPolymerElementTest.java
+++ b/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesInPolymerElementTest.java
@@ -46,7 +46,7 @@ public final class CheckUnusedPrivatePropertiesInPolymerElementTest extends Type
     return new CompilerPass() {
       @Override
       public void process(Node externs, Node root) {
-        new PolymerPass(compiler).process(externs, root);
+        new PolymerPass(compiler, 1, true).process(externs, root);
         new CheckUnusedPrivateProperties(compiler).process(externs, root);
       }
     };

--- a/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/CheckUnusedPrivatePropertiesTest.java
@@ -208,6 +208,20 @@ public final class CheckUnusedPrivatePropertiesTest extends TypeICompilerTestCas
     used(LINE_JOINER.join(
         "/** @constructor */ function A() {/** @private */ this.foo = 1;}",
         "use(goog.reflect.object(A, {foo: 'foo'}));"));
+
+    // Verify reflection prevents warning.
+    used(
+        LINE_JOINER.join(
+            "/** @const */ var $jscomp = {};",
+            "/** @const */ $jscomp.scope = {};",
+            "/**",
+            " * @param {!Function} type",
+            " * @param {Object} object",
+            " * @return {Object}",
+            " */",
+            "$jscomp.reflectObject = function (type, object) { return object; };",
+            "/** @constructor */ function A() {/** @private */ this.foo = 1;}",
+            "use($jscomp.reflectObject(A, {foo: 'foo'}));"));
   }
 
   public void testObjectReflection2() {

--- a/test/com/google/javascript/jscomp/ClosureCodingConventionTest.java
+++ b/test/com/google/javascript/jscomp/ClosureCodingConventionTest.java
@@ -169,6 +169,11 @@ public final class ClosureCodingConventionTest extends TestCase {
     assertNotObjectLiteralCast("goog.reflect.object(A);");
     assertNotObjectLiteralCast("goog.reflect.object(1, {});");
     assertObjectLiteralCast("goog.reflect.object(A, {});");
+
+    assertNotObjectLiteralCast("$jscomp.reflectObject();");
+    assertNotObjectLiteralCast("$jscomp.reflectObject(A);");
+    assertNotObjectLiteralCast("$jscomp.reflectObject(1, {});");
+    assertObjectLiteralCast("$jscomp.reflectObject(A, {});");
   }
 
   public void testFunctionBind() {

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -1374,7 +1374,7 @@ public abstract class CompilerTestCase extends TestCase {
 
         if (polymerPass && i == 0) {
           recentChange.reset();
-          new PolymerPass(compiler).process(externsRoot, mainRoot);
+          new PolymerPass(compiler, 1, false).process(externsRoot, mainRoot);
           hasCodeChanged = hasCodeChanged || recentChange.hasCodeChanged();
         }
 

--- a/test/com/google/javascript/jscomp/PolymerClassDefinitionTest.java
+++ b/test/com/google/javascript/jscomp/PolymerClassDefinitionTest.java
@@ -18,7 +18,9 @@ package com.google.javascript.jscomp;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Predicates;
+import com.google.javascript.jscomp.testing.NodeSubject;
 import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.Token;
 
 public final class PolymerClassDefinitionTest extends CompilerTypeTestCase {
 
@@ -33,50 +35,81 @@ public final class PolymerClassDefinitionTest extends CompilerTypeTestCase {
   // TODO(jlklein): Add more complex test cases and verify behaviors and descriptors.
 
   public void testSimpleBehavior() {
-    PolymerClassDefinition def = parseAndExtractClassDef(
-        LINE_JOINER.join(
-            "/** @polymerBehavior */",
-            "var FunBehavior = {",
-            "  properties: {",
-            "    /** @type {boolean} */",
-            "    isFun: {",
-            "      type: Boolean,",
-            "      value: true,",
-            "    }",
-            "  },",
-            "  listeners: {",
-            "    click: 'doSomethingFun',",
-            "  },",
-            "  /** @type {string} */",
-            "  foo: 'hooray',",
-            "",
-            "  /** @param {string} funAmount */",
-            "  doSomethingFun: function(funAmount) { alert('Something ' + funAmount + ' fun!'); },",
-            "  /** @override */",
-            "  created: function() {}",
-            "};",
-            "var A = Polymer({",
-            "  is: 'x-element',",
-            "  properties: {",
-            "    pets: {",
-            "      type: Array,",
-            "      notify: true,",
-            "    },",
-            "    name: String,",
-            "  },",
-            "  behaviors: [ FunBehavior ],",
-            "});"));
+    PolymerClassDefinition def =
+        parseAndExtractClassDefFromCall(
+            LINE_JOINER.join(
+                "/** @polymerBehavior */",
+                "var FunBehavior = {",
+                "  properties: {",
+                "    /** @type {boolean} */",
+                "    isFun: {",
+                "      type: Boolean,",
+                "      value: true,",
+                "    }",
+                "  },",
+                "  listeners: {",
+                "    click: 'doSomethingFun',",
+                "  },",
+                "  /** @type {string} */",
+                "  foo: 'hooray',",
+                "",
+                "  /** @param {string} funAmount */",
+                "  doSomethingFun: function(funAmount) { alert('Something ' + funAmount + ' fun!'); },",
+                "  /** @override */",
+                "  created: function() {}",
+                "};",
+                "var A = Polymer({",
+                "  is: 'x-element',",
+                "  properties: {",
+                "    pets: {",
+                "      type: Array,",
+                "      notify: true,",
+                "    },",
+                "    name: String,",
+                "  },",
+                "  behaviors: [ FunBehavior ],",
+                "});"));
 
     assertNotNull(def);
-    assertTrue(def.target.isName());
+    assertEquals(PolymerClassDefinition.DefinitionType.ObjectLiteral, def.defType);
+    NodeSubject.assertNode(def.target).hasType(Token.NAME);
     assertEquals("A", def.target.getString());
     assertNull(def.nativeBaseElement);
     assertThat(def.behaviors).hasSize(1);
     assertThat(def.props).hasSize(3);
   }
 
+  public void testBasicClass() {
+    compiler.getOptions().setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2015);
+    PolymerClassDefinition def =
+        parseAndExtractClassDefFromClass(
+            LINE_JOINER.join(
+                "class A extends Polymer.Element {",
+                "  static get is() { return 'x-element'; }",
+                "  static get properties() {",
+                "    return {",
+                "      pets: {",
+                "        type: Array,",
+                "        notify: true,",
+                "      },",
+                "      name: String",
+                "    };",
+                "  }",
+                "}"));
+
+    assertNotNull(def);
+    assertEquals(PolymerClassDefinition.DefinitionType.ES6Class, def.defType);
+    NodeSubject.assertNode(def.target).hasType(Token.NAME);
+    assertEquals("A", def.target.getString());
+    assertNotNull(def.descriptor);
+    NodeSubject.assertNode(def.descriptor).hasType(Token.OBJECTLIT);
+    assertNull(def.nativeBaseElement);
+    assertNull(def.behaviors);
+    assertThat(def.props).hasSize(2);
+  }
+
   public void testDynamicDescriptor() {
-    PolymerClassDefinition def = parseAndExtractClassDef(
+    PolymerClassDefinition def = parseAndExtractClassDefFromCall(
         LINE_JOINER.join(
             "var A = Polymer({",
             "  is: x,",
@@ -86,7 +119,7 @@ public final class PolymerClassDefinitionTest extends CompilerTypeTestCase {
   }
 
   public void testDynamicDescriptor1() {
-    PolymerClassDefinition def = parseAndExtractClassDef(
+    PolymerClassDefinition def = parseAndExtractClassDefFromCall(
         LINE_JOINER.join(
             "Polymer({",
             "  is: x,",
@@ -96,7 +129,7 @@ public final class PolymerClassDefinitionTest extends CompilerTypeTestCase {
   }
 
   public void testDynamicDescriptor2() {
-    PolymerClassDefinition def = parseAndExtractClassDef(
+    PolymerClassDefinition def = parseAndExtractClassDefFromCall(
         LINE_JOINER.join(
             "Polymer({",
             "  is: foo.bar,",
@@ -106,7 +139,7 @@ public final class PolymerClassDefinitionTest extends CompilerTypeTestCase {
   }
 
   public void testDynamicDescriptor3() {
-    PolymerClassDefinition def = parseAndExtractClassDef(
+    PolymerClassDefinition def = parseAndExtractClassDefFromCall(
         LINE_JOINER.join(
             "Polymer({",
             "  is: this.bar,",
@@ -115,20 +148,43 @@ public final class PolymerClassDefinitionTest extends CompilerTypeTestCase {
     assertEquals("This$barElement", def.target.getString());
   }
 
-  private PolymerClassDefinition parseAndExtractClassDef(String code) {
+  private PolymerClassDefinition parseAndExtractClassDefFromCall(String code) {
     Node rootNode = compiler.parseTestCode(code);
     GlobalNamespace globalNamespace =  new GlobalNamespace(compiler, rootNode);
 
-    NodeUtil.visitPostOrder(rootNode, new NodeUtil.Visitor() {
-      @Override
-      public void visit(Node node) {
-        if (PolymerPass.isPolymerCall(node)) {
-          polymerCall = node;
-        }
-      }
-    }, Predicates.<Node>alwaysTrue());
+    NodeUtil.visitPostOrder(
+        rootNode,
+        new NodeUtil.Visitor() {
+          @Override
+          public void visit(Node node) {
+            if (PolymerPassStaticUtils.isPolymerCall(node)) {
+              polymerCall = node;
+            }
+          }
+        },
+        Predicates.<Node>alwaysTrue());
 
     assertNotNull(polymerCall);
     return PolymerClassDefinition.extractFromCallNode(polymerCall, compiler, globalNamespace);
+  }
+
+  private PolymerClassDefinition parseAndExtractClassDefFromClass(String code) {
+    Node rootNode = compiler.parseTestCode(code);
+    GlobalNamespace globalNamespace = new GlobalNamespace(compiler, rootNode);
+
+    NodeUtil.visitPostOrder(
+        rootNode,
+        new NodeUtil.Visitor() {
+          @Override
+          public void visit(Node node) {
+            if (PolymerPassStaticUtils.isPolymerClass(node)) {
+              polymerCall = node;
+            }
+          }
+        },
+        Predicates.<Node>alwaysTrue());
+
+    assertNotNull(polymerCall);
+    return PolymerClassDefinition.extractFromClassNode(polymerCall, compiler, globalNamespace);
   }
 }

--- a/test/com/google/javascript/jscomp/PolymerPassStaticUtilsTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassStaticUtilsTest.java
@@ -18,20 +18,39 @@ package com.google.javascript.jscomp;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.javascript.rhino.IR;
-
 import junit.framework.TestCase;
 
 public final class PolymerPassStaticUtilsTest extends TestCase {
 
   public void testGetPolymerElementType_noNativeElement() {
-    PolymerClassDefinition def = new PolymerClassDefinition(
-        null, IR.objectlit(), null, null, null, null, null, null);
+    PolymerClassDefinition def =
+        new PolymerClassDefinition(
+            PolymerClassDefinition.DefinitionType.ObjectLiteral,
+            null,
+            null,
+            IR.objectlit(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertThat(PolymerPassStaticUtils.getPolymerElementType(def)).isEqualTo("PolymerElement");
   }
 
   public void testGetPolymerElementType_inputBaseElement() {
-    PolymerClassDefinition def = new PolymerClassDefinition(
-        null, IR.objectlit(), null, null, "input", null, null, null);
+    PolymerClassDefinition def =
+        new PolymerClassDefinition(
+            PolymerClassDefinition.DefinitionType.ES6Class,
+            null,
+            null,
+            IR.objectlit(),
+            null,
+            null,
+            "input",
+            null,
+            null,
+            null);
     assertThat(PolymerPassStaticUtils.getPolymerElementType(def)).isEqualTo("PolymerInputElement");
   }
 

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -16,6 +16,9 @@
 package com.google.javascript.jscomp;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.javascript.jscomp.PolymerClassRewriter.POLYMER_ELEMENT_PROP_CONFIG;
+import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_CLASS_PROPERTIES_INVALID;
+import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_CLASS_PROPERTIES_NOT_STATIC;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_DESCRIPTOR_NOT_VALID;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_DECLARATION;
 import static com.google.javascript.jscomp.PolymerPassErrors.POLYMER_INVALID_EXTENDS;
@@ -122,31 +125,19 @@ public class PolymerPassTest extends CompilerTestCase {
           "/** @interface */",
           "var PolymerXInputElementInterface = function() {};");
 
-  private static final String READONLY_EXTERNS =
-      EXTERNS
-          + LINE_JOINER.join(
-              "/** @interface */",
-              "var Polymera_BInterface = function() {};",
-              "/** @type {!Array<string>} */",
-              "Polymera_BInterface.prototype.pets;",
-              "/** @private {string} */",
-              "Polymera_BInterface.prototype.name_;",
-              "/** @param {!Array<string>} pets **/",
-              "Polymera_BInterface.prototype._setPets;");
+  private static final String REFLECT_OBJECT_DEF =
+      LINE_JOINER.join(
+          "/** @const */ var $jscomp = $jscomp || {};",
+          "/** @const */ $jscomp.scope = {};",
+          "/**",
+          " * @param {!Function} type",
+          " * @param {Object} object",
+          " * @return {Object}",
+          " */",
+          "$jscomp.reflectObject = function (type, object) { return object; };");
 
-  private static final String BEHAVIOR_READONLY_EXTERNS =
-      EXTERNS
-          + LINE_JOINER.join(
-              "/** @interface */",
-              "var PolymerAInterface = function() {};",
-              "/** @type {boolean} */",
-              "PolymerAInterface.prototype.isFun;",
-              "/** @type {!Array} */",
-              "PolymerAInterface.prototype.pets;",
-              "/** @type {string} */",
-              "PolymerAInterface.prototype.name;",
-              "/** @param {boolean} isFun **/",
-              "PolymerAInterface.prototype._setIsFun;");
+  private int polymerVersion = 1;
+  private boolean propertyRenamingEnabled = false;
 
   public PolymerPassTest() {
     super(EXTERNS);
@@ -154,7 +145,7 @@ public class PolymerPassTest extends CompilerTestCase {
 
   @Override
   protected CompilerPass getProcessor(Compiler compiler) {
-    return new PolymerPass(compiler);
+    return new PolymerPass(compiler, polymerVersion, propertyRenamingEnabled);
   }
 
   @Override
@@ -185,9 +176,26 @@ public class PolymerPassTest extends CompilerTestCase {
             "X = Polymer(/** @lends {X.prototype} */ {",
             "  is: 'x-element',",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "var X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return {}; }",
+            "};"),
+        LINE_JOINER.join(
+            "var X = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() { return {}; }",
+            "};"));
   }
 
   public void testLetTarget() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     test(
         LINE_JOINER.join(
@@ -202,15 +210,46 @@ public class PolymerPassTest extends CompilerTestCase {
             " */",
             "var X = function() {};",
             "X = Polymer(/** @lends {X.prototype} */ {is:'x-element'});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "let X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return { }; }",
+            "};"),
+        LINE_JOINER.join(
+            "let X = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() { return {}; }",
+            "};"));
   }
 
   public void testConstTarget() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testError(
         LINE_JOINER.join(
             "const X = Polymer({",
             "  is: 'x-element',",
             "});"), POLYMER_INVALID_DECLARATION);
+
+    test(
+        LINE_JOINER.join(
+            "const X = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return {}; }",
+            "};"),
+        LINE_JOINER.join(
+            "const X = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() { return {}; }",
+            "};"));
   }
 
   public void testDefaultTypeNameTarget() {
@@ -246,9 +285,28 @@ public class PolymerPassTest extends CompilerTestCase {
             "x.Z = Polymer(/** @lends {x.Z.prototype} */ {",
             "  is: 'x-element',",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "const x = {};",
+            "x.Z = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return {}; }",
+            "};"),
+        LINE_JOINER.join(
+            "const x = {};",
+            "x.Z = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() { return {}; }",
+            "};"));
   }
 
   public void testComputedPropName() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck(); // TypeCheck cannot grab a name from a complicated computedPropName
     test("var X = Polymer({is:'x-element', [name + (() => 42)]: function() {return 42;}});",
         LINE_JOINER.join(
@@ -289,6 +347,28 @@ public class PolymerPassTest extends CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "const x = {};",
+            "(function() {",
+            "  x.Z = class extends Polymer.Element {",
+            "    static get is() { return 'x-element'; }",
+            "    static get properties() { return {}; }",
+            "  };",
+            "})();"),
+        LINE_JOINER.join(
+            "const x = {};",
+            "(function() {",
+            "  x.Z = class extends Polymer.Element {",
+            "    /** @return {string} */",
+            "    static get is() { return 'x-element'; }",
+            "    /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "    static get properties() { return {}; }",
+            "  };",
+            "})();"));
   }
 
   /**
@@ -298,6 +378,7 @@ public class PolymerPassTest extends CompilerTestCase {
    */
   public void testIIFEExtractionNoAssignmentTarget() {
     test(
+        1,
         LINE_JOINER.join(
             "(function() {",
             "  Polymer({",
@@ -305,7 +386,6 @@ public class PolymerPassTest extends CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"),
-
         LINE_JOINER.join(
             "/**",
             " * @constructor @extends {PolymerElement}",
@@ -319,6 +399,49 @@ public class PolymerPassTest extends CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"));
+
+    test(
+        2,
+        LINE_JOINER.join(
+            "(function() {",
+            "  Polymer({",
+            "    is: 'x',",
+            "    sayHi: function() { alert('hi'); },",
+            "  });",
+            "})()"),
+        LINE_JOINER.join(
+            "(function() {",
+            "  /**",
+            "   * @constructor @extends {PolymerElement}",
+            "   * @implements {PolymerXElementInterface}",
+            "   */",
+            "  var XElement = function() {};",
+            "  Polymer(/** @lends {XElement.prototype} */ {",
+            "    is: 'x',",
+            "    /** @this {XElement} */",
+            "    sayHi: function() { alert('hi'); },",
+            "  });",
+            "})()"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "(function() {",
+            "  const X = class extends Polymer.Element {",
+            "    static get is() { return 'x-element'; }",
+            "    static get properties() { return {}; }",
+            "  };",
+            "})();"),
+        LINE_JOINER.join(
+            "(function() {",
+            "  const X = class extends Polymer.Element {",
+            "    /** @return {string} */",
+            "    static get is() { return 'x-element'; }",
+            "    /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "    static get properties() { return {}; }",
+            "  };",
+            "})();"));
   }
 
   /**
@@ -328,6 +451,7 @@ public class PolymerPassTest extends CompilerTestCase {
    */
   public void testIIFEExtractionVarTarget() {
     test(
+        1,
         LINE_JOINER.join(
             "(function() {",
             "  var FooThing = Polymer({",
@@ -335,7 +459,6 @@ public class PolymerPassTest extends CompilerTestCase {
             "    sayHi: function() { alert('hi'); },",
             "  });",
             "})()"),
-
         LINE_JOINER.join(
             "/**",
             " * @constructor @extends {PolymerElement}",
@@ -428,6 +551,25 @@ public class PolymerPassTest extends CompilerTestCase {
             "    alert('Thank you for clicking');",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "class X extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  handleClick(e) {",
+            "    alert('Thank you for clicking');",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "class X extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  handleClick(e) {",
+            "    alert('Thank you for clicking');",
+            "  }",
+            "}"));
   }
 
   public void testListenersAndHostAttributeKeysQuoted() {
@@ -496,6 +638,7 @@ public class PolymerPassTest extends CompilerTestCase {
   }
 
   public void testExtendNonExistentElement() {
+    polymerVersion = 1;
     String js = LINE_JOINER.join(
         "Polymer({",
         "  is: 'x-input',",
@@ -571,9 +714,61 @@ public class PolymerPassTest extends CompilerTestCase {
             "    thingToDo: Function,",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "/** @type {!Function} */",
+            "a.B.prototype.thingToDo;"));
   }
 
   public void testPropertiesObjLitShorthand() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testError(
         LINE_JOINER.join(
@@ -583,6 +778,35 @@ public class PolymerPassTest extends CompilerTestCase {
             "    name,",
             "  },",
             "});"),
+        POLYMER_SHORTHAND_NOT_SUPPORTED);
+
+    testError(
+        LINE_JOINER.join(
+            "var XElem = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      name",
+            "    };",
+            "  }",
+            "};"),
+        POLYMER_SHORTHAND_NOT_SUPPORTED);
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testError(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      name,",
+            "    };",
+            "  }",
+            "};"),
         POLYMER_SHORTHAND_NOT_SUPPORTED);
   }
 
@@ -638,6 +862,63 @@ public class PolymerPassTest extends CompilerTestCase {
             "    name: String,",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: {",
+            "        type: Object,",
+            "        value: function() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        value: function() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      user_: {",
+            "        type: Object,",
+            "        /** @this {a.B} @return {!User} */",
+            "        value: function() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        /** @this {a.B} @return {!Array} */",
+            "        value: function() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;"));
   }
 
   public void testPropertiesDefaultValueShortHandFunction() {
@@ -676,6 +957,63 @@ public class PolymerPassTest extends CompilerTestCase {
             "    },",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: {",
+            "        type: Object,",
+            "        value() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        value() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      user_: {",
+            "        type: Object,",
+            "        /** @this {a.B} @return {!User} */",
+            "        value() { return new User(); },",
+            "      },",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "        /** @this {a.B} @return {!Array} */",
+            "        value() { return [this.name]; },",
+            "      },",
+            "      name: String,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;"));
   }
 
   public void testReadOnlyPropertySetters() {
@@ -696,6 +1034,7 @@ public class PolymerPassTest extends CompilerTestCase {
             "});");
 
     test(
+        1,
         js,
         LINE_JOINER.join(
             "var a = {};",
@@ -718,7 +1057,222 @@ public class PolymerPassTest extends CompilerTestCase {
             "  },",
             "});"));
 
-    testExternChanges(EXTERNS, js, READONLY_EXTERNS);
+    testExternChanges(
+        1,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var Polymera_BInterface = function() {};",
+            "/** @type {!Array<string>} */",
+            "Polymera_BInterface.prototype.pets;",
+            "/** @private {string} */",
+            "Polymera_BInterface.prototype.name_;",
+            "/** @param {!Array<string>} pets **/",
+            "Polymera_BInterface.prototype._setPets;"));
+
+    test(
+        2,
+        js,
+        LINE_JOINER.join(
+            "var a = {};",
+            "/** @constructor @extends {PolymerElement} @implements {Polymera_BInterface} */",
+            "a.B = function() {};",
+            "/** @type {!Array<string>} */",
+            "a.B.prototype.pets;",
+            "/** @private {string} */",
+            "a.B.prototype.name_;",
+            "/** @override */",
+            "a.B.prototype._setPets = function(pets) {};",
+            "a.B = Polymer(/** @lends {a.B.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    pets: {",
+            "      type: Array,",
+            "      readOnly: true,",
+            "    },",
+            "    name_: String,",
+            "  },",
+            "});"));
+
+    testExternChanges(
+        2,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var Polymera_BInterface = function() {};",
+            "/** @type {!Array<string>} */",
+            "Polymera_BInterface.prototype.pets;",
+            "/** @param {!Array<string>} pets **/",
+            "Polymera_BInterface.prototype._setPets;"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    String jsClass = LINE_JOINER.join(
+        "class A extends Polymer.Element {",
+        "  static get is() { return 'a-element'; }",
+        "  static get properties() {",
+        "    return {",
+        "      pets: {",
+        "        type: Array,",
+        "        readOnly: true",
+        "      }",
+        "    };",
+        "  }",
+        "}");
+
+    testExternChanges(
+        2,
+        EXTERNS,
+        jsClass,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var PolymerAInterface = function() {};",
+            "/** @type {!Array} */",
+            "PolymerAInterface.prototype.pets;",
+            "/** @param {!Array} pets **/",
+            "PolymerAInterface.prototype._setPets;"));
+
+    test(
+        2,
+        jsClass,
+        LINE_JOINER.join(
+            "/** @implements {PolymerAInterface} */",
+            "class A extends Polymer.Element {",
+            "  /** @return {string} */ static get is() { return 'a-element'; }",
+            "  /** @return {Polymer.ElementProperties} */ static get properties() {",
+            "    return {",
+            "      pets: {",
+            "        type: Array,",
+            "        readOnly: true",
+            "      }",
+            "    };",
+            "  }",
+            "}",
+            "/** @type {!Array} */",
+            "A.prototype.pets;",
+            "/** @override */",
+            "A.prototype._setPets = function(pets) {};"));
+  }
+
+  public void testReflectToAttributeProperties() {
+    String js =
+        LINE_JOINER.join(
+            "var a = {};",
+            "a.B = Polymer({",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    /** @type {!Array<string>} */",
+            "    pets: {",
+            "      type: Array,",
+            "      readOnly: false,",
+            "    },",
+            "    name: {",
+            "      type: String,",
+            "      reflectToAttribute: true",
+            "    }",
+            "  },",
+            "});");
+
+    test(
+        1,
+        js,
+        LINE_JOINER.join(
+            "var a = {};",
+            "/** @constructor @extends {PolymerElement} @implements {Polymera_BInterface} */",
+            "a.B = function() {};",
+            "/** @type {!Array<string>} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "a.B = Polymer(/** @lends {a.B.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    pets: {",
+            "      type: Array,",
+            "      readOnly: false,",
+            "    },",
+            "    name: {",
+            "      type: String,",
+            "      reflectToAttribute: true",
+            "    }",
+            "  },",
+            "});"));
+
+    testExternChanges(
+        1,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var Polymera_BInterface = function() {};",
+            "/** @type {!Array<string>} */",
+            "Polymera_BInterface.prototype.pets;",
+            "/** @type {string} */",
+            "Polymera_BInterface.prototype.name;"));
+
+    test(
+        2,
+        js,
+        LINE_JOINER.join(
+            "var a = {};",
+            "/** @constructor @extends {PolymerElement} @implements {Polymera_BInterface} */",
+            "a.B = function() {};",
+            "/** @type {!Array<string>} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "a.B = Polymer(/** @lends {a.B.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    pets: {",
+            "      type: Array,",
+            "      readOnly: false,",
+            "    },",
+            "    name: {",
+            "      type: String,",
+            "      reflectToAttribute: true",
+            "    }",
+            "  },",
+            "});"));
+
+    testExternChanges(
+        2,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var Polymera_BInterface = function() {};",
+            "/** @type {string} */",
+            "Polymera_BInterface.prototype.name;"));
+  }
+
+  public void testPolymerClassObserversTyped() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "class FooElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get observers() {",
+            "    return [];",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "class FooElement extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {!Array<string>} */",
+            "  static get observers() {",
+            "    return [];",
+            "  }",
+            "}"));
   }
 
   public void testShorthandFunctionDefinition() {
@@ -863,6 +1417,47 @@ public class PolymerPassTest extends CompilerTestCase {
             "    alert('Hello, ' + name);",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  sayHi() {",
+            "    alert('hi');",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.sayHelloTo_('Tester');",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    alert('Hello, ' + name);",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  sayHi() {",
+            "    alert('hi');",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.sayHelloTo_('Tester');",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    alert('Hello, ' + name);",
+            "  }",
+            "}"));
   }
 
   public void testDollarSignPropsConvertedToBrackets() {
@@ -936,6 +1531,68 @@ public class PolymerPassTest extends CompilerTestCase {
             "    this.$['otherThing'].touch();",
             "  },",
             "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!HTMLElement} */",
+            "      propName: {",
+            "        type: Object,",
+            "        value: function() { return this.$.id; },",
+            "      }",
+            "    };",
+            "  }",
+            "  sayHi() {",
+            "    this.$.checkbox.toggle();",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.$.radioButton.switch();",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    this.$.otherThing.touch();",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "class Foo extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      propName: {",
+            "        type: Object,",
+            "        /** @this {Foo} @return {!HTMLElement} */",
+            "        value: function() { return this.$['id']; },",
+            "      }",
+            "    };",
+            "  }",
+            "  sayHi() {",
+            "    this.$['checkbox'].toggle();",
+            "  }",
+            "  connectedCallback() {",
+            "    this.sayHi();",
+            "    this.$['radioButton'].switch();",
+            "  }",
+            "  /**",
+            "   * @param {string} name",
+            "   * @private",
+            "   */",
+            "  sayHelloTo_(name) {",
+            "    this.$['otherThing'].touch();",
+            "  }",
+            "}",
+            "/** @type {!HTMLElement} */",
+            "Foo.prototype.propName;"));
   }
 
   public void testDollarSignPropsInShorthandFunctionConvertedToBrackets() {
@@ -1168,53 +1825,56 @@ public class PolymerPassTest extends CompilerTestCase {
   /** If a behavior method is {@code @protected} there is no visibility warning. */
   public void testBehaviorWithProtectedMethod() {
     enableCheckAccessControls();
-    test(
-        new String[] {
-          LINE_JOINER.join(
-              "/** @polymerBehavior */",
-              "var FunBehavior = {",
-              "  /** @protected */",
-              "  doSomethingFun: function() {},",
-              "};"),
-          LINE_JOINER.join(
-              "var A = Polymer({",
-              "  is: 'x-element',",
-              "  callBehaviorMethod: function() {",
-              "    this.doSomethingFun();",
-              "  },",
-              "  behaviors: [ FunBehavior ],",
-              "});"),
-        },
-        new String[] {
-          LINE_JOINER.join(
-              "/** @polymerBehavior @nocollapse */",
-              "var FunBehavior = {",
-              "  /**",
-              "   * @suppress {checkTypes|globalThis|visibility}",
-              "   */",
-              "  doSomethingFun: function() {},",
-              "};"),
-          LINE_JOINER.join(
-              "/**",
-              " * @constructor",
-              " * @extends {PolymerElement}",
-              " * @implements {PolymerAInterface}",
-              " */",
-              "var A = function() {};",
-              "",
-              "/**",
-              " * @public",
-              " * @suppress {unusedPrivateMembers}",
-              " */",
-              "A.prototype.doSomethingFun = function(){};",
-              "",
-              "A = Polymer(/** @lends {A.prototype} */ {",
-              "  is: 'x-element',",
-              "  /** @this {A} */",
-              "  callBehaviorMethod: function(){ this.doSomethingFun(); },",
-              "  behaviors: [FunBehavior],",
-              "})"),
-        });
+    for (int i = 1; i <= 2; i++) {
+      this.polymerVersion = i;
+      test(
+          new String[] {
+              LINE_JOINER.join(
+                  "/** @polymerBehavior */",
+                  "var FunBehavior = {",
+                  "  /** @protected */",
+                  "  doSomethingFun: function() {},",
+                  "};"),
+              LINE_JOINER.join(
+                  "var A = Polymer({",
+                  "  is: 'x-element',",
+                  "  callBehaviorMethod: function() {",
+                  "    this.doSomethingFun();",
+                  "  },",
+                  "  behaviors: [ FunBehavior ],",
+                  "});"),
+          },
+          new String[] {
+              LINE_JOINER.join(
+                  "/** @polymerBehavior @nocollapse */",
+                  "var FunBehavior = {",
+                  "  /**",
+                  "   * @suppress {checkTypes|globalThis|visibility}",
+                  "   */",
+                  "  doSomethingFun: function() {},",
+                  "};"),
+              LINE_JOINER.join(
+                  "/**",
+                  " * @constructor",
+                  " * @extends {PolymerElement}",
+                  " * @implements {PolymerAInterface}",
+                  " */",
+                  "var A = function() {};",
+                  "",
+                  "/**",
+                  " * @public",
+                  " * @suppress {unusedPrivateMembers}",
+                  " */",
+                  "A.prototype.doSomethingFun = function(){};",
+                  "",
+                  "A = Polymer(/** @lends {A.prototype} */ {",
+                  "  is: 'x-element',",
+                  "  /** @this {A} */",
+                  "  callBehaviorMethod: function(){ this.doSomethingFun(); },",
+                  "  behaviors: [FunBehavior],",
+                  "})"),
+          });
+    }
   }
 
   /** If a behavior method is {@code @private} there is a visibility warning. */
@@ -1923,7 +2583,35 @@ public class PolymerPassTest extends CompilerTestCase {
             "  behaviors: [ FunBehavior ],",
             "});"));
 
-    testExternChanges(EXTERNS, js, BEHAVIOR_READONLY_EXTERNS);
+    testExternChanges(
+        1,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var PolymerAInterface = function() {};",
+            "/** @type {boolean} */",
+            "PolymerAInterface.prototype.isFun;",
+            "/** @type {!Array} */",
+            "PolymerAInterface.prototype.pets;",
+            "/** @type {string} */",
+            "PolymerAInterface.prototype.name;",
+            "/** @param {boolean} isFun **/",
+            "PolymerAInterface.prototype._setIsFun;"));
+
+    testExternChanges(
+        2,
+        EXTERNS,
+        js,
+        LINE_JOINER.join(
+            EXTERNS,
+            "/** @interface */",
+            "var PolymerAInterface = function() {};",
+            "/** @type {boolean} */",
+            "PolymerAInterface.prototype.isFun;",
+            "/** @param {boolean} isFun **/",
+            "PolymerAInterface.prototype._setIsFun;"));
   }
 
   /**
@@ -2121,6 +2809,7 @@ public class PolymerPassTest extends CompilerTestCase {
   }
 
   public void testInvalid1() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     testWarning("var x = Polymer('blah');", POLYMER_DESCRIPTOR_NOT_VALID);
     testWarning("var x = Polymer('foo-bar', {});", POLYMER_DESCRIPTOR_NOT_VALID);
@@ -2129,6 +2818,22 @@ public class PolymerPassTest extends CompilerTestCase {
     testError("var x = Polymer({is});", POLYMER_MISSING_IS);
     testError("var x = Polymer({is: 'x-element', shortHand,});",
         POLYMER_SHORTHAND_NOT_SUPPORTED);
+
+    testError(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() { return '' }",
+            "};"),
+        POLYMER_CLASS_PROPERTIES_INVALID);
+
+    testError(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  get properties() { return {} }",
+            "};"),
+        POLYMER_CLASS_PROPERTIES_NOT_STATIC);
   }
 
   public void testInvalidProperties() {
@@ -2167,6 +2872,49 @@ public class PolymerPassTest extends CompilerTestCase {
             "    },",
             "  },",
             "});"),
+        POLYMER_INVALID_PROPERTY);
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    testError(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      isHappy: true,",
+            "    };",
+            "  }",
+            "};"),
+        POLYMER_INVALID_PROPERTY);
+
+    testError(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      isHappy: {",
+            "        value: true,",
+            "      }",
+            "    };",
+            "  }",
+            "};"),
+        POLYMER_INVALID_PROPERTY);
+
+    testError(
+        LINE_JOINER.join(
+            "var x = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      isHappy: {",
+            "        type: foo.Bar,",
+            "        value: true,",
+            "      }",
+            "    };",
+            "  }",
+            "};"),
         POLYMER_INVALID_PROPERTY);
   }
 
@@ -2264,7 +3012,8 @@ public class PolymerPassTest extends CompilerTestCase {
     "});"), warning(TYPE_MISMATCH_WARNING));
   }
 
-  public void testES6FeaturesInFunctionBody() {
+  public void testFeaturesInFunctionBody() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
     disableTypeCheck();
     test(
         LINE_JOINER.join(
@@ -2300,5 +3049,461 @@ public class PolymerPassTest extends CompilerTestCase {
             "    var [eins, zwei, drei] = arr;",
             "  },",
             "});"));
+  }
+
+  public void testPolymerElementAnnotation1() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @polymer */",
+            "class Foo extends Bar {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function",
+            "    };",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @polymer */",
+            "class Foo extends Bar {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function",
+            "    };",
+            "  }",
+            "}",
+            "/** @type {!User} @private */",
+            "Foo.prototype.user_;",
+            "/** @type {!Array} */",
+            "Foo.prototype.pets;",
+            "/** @type {string} */",
+            "Foo.prototype.name;",
+            "/** @type {!Function} */",
+            "Foo.prototype.thingToDo;"));
+  }
+
+  public void testPolymerElementAnnotation2() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "/** @polymer */",
+            "a.B = class extends Foo {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "      type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "/** @polymer */",
+            "a.B = class extends Foo {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "/** @type {!Function} */",
+            "a.B.prototype.thingToDo;"));
+  }
+
+  public void testObjectReflectionAddedToConfigProperties1() {
+    propertyRenamingEnabled = true;
+    test(
+        2,
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = Polymer({",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    /** @type {!User} @private */",
+            "    user_: Object,",
+            "    pets: {",
+            "      type: Array,",
+            "      notify: true,",
+            "    },",
+            "    name: String,",
+            "    thingToDo: Function,",
+            "  },",
+            "});"),
+        LINE_JOINER.join(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "/** @constructor @extends {PolymerElement} @implements {Polymera_BInterface}*/",
+            "a.B = function() {};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "/** @type {!Function} */",
+            "a.B.prototype.thingToDo;",
+            "a.B = Polymer(/** @lends {a.B.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: $jscomp.reflectObject(a.B, {",
+            "    user_: Object,",
+            "    pets: {",
+            "      type: Array,",
+            "      notify: true,",
+            "    },",
+            "    name: String,",
+            "    thingToDo: Function,",
+            "  }),",
+            "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return  $jscomp.reflectObject(a.B, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function",
+            "    });",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "/** @type {!Function} */",
+            "a.B.prototype.thingToDo;"));
+  }
+
+  public void testObjectReflectionAddedToConfigProperties2() {
+    propertyRenamingEnabled = true;
+    test(
+        2,
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var A = Polymer({",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    /** @type {!User} @private */",
+            "    user_: Object,",
+            "    pets: {",
+            "      type: Array,",
+            "      notify: true,",
+            "    },",
+            "    name: String,",
+            "    thingToDo: Function,",
+            "  },",
+            "});"),
+        LINE_JOINER.join(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @constructor @extends {PolymerElement} @implements {PolymerAInterface}*/",
+            "var A = function() {};",
+            "/** @type {!User} @private */",
+            "A.prototype.user_;",
+            "/** @type {!Array} */",
+            "A.prototype.pets;",
+            "/** @type {string} */",
+            "A.prototype.name;",
+            "/** @type {!Function} */",
+            "A.prototype.thingToDo;",
+            "A = Polymer(/** @lends {A.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: $jscomp.reflectObject(A, {",
+            "    user_: Object,",
+            "    pets: {",
+            "      type: Array,",
+            "      notify: true,",
+            "    },",
+            "    name: String,",
+            "    thingToDo: Function,",
+            "  }),",
+            "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "const A = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "};"),
+        LINE_JOINER.join(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "const A = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(A, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "};",
+            "/** @type {!User} @private */",
+            "A.prototype.user_;",
+            "/** @type {!Array} */",
+            "A.prototype.pets;",
+            "/** @type {string} */",
+            "A.prototype.name;",
+            "/** @type {!Function} */",
+            "A.prototype.thingToDo;"));
+  }
+
+  public void testObjectReflectionAddedToConfigProperties3() {
+    propertyRenamingEnabled = true;
+    test(
+        2,
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "Polymer({",
+            "  is: 'x-element',",
+            "  properties: {",
+            "    /** @type {!User} @private */",
+            "    user_: Object,",
+            "    pets: {",
+            "      type: Array,",
+            "      notify: true,",
+            "    },",
+            "    name: String,",
+            "    thingToDo: Function,",
+            "  },",
+            "});"),
+        LINE_JOINER.join(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @constructor @extends {PolymerElement} @implements {PolymerXElementElementInterface}*/",
+            "var XElementElement = function() {};",
+            "/** @type {!User} @private */",
+            "XElementElement.prototype.user_;",
+            "/** @type {!Array} */",
+            "XElementElement.prototype.pets;",
+            "/** @type {string} */",
+            "XElementElement.prototype.name;",
+            "/** @type {!Function} */",
+            "XElementElement.prototype.thingToDo;",
+            "Polymer(/** @lends {XElementElement.prototype} */ {",
+            "  is: 'x-element',",
+            "  properties: $jscomp.reflectObject(XElementElement, {",
+            "    user_: Object,",
+            "    pets: {",
+            "      type: Array,",
+            "      notify: true,",
+            "    },",
+            "    name: String,",
+            "    thingToDo: Function,",
+            "  }),",
+            "});"));
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        LINE_JOINER.join(
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "}"),
+        LINE_JOINER.join(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(XElement, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        notify: true,",
+            "      },",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "}",
+            "/** @type {!User} @private */",
+            "XElement.prototype.user_;",
+            "/** @type {!Array} */",
+            "XElement.prototype.pets;",
+            "/** @type {string} */",
+            "XElement.prototype.name;",
+            "/** @type {!Function} */",
+            "XElement.prototype.thingToDo;"));
+  }
+
+  @Override
+  public void test(String js, String expected) {
+    polymerVersion = 1;
+    super.test(js, expected);
+
+    polymerVersion = 2;
+    super.test(js, expected);
+  }
+
+  public void test(int polymerVersion, String js, String expected) {
+    this.polymerVersion = polymerVersion;
+    super.test(js, expected);
+  }
+
+  @Override
+  protected void testExternChanges(String extern, String input, String expectedExtern) {
+    polymerVersion = 1;
+    super.testExternChanges(extern, input, expectedExtern);
+
+    polymerVersion = 2;
+    super.testExternChanges(extern, input, expectedExtern);
+  }
+
+  protected void testExternChanges(
+      int polymerVersion, String extern, String input, String expectedExtern) {
+    this.polymerVersion = polymerVersion;
+    super.testExternChanges(extern, input, expectedExtern);
+  }
+
+  @Override
+  public void testError(String js, DiagnosticType error) {
+    polymerVersion = 1;
+    super.testError(js, error);
+
+    polymerVersion = 2;
+    super.testError(js, error);
+  }
+
+  @Override
+  public void testWarning(String js, DiagnosticType error) {
+    polymerVersion = 1;
+    super.testWarning(js, error);
+
+    polymerVersion = 2;
+    super.testWarning(js, error);
   }
 }

--- a/test/com/google/javascript/jscomp/TypedScopeCreatorTest.java
+++ b/test/com/google/javascript/jscomp/TypedScopeCreatorTest.java
@@ -997,6 +997,14 @@ public final class TypedScopeCreatorTest extends CompilerTestCase {
              "goog.reflect.object(A.B, {isEnabled: 3})\n" +
              "var x = (new A.B()).isEnabled;");
 
+    // Verify that "$jscomp.reflectObject" does not modify the types on
+    // "A.B"
+    testSame(
+        "/** @constructor */ A.B = function() {}\n"
+            + "A.B.prototype.isEnabled = true;\n"
+            + "$jscomp.reflectObject(A.B, {isEnabled: 3})\n"
+            + "var x = (new A.B()).isEnabled;");
+
     assertEquals("A.B",
         findTokenType(Token.OBJECTLIT, globalScope).toString());
     assertEquals("boolean",

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -4304,6 +4304,38 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
     parse("@polymerBehavior \n@polymerBehavior*/", "extra @polymerBehavior tag");
   }
 
+  public void testParsePolymer() {
+    assertThat(parse("@polymer*/").isPolymer()).isTrue();
+  }
+
+  public void testParsePolymerExtra() {
+    parse("@polymer \n@polymer*/", "extra @polymer tag");
+  }
+
+  public void testParseCustomElement() {
+    assertThat(parse("@customElement*/").isCustomElement()).isTrue();
+  }
+
+  public void testParseCustomElementExtra() {
+    parse("@customElement \n@customElement*/", "extra @customElement tag");
+  }
+
+  public void testParseMixinClass() {
+    assertThat(parse("@mixinClass*/").isMixinClass()).isTrue();
+  }
+
+  public void testParseMixinClassExtra() {
+    parse("@mixinClass \n@mixinClass*/", "extra @mixinClass tag");
+  }
+
+  public void testParseMixinFunction() {
+    assertThat(parse("@mixinFunction*/").isMixinFunction()).isTrue();
+  }
+
+  public void testParseMixinFunctionExtra() {
+    parse("@mixinFunction \n@mixinFunction*/", "extra @mixinFunction tag");
+  }
+
   public void testParseWizaction1() {
     assertThat(parse("@wizaction*/").isWizaction()).isTrue();
   }

--- a/test/com/google/javascript/rhino/JSDocInfoTest.java
+++ b/test/com/google/javascript/rhino/JSDocInfoTest.java
@@ -344,6 +344,38 @@ public class JSDocInfoTest extends TestCase {
     assertTrue(info.isPolymerBehavior());
   }
 
+  public void testSetPolymer() {
+    JSDocInfo info = new JSDocInfo();
+    assertFalse(info.isPolymer());
+    info.setPolymer(true);
+
+    assertTrue(info.isPolymer());
+  }
+
+  public void testSetCustomElement() {
+    JSDocInfo info = new JSDocInfo();
+    assertFalse(info.isCustomElement());
+    info.setCustomElement(true);
+
+    assertTrue(info.isCustomElement());
+  }
+
+  public void testSetMixinClass() {
+    JSDocInfo info = new JSDocInfo();
+    assertFalse(info.isMixinClass());
+    info.setMixinClass(true);
+
+    assertTrue(info.isMixinClass());
+  }
+
+  public void testSetMixinFunction() {
+    JSDocInfo info = new JSDocInfo();
+    assertFalse(info.isMixinFunction());
+    info.setMixinFunction(true);
+
+    assertTrue(info.isMixinFunction());
+  }
+
   public void testSetNoAlias() {
     JSDocInfo info = new JSDocInfo();
     info.setNoAlias(true);


### PR DESCRIPTION
Provides full support for Polymer 2 class based and hybrid elements. By setting the new `--polymer_version=2` flag, the behavior is changed to support both Polymer 2 class based elements as well as better renaming. In particular:

 * Declared properties are now renamable (except for those marked readonly).
 * Both declared and standard properties follow the ALL_UNQUOTED policy.
 * Designed for new type inference only. Type names are no longer forced into the global scope.
 * Adds an `@polymerElement` annotation for Polymer 2 classes so the compiler can recognize elements which do not directly extend `Polymer.Element`.
 * `@polymerElement` and `@polymerBehavior` annotations are now printed out when `--preserve_type_annotations` is enabled.
 * Auto-injects an object reflection primitive to support consistently renaming Polymer property configuration literals with the object.

Requires #2337 to prevent the compiler from creating invalid property names.

We can either land #2277 first and then I'll rebase these changes, or it can be closed and this PR can be merged in it's stead as it includes those changes.

I've tested this code on my project with the `--polymer_version` flag at both 1 and 2.

cc @MatrixFrog, @justinfagnani 