### PR TITLE
Conditional operator: when the condition and first expression are the same, OR could be used instead

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java
+++ b/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java
@@ -1148,6 +1148,7 @@ class PeepholeMinimizeConditions
    *   x && true        --> x
    *   x ? false : true --> !x
    *   x ? true : y     --> x || y
+   *   x ? x : y        --> x || y
    *
    *   Returns the replacement for n, or the original if no change was made
    */
@@ -1222,11 +1223,14 @@ class PeepholeMinimizeConditions
         trueNode = performConditionSubstitutions(trueNode);
         falseNode = performConditionSubstitutions(falseNode);
 
-        // Handle four cases:
+        // Handle five cases:
         //   x ? true : false --> x
         //   x ? false : true --> !x
         //   x ? true : y     --> x || y
         //   x ? y : false    --> x && y
+        
+        //   Only when x is NAME, hence x does not have side effects
+        //   x ? x : y        --> x || y
         Node replacement = null;
         TernaryValue trueNodeVal = NodeUtil.getPureBooleanValue(trueNode);
         TernaryValue falseNodeVal = NodeUtil.getPureBooleanValue(falseNode);
@@ -1248,6 +1252,12 @@ class PeepholeMinimizeConditions
           // Remove useless false case
           n.detachChildren();
           replacement = IR.and(condition, trueNode);
+        } else if (condition.isName()
+            && trueNode.isName()
+            && condition.isEquivalentTo(trueNode)) {
+          // Remove redundant condition  
+          n.detachChildren();
+          replacement = IR.or(trueNode, falseNode);
         }
 
         if (replacement != null) {

--- a/test/com/google/javascript/jscomp/PeepholeMinimizeConditionsTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeMinimizeConditionsTest.java
@@ -337,6 +337,12 @@ public final class PeepholeMinimizeConditionsTest extends CompilerTestCase {
   }
 
   public void testMinimizeHook() {
+    fold("x ? x : y",
+	 "x || y");
+    // These two cases cannot be folded, because of possible side effects
+    foldSame("x() ? x() : y()");
+    foldSame("x.y ? x.y : x.z");
+    
     fold("!x ? foo() : bar()",
          "x ? bar() : foo()");
     fold("while(!(x ? y : z)) foo();",


### PR DESCRIPTION
This should (partially) fix https://github.com/google/closure-compiler/issues/180.

When using the ? operator the following can be transformed:

```x ? x : y```

to a shorter equivalent:

```x || y```.

I added a Unit test to verify that the change works. However the transformation only works for conditionals now, e.g. in an `if` statement. It does not work for example in an `assignment` statement yet.
