### PR TITLE
Add Object to isUnextendableNativeClass

### DIFF
--- a/src/com/google/javascript/jscomp/Es6ConvertSuperConstructorCalls.java
+++ b/src/com/google/javascript/jscomp/Es6ConvertSuperConstructorCalls.java
@@ -380,6 +380,7 @@ implements NodeTraversal.Callback, HotSwapCompilerPass {
       case "InternalError":
       case "Map":
       case "Number":
+      case "Object":
       case "Promise":
       case "Proxy":
       case "RegExp":


### PR DESCRIPTION
Spent a good amount of time spinning my wheels trying `class Foo extends Object { }` and not getting the desired results until I noticed other built-ins like `Array` have an error when trying to extend.

I don't see any reason `Object` shouldn't be included in the list of unextendable native classes, so I've added it to prevent anyone else from spinning their wheels.