### PR TITLE
Add missing jsonpCallbackParam option in angular externs

### DIFF
--- a/contrib/externs/angular-1.6.js
+++ b/contrib/externs/angular-1.6.js
@@ -1565,6 +1565,9 @@ angular.$http.Config.prototype.data
 angular.$http.Config.prototype.headers;
 
 /** @type {(string|undefined)} */
+angular.$http.Config.prototype.jsonpCallbackParam;
+
+/** @type {(string|undefined)} */
 angular.$http.Config.prototype.method;
 
 /** @type {(?Object<(boolean|number|string|Object)>|undefined)} */


### PR DESCRIPTION
This option was added in version 1.6, see:
  https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$http