### PR TITLE
Fix the interaction between absolute path imports and module roots

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1534,10 +1534,20 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
                 options.moduleRoots,
                 inputs,
                 ModuleLoader.PathResolver.RELATIVE,
-                options.moduleResolutionMode);
+                options.moduleResolutionMode,
+                null);
 
         if (options.moduleResolutionMode == ModuleLoader.ResolutionMode.NODE) {
-          this.moduleLoader.setPackageJsonMainEntries(processJsonInputs(inputs));
+          // processJsonInputs requires a module loader to already be defined
+          // so we redefine it afterwards with the package.json inputs
+          this.moduleLoader =
+              new ModuleLoader(
+                  this,
+                  options.moduleRoots,
+                  inputs,
+                  ModuleLoader.PathResolver.RELATIVE,
+                  options.moduleResolutionMode,
+                  processJsonInputs(inputs));
         }
 
         if (options.lowerFromEs6()) {

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1554,10 +1554,9 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
         Map<String, CompilerInput> inputModuleIdentifiers = new HashMap<>();
         for (CompilerInput input : inputs) {
           if (input.getKnownProvides().isEmpty()) {
-            ModuleIdentifier modInfo =
-                ModuleIdentifier.forFile(input.getSourceFile().getOriginalPath());
-
-            inputModuleIdentifiers.put(modInfo.getClosureNamespace(), input);
+            ModuleLoader.ModulePath modPath =
+                moduleLoader.resolve(input.getSourceFile().getOriginalPath());
+            inputModuleIdentifiers.put(modPath.toModuleName(), input);
           }
         }
 

--- a/src/com/google/javascript/jscomp/deps/BrowserModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/BrowserModuleResolver.java
@@ -42,17 +42,15 @@ public class BrowserModuleResolver extends ModuleResolver {
       String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
 
     if (ModuleLoader.isAmbiguousIdentifier(moduleAddress)) {
-      if (errorHandler != null) {
-        errorHandler.report(
-            CheckLevel.WARNING,
-            JSError.make(
-                sourcename,
-                lineno,
-                colno,
-                ModuleLoader.INVALID_MODULE_PATH,
-                moduleAddress,
-                "BROWSER"));
-      }
+      errorHandler.report(
+          CheckLevel.WARNING,
+          JSError.make(
+              sourcename,
+              lineno,
+              colno,
+              ModuleLoader.INVALID_MODULE_PATH,
+              moduleAddress,
+              "BROWSER"));
       return null;
     }
 

--- a/src/com/google/javascript/jscomp/deps/BrowserModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/BrowserModuleResolver.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.ErrorHandler;
+import com.google.javascript.jscomp.JSError;
+import javax.annotation.Nullable;
+
+/**
+ * Resolution algorithm for Browsers.
+ *
+ * <p>Only unambiguous paths are supported. Paths must specify a file extension.
+ */
+public class BrowserModuleResolver extends ModuleResolver {
+
+  public BrowserModuleResolver(
+      ImmutableSet<String> modulePaths,
+      ImmutableList<String> moduleRootPaths,
+      ErrorHandler errorHandler) {
+    super(modulePaths, moduleRootPaths, errorHandler);
+  }
+
+  @Nullable
+  public String resolveJsModule(
+      String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
+
+    if (ModuleLoader.isAmbiguousIdentifier(moduleAddress)) {
+      if (errorHandler != null) {
+        errorHandler.report(
+            CheckLevel.WARNING,
+            JSError.make(
+                sourcename,
+                lineno,
+                colno,
+                ModuleLoader.INVALID_MODULE_PATH,
+                moduleAddress,
+                "BROWSER"));
+      }
+      return null;
+    }
+
+    String loadAddress = locate(scriptAddress, moduleAddress);
+    if (loadAddress == null && errorHandler != null) {
+      errorHandler.report(
+          CheckLevel.WARNING,
+          JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));
+    }
+    return loadAddress;
+  }
+}

--- a/src/com/google/javascript/jscomp/deps/BrowserModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/BrowserModuleResolver.java
@@ -57,7 +57,7 @@ public class BrowserModuleResolver extends ModuleResolver {
     }
 
     String loadAddress = locate(scriptAddress, moduleAddress);
-    if (loadAddress == null && errorHandler != null) {
+    if (loadAddress == null) {
       errorHandler.report(
           CheckLevel.WARNING,
           JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));

--- a/src/com/google/javascript/jscomp/deps/LegacyModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/LegacyModuleResolver.java
@@ -48,11 +48,9 @@ public class LegacyModuleResolver extends ModuleResolver {
     String loadAddress = locate(scriptAddress, moduleAddress);
 
     if (loadAddress == null) {
-      if (errorHandler != null) {
-        errorHandler.report(
-            CheckLevel.WARNING,
-            JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));
-      }
+      errorHandler.report(
+          CheckLevel.WARNING,
+          JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));
       return canonicalizePath(scriptAddress, moduleAddress);
     }
     return loadAddress;

--- a/src/com/google/javascript/jscomp/deps/LegacyModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/LegacyModuleResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.ErrorHandler;
+import com.google.javascript.jscomp.JSError;
+import javax.annotation.Nullable;
+
+/**
+ * Resolution algorithm historically used by the compiler.
+ *
+ * <p>Ambiguous paths are assumed to be absolute.
+ */
+public class LegacyModuleResolver extends ModuleResolver {
+
+  public LegacyModuleResolver(
+      ImmutableSet<String> modulePaths,
+      ImmutableList<String> moduleRootPaths,
+      ErrorHandler errorHandler) {
+    super(modulePaths, moduleRootPaths, errorHandler);
+  }
+
+  @Nullable
+  public String resolveJsModule(
+      String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
+    // Allow module names with or without the ".js" extension.
+    if (!moduleAddress.endsWith(".js")) {
+      moduleAddress += ".js";
+    }
+
+    String loadAddress = locate(scriptAddress, moduleAddress);
+
+    if (loadAddress == null) {
+      if (errorHandler != null) {
+        errorHandler.report(
+            CheckLevel.WARNING,
+            JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));
+      }
+      return canonicalizePath(scriptAddress, moduleAddress);
+    }
+    return loadAddress;
+  }
+}

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -24,8 +24,10 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.DiagnosticType;
 import com.google.javascript.jscomp.ErrorHandler;
+import com.google.javascript.jscomp.JSError;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Map;
@@ -56,7 +58,7 @@ public final class ModuleLoader {
       DiagnosticType.warning(
           "JSC_INVALID_MODULE_PATH", "Invalid module path \"{0}\" for resolution mode \"{1}\"");
 
-  @Nullable private final ErrorHandler errorHandler;
+  private final ErrorHandler errorHandler;
 
   /** Root URIs to match module roots against. */
   private final ImmutableList<String> moduleRootPaths;
@@ -84,7 +86,7 @@ public final class ModuleLoader {
     checkNotNull(inputs);
     checkNotNull(pathResolver);
     this.pathResolver = pathResolver;
-    this.errorHandler = errorHandler;
+    this.errorHandler = errorHandler == null ? new NoopErrorHandler() : errorHandler;
     this.moduleRootPaths = createRootPaths(moduleRoots, pathResolver);
     this.modulePaths =
         resolvePaths(
@@ -386,5 +388,9 @@ public final class ModuleLoader {
      * Exact match, then ".js", then ".json" file extensions are searched.
      */
     NODE
+  }
+
+  private final class NoopErrorHandler implements ErrorHandler {
+    public void report(CheckLevel level, JSError error) {}
   }
 }

--- a/src/com/google/javascript/jscomp/deps/ModuleNames.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleNames.java
@@ -69,6 +69,10 @@ public class ModuleNames {
   }
 
   static String toModuleName(String path) {
+    if (path.startsWith(MODULE_SLASH)) {
+      path = path.substring(1);
+    }
+
     return "module$" + toJSIdentifier(path);
   }
 

--- a/src/com/google/javascript/jscomp/deps/ModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleResolver.java
@@ -22,6 +22,9 @@ import com.google.javascript.jscomp.ErrorHandler;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+/**
+ * Base class for algorithms that resolve JavaScript module references to input files.
+ */
 public abstract class ModuleResolver {
   /** The set of all known input module URIs (including trailing .js), after normalization. */
   protected final ImmutableSet<String> modulePaths;

--- a/src/com/google/javascript/jscomp/deps/ModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleResolver.java
@@ -22,9 +22,7 @@ import com.google.javascript.jscomp.ErrorHandler;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-/**
- * Base class for algorithms that resolve JavaScript module references to input files.
- */
+/** Base class for algorithms that resolve JavaScript module references to input files. */
 public abstract class ModuleResolver {
   /** The set of all known input module URIs (including trailing .js), after normalization. */
   protected final ImmutableSet<String> modulePaths;

--- a/src/com/google/javascript/jscomp/deps/ModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleResolver.java
@@ -17,6 +17,7 @@
 package com.google.javascript.jscomp.deps;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.ErrorHandler;
 import java.util.Map;
@@ -42,7 +43,7 @@ public abstract class ModuleResolver {
   }
 
   Map<String, String> getPackageJsonMainEntries() {
-    return null;
+    return ImmutableMap.of();
   }
 
   @Nullable

--- a/src/com/google/javascript/jscomp/deps/ModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleResolver.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.ErrorHandler;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public abstract class ModuleResolver {
+  /** The set of all known input module URIs (including trailing .js), after normalization. */
+  protected final ImmutableSet<String> modulePaths;
+
+  /** Root URIs to match module roots against. */
+  protected final ImmutableList<String> moduleRootPaths;
+
+  protected final ErrorHandler errorHandler;
+
+  public ModuleResolver(
+      ImmutableSet<String> modulePaths,
+      ImmutableList<String> moduleRootPaths,
+      ErrorHandler errorHandler) {
+    this.modulePaths = modulePaths;
+    this.moduleRootPaths = moduleRootPaths;
+    this.errorHandler = errorHandler;
+  }
+
+  Map<String, String> getPackageJsonMainEntries() {
+    return null;
+  }
+
+  @Nullable
+  public String resolveJsModule(
+      String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
+    return null;
+  }
+
+  /**
+   * Locates the module with the given name, but returns null if there is no JS file in the expected
+   * location.
+   */
+  @Nullable
+  protected String locate(String scriptAddress, String name) {
+    String canonicalizedPath = canonicalizePath(scriptAddress, name);
+
+    String normalizedPath = canonicalizedPath;
+    if (ModuleLoader.isAmbiguousIdentifier(canonicalizedPath)) {
+      normalizedPath = ModuleLoader.MODULE_SLASH + canonicalizedPath;
+    }
+
+    // First check to see if the module is known with it's provided path
+    if (modulePaths.contains(normalizedPath)) {
+      return canonicalizedPath;
+    }
+
+    // Check for the module beneath each of the module roots
+    for (String rootPath : moduleRootPaths) {
+      String modulePath = rootPath + normalizedPath;
+
+      // Since there might be code that relying on whether the path has a leading slash or not,
+      // honor the state it was provided in. In an ideal world this would always be normalized
+      // to contain a leading slash.
+      if (modulePaths.contains(modulePath)) {
+        return canonicalizedPath;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Normalizes a module path reference. Includes escaping special characters and converting
+   * relative paths to absolute references.
+   */
+  protected String canonicalizePath(String scriptAddress, String moduleAddress) {
+    String path = ModuleNames.escapePath(moduleAddress);
+    if (ModuleLoader.isRelativeIdentifier(moduleAddress)) {
+      String ourPath = scriptAddress;
+      int lastIndex = ourPath.lastIndexOf(ModuleLoader.MODULE_SLASH);
+      path =
+          ModuleNames.canonicalizePath(
+              ourPath.substring(0, lastIndex + ModuleLoader.MODULE_SLASH.length()) + path);
+    }
+    return path;
+  }
+}

--- a/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.ErrorHandler;
+import com.google.javascript.jscomp.JSError;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
+
+/**
+ * Resolution algorithm for NodeJS. See https://nodejs.org/api/modules.html#modules_all_together
+ *
+ * <p>Unambiguous paths are file paths resolved from the current script. Ambiguous paths are located
+ * within the nearest node_modules folder ancestor.
+ */
+public class NodeModuleResolver extends ModuleResolver {
+  private static final String[] FILE_EXTENSIONS_TO_SEARCH = {"", ".js", ".json"};
+  private static final String[] FILES_TO_SEARCH = {
+    ModuleLoader.MODULE_SLASH + "package.json",
+    ModuleLoader.MODULE_SLASH + "index.js",
+    ModuleLoader.MODULE_SLASH + "index.json"
+  };
+
+  /** Named modules found in node_modules folders */
+  private final ImmutableMap<String, String> packageJsonMainEntries;
+
+  /** Named modules found in node_modules folders */
+  private final ImmutableSortedSet<String> nodeModulesFolders;
+
+  /**
+   * Build a list of node module paths. Given the following path:
+   *
+   * <p>/foo/node_modules/bar/node_modules/baz/foo_bar_baz.js
+   *
+   * <p>Return a set containing:
+   *
+   * <p>/foo/ /foo/node_modules/bar/
+   *
+   * @param modulePaths Set of all module paths where the key is the module path normalized to have
+   *     a leading slash
+   * @return A sorted set with the longest paths first where each entry is the folder containing a
+   *     node_modules sub-folder.
+   */
+  private static ImmutableSortedSet<String> buildNodeModulesFoldersRegistry(
+      Iterable<String> modulePaths) {
+    SortedSet<String> registry =
+        new TreeSet<>(
+            new Comparator<String>() {
+              @Override
+              public int compare(String a, String b) {
+                // Order longest path first
+                int comparison = Integer.compare(b.length(), a.length());
+                if (comparison != 0) {
+                  return comparison;
+                }
+
+                return a.compareTo(b);
+              }
+            });
+
+    // For each modulePath, find all the node_modules folders
+    // There might be more than one:
+    //    /foo/node_modules/bar/node_modules/baz/foo_bar_baz.js
+    // Should add:
+    //   /foo/ -> bar/node_modules/baz/foo_bar_baz.js
+    //   /foo/node_modules/bar/ -> baz/foo_bar_baz.js
+    for (String modulePath : modulePaths) {
+      String[] nodeModulesDirs = modulePath.split("/node_modules/");
+      String parentPath = "";
+
+      for (int i = 0; i < nodeModulesDirs.length - 1; i++) {
+        if (i + 1 < nodeModulesDirs.length) {
+          parentPath += nodeModulesDirs[i] + "/";
+        }
+
+        if (!registry.contains(parentPath)) {
+          registry.add(parentPath);
+        }
+        parentPath += "node_modules/";
+      }
+    }
+
+    return ImmutableSortedSet.copyOfSorted(registry);
+  }
+
+  public NodeModuleResolver(
+      ImmutableSet<String> modulePaths,
+      ImmutableList<String> moduleRootPaths,
+      Map<String, String> packageJsonMainEntries,
+      ErrorHandler errorHandler) {
+    super(modulePaths, moduleRootPaths, errorHandler);
+    this.nodeModulesFolders = buildNodeModulesFoldersRegistry(modulePaths);
+
+    if (packageJsonMainEntries == null) {
+      this.packageJsonMainEntries = ImmutableMap.of();
+    } else {
+      this.packageJsonMainEntries = buildPackageJsonMainEntries(packageJsonMainEntries);
+    }
+  }
+
+  /**
+   * @param packageJsonMainEntries a map with keys that are package.json file paths and values which
+   *     are the "main" entry from the package.json. "main" entries are absolute paths rooted from
+   *     the folder containing the package.json file.
+   */
+  private ImmutableMap<String, String> buildPackageJsonMainEntries(
+      Map<String, String> packageJsonMainEntries) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    for (Map.Entry<String, String> packageJsonMainEntry : packageJsonMainEntries.entrySet()) {
+      String entryKey = packageJsonMainEntry.getKey();
+      if (ModuleLoader.isAmbiguousIdentifier(entryKey)) {
+        entryKey = ModuleLoader.MODULE_SLASH + entryKey;
+      }
+
+      builder.put(entryKey, packageJsonMainEntry.getValue());
+    }
+
+    return builder.build();
+  }
+
+  Map<String, String> getPackageJsonMainEntries() {
+    return this.packageJsonMainEntries;
+  }
+
+  @Nullable
+  public String resolveJsModule(
+      String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
+    String loadAddress;
+    if (ModuleLoader.isAbsoluteIdentifier(moduleAddress)
+        || ModuleLoader.isRelativeIdentifier(moduleAddress)) {
+      loadAddress = resolveJsModuleNodeFileOrDirectory(scriptAddress, moduleAddress);
+    } else {
+      loadAddress = resolveJsModuleFromRegistry(scriptAddress, moduleAddress);
+    }
+
+    if (loadAddress == null && errorHandler != null) {
+      errorHandler.report(
+          CheckLevel.WARNING,
+          JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));
+    }
+    return loadAddress;
+  }
+
+  public String resolveJsModuleFile(String scriptAddress, String moduleAddress) {
+    for (int i = 0; i < FILE_EXTENSIONS_TO_SEARCH.length; i++) {
+      String loadAddress = locate(scriptAddress, moduleAddress + FILE_EXTENSIONS_TO_SEARCH[i]);
+      if (loadAddress != null) {
+        return loadAddress;
+      }
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private String resolveJsModuleNodeFileOrDirectory(String scriptAddress, String moduleAddress) {
+    String loadAddress;
+    loadAddress = resolveJsModuleFile(scriptAddress, moduleAddress);
+    if (loadAddress == null) {
+      loadAddress = resolveJsModuleNodeDirectory(scriptAddress, moduleAddress);
+    }
+    return loadAddress;
+  }
+
+  @Nullable
+  private String resolveJsModuleNodeDirectory(String scriptAddress, String moduleAddress) {
+    if (moduleAddress.endsWith(ModuleLoader.MODULE_SLASH)) {
+      moduleAddress = moduleAddress.substring(0, moduleAddress.length() - 1);
+    }
+
+    // Load as a file
+    for (int i = 0; i < FILES_TO_SEARCH.length; i++) {
+      String loadAddress = locate(scriptAddress, moduleAddress + FILES_TO_SEARCH[i]);
+      if (loadAddress != null) {
+        if (FILES_TO_SEARCH[i].equals(ModuleLoader.MODULE_SLASH + "package.json")) {
+          if (packageJsonMainEntries.containsKey(loadAddress)) {
+            return resolveJsModuleFile(scriptAddress, packageJsonMainEntries.get(loadAddress));
+          }
+        } else {
+          return loadAddress;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private String resolveJsModuleFromRegistry(String scriptAddress, String moduleAddress) {
+    for (String nodeModulesFolder : nodeModulesFolders) {
+      String normalizedScriptAddress =
+          (ModuleLoader.isAmbiguousIdentifier(scriptAddress) ? ModuleLoader.MODULE_SLASH : "")
+              + scriptAddress;
+
+      if (!normalizedScriptAddress.startsWith(nodeModulesFolder)) {
+        continue;
+      }
+
+      // Load as a file
+      String fullModulePath = nodeModulesFolder + "node_modules/" + moduleAddress;
+      String loadAddress = resolveJsModuleFile(scriptAddress, fullModulePath);
+      if (loadAddress == null) {
+        // Load as a directory
+        loadAddress = resolveJsModuleNodeDirectory(scriptAddress, fullModulePath);
+      }
+
+      if (loadAddress != null) {
+        return loadAddress;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
@@ -155,7 +155,7 @@ public class NodeModuleResolver extends ModuleResolver {
       loadAddress = resolveJsModuleFromRegistry(scriptAddress, moduleAddress);
     }
 
-    if (loadAddress == null && errorHandler != null) {
+    if (loadAddress == null) {
       errorHandler.report(
           CheckLevel.WARNING,
           JSError.make(sourcename, lineno, colno, ModuleLoader.LOAD_WARNING, moduleAddress));

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -25,11 +25,18 @@ import com.google.javascript.rhino.Node;
 
 public final class ProcessCommonJSModulesTest extends CompilerTestCase {
 
+  private ImmutableList<String> moduleRoots = null;
+
   @Override
   protected CompilerOptions getOptions() {
     CompilerOptions options = super.getOptions();
     // Trigger module processing after parsing.
     options.setProcessCommonJSModules(true);
+
+    if (moduleRoots != null) {
+      options.setModuleRoots(moduleRoots);
+    }
+
     return options;
   }
 
@@ -780,5 +787,30 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "module$test.y = null;",
             "var x$$module$test;",
             "x$$module$test = module$test.y"));
+  }
+
+  public void testAbsoluteImportsWithModuleRoots() {
+    moduleRoots = ImmutableList.of("/base");
+    test(
+        ImmutableList.of(
+            SourceFile.fromCode(Compiler.joinPathParts("base", "mod", "name.js"), ""),
+            SourceFile.fromCode(
+                Compiler.joinPathParts("base", "test", "sub.js"),
+                LINE_JOINER.join(
+                    "var name = require('/mod/name');", "(function() { module$mod$name(); })();"))),
+        ImmutableList.of(
+            SourceFile.fromCode(
+                Compiler.joinPathParts("base", "mod", "name.js"),
+                LINE_JOINER.join(
+                    "/** @fileoverview",
+                    " * @suppress {missingProvide|missingRequire}",
+                    " */",
+                    "goog.provide('module$mod$name');")),
+            SourceFile.fromCode(
+                Compiler.joinPathParts("base", "test", "sub.js"),
+                LINE_JOINER.join(
+                    "goog.require('module$mod$name');",
+                    "var name = module$mod$name;",
+                    "(function() { module$mod$name(); })();"))));
   }
 }

--- a/test/com/google/javascript/jscomp/deps/JsFileParserTest.java
+++ b/test/com/google/javascript/jscomp/deps/JsFileParserTest.java
@@ -170,12 +170,15 @@ public final class JsFileParserTest extends TestCase {
         + "import '../a/z';\n"
         + "import '../c/w';\n";
 
-    DependencyInfo expected = new SimpleDependencyInfo("../../a/b.js", "/foo/bar/a/b.js",
-        ImmutableList.of("module$$foo$bar$a$b"),
-        ImmutableList.of(
-            "module$$foo$bar$a$x", "module$$foo$bar$y",
-            "module$$foo$bar$a$z", "module$$foo$bar$c$w"),
-        ImmutableMap.of("module", "es6"));
+    DependencyInfo expected =
+        new SimpleDependencyInfo(
+            "../../a/b.js",
+            "/foo/bar/a/b.js",
+            ImmutableList.of("module$foo$bar$a$b"),
+            ImmutableList.of(
+                "module$foo$bar$a$x", "module$foo$bar$y",
+                "module$foo$bar$a$z", "module$foo$bar$c$w"),
+            ImmutableMap.of("module", "es6"));
 
     DependencyInfo result = parser.parseFile("/foo/bar/a/b.js", "../../a/b.js", contents);
 

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -357,9 +357,9 @@ public final class ModuleLoaderTest extends TestCase {
     assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index"));
     assertUri("/A/index.json", loader.resolve("/foo.js").resolveJsModule("/A/index.json"));
 
-    assertUri("node_modules/A/index.js", loader.resolve("/foo.js").resolveJsModule("A"));
+    assertUri("/node_modules/A/index.js", loader.resolve("/foo.js").resolveJsModule("A"));
     assertUri(
-        "node_modules/A/node_modules/A/index.json",
+        "/node_modules/A/node_modules/A/index.json",
         loader.resolve("node_modules/A/foo.js").resolveJsModule("A"));
     assertUri(
         "node_modules/A/foo.js",

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -27,7 +27,7 @@ import junit.framework.TestCase;
 /** Tests for {@link ModuleLoader}. */
 
 public final class ModuleLoaderTest extends TestCase {
-  private ImmutableMap<String, String> packageJsonMainEntries =
+  private final ImmutableMap<String, String> packageJsonMainEntries =
       ImmutableMap.of(
           "/B/package.json", "/B/lib/b",
           "/node_modules/B/package.json", "/node_modules/B/lib/b.js");


### PR DESCRIPTION
The interaction between the `--js_module_root` flag and absolute imports `require('/foo/bar.js')` results in the module loader unable to locate the module. This applies equally to all 3 module resolution modes and both CommonJS and ES6 modules.

Fixing this without breaking existing functionality has proven challenging. I'm hopeful this PR actually accomplishes it.

Given a module root of `base/`, the following modules should properly resolve:

**base/mod1.js**
```js
module.exports = true;
```

**base/app.js**
```js
const mod1 = require('/mod1.js');
```