### PR TITLE
README run instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ java -jar compiler.jar --help
 More detailed information about running the Closure Compiler is available in the
 [documentation](http://code.google.com/closure/compiler/docs/gettingstarted_app.html).
 
+
+###Run using Eclipse
+
+1. Open the class `src/com/google/javascript/jscomp/CommandLineRunner.java` or create your own extended version of the class.
+2. Run the class in Eclipse.
+3. See the instructions above on how to use the interactive mode - but beware of the [bug](http://stackoverflow.com/questions/4711098/passing-end-of-transmission-ctrl-d-character-in-eclipse-cdt-console) regarding passing "End of Transmission" in the Eclipse console.
+
+
 ## Compiling Multiple Scripts
 
 If you have multiple scripts, you should compile them all together with one


### PR DESCRIPTION
Running the Closure Compiler from inside of Eclipse is a bit of a struggle, thanks to the bug in eclipse [described here](http://stackoverflow.com/questions/4711098/passing-end-of-transmission-ctrl-d-character-in-eclipse-cdt-console). Since the README instructions contains information about how to build the project using Eclipse, I find it appropriate that these extra instructions on how to run the project using Eclipse are included in the README as well. This has been tested and verified by me and @lbercken, but I suggest you try it out as well if you have the time.

This PR goes well together with my two previous PRs (#2351 and #2352).