### PR TITLE
Fixed broken header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ More detailed information about running the Closure Compiler is available in the
 [documentation](http://code.google.com/closure/compiler/docs/gettingstarted_app.html).
 
 
-###Run using Eclipse
+### Run using Eclipse
 
 1. Open the class `src/com/google/javascript/jscomp/CommandLineRunner.java` or create your own extended version of the class.
 2. Run the class in Eclipse.


### PR DESCRIPTION
Today, we experienced for the first time that headers with `#Title` notation no longer works on Github. Instead `# Title` notation should be used. This PR fixes the only occurrence of this invalid header notation (an occurrence I created.. ).

Github is very inconsistent when it comes to if spaces are required in the header. If you go to:

https://github.com/google/closure-compiler#run-using-eclipse

The header works. If you go to:

https://github.com/google/closure-compiler/blob/master/README.md#run-using-eclipse

It also works. But if you go to:

https://github.com/delftswa2017/closure-compiler/blob/master/README.md#run-using-eclipse

It does not work. 😁 

So even if this is a temporary bug on Github, or if `#Title` notation is no longer supported, I suggest that this change should be merged to achieve consistency in the README.