### PR TITLE
Updated README with more detailed instructions on how to build project using Eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ unit tests too).
 6. In Package Explorer, remove from the build path:
     - `src/com/google/javascript/jscomp/debugger/DebuggerGwtMain.java`
     - `src/com/google/javascript/jscomp/gwt/`
-7. See *Using Maven* above to build the JAR.
+7. [Exclude the files](http://stackoverflow.com/questions/1187868/how-can-i-exclude-some-folders-from-my-eclipse-project) in the directory `src/com/google/debugging/sourcemap/super` from the project.
+8. Build project in Eclipse (right click on the project `closure-compiler-parent` and select `Build Project`).
+9. See *Using Maven* above to build the JAR.
 
 ## Running
 


### PR DESCRIPTION
This is related to issue #2028. We have experienced the same issues as @hoyt85, where the files in `src/com/google/debugging/sourcemap/super/` contains errors in Eclipse after importing the project, which results in us being unable to build and run the project. My update to the README build instructions will make sure to avoid this issue. This solution has been tested and verified by me and @lbercken, but I suggest you give it a try as well if you have the time.

This PR goes well together with my previous PR (#2351).