### PR TITLE
[WIP] Provide correct location info for getprop, getelem and call invocations

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/parser/Parser.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Parser.java
@@ -2824,7 +2824,7 @@ public class Parser {
 
     if (isStartOfAsyncArrowFunction(left)) {
       // re-evaluate as an async arrow function.
-      resetScanner(left);
+      resetScanner(start);
       return parseAsyncArrowFunction(expressionIn);
     }
     if (peek(TokenType.ARROW)) {
@@ -3016,12 +3016,16 @@ public class Parser {
     return parsePattern(PatternKind.ANY);
   }
 
+  private void resetScanner(SourcePosition pos) {
+    lastSourcePosition = pos;
+    scanner.setOffset(lastSourcePosition.offset);
+  }
+
   private void resetScanner(ParseTree tree) {
     // TODO(bradfordcsmith): lastSourcePosition should really point to the end of the last token
     //     before the tree to correctly detect implicit semicolons, but it doesn't matter for the
     //     current use case.
-    lastSourcePosition = tree.location.start;
-    scanner.setOffset(lastSourcePosition.offset);
+    resetScanner(tree.location.start);
   }
 
   private void resetScannerAfter(ParseTree parseTree) {
@@ -3381,6 +3385,7 @@ public class Parser {
 
       // The Call expression productions
       while (peekCallSuffix()) {
+        start = getTreeStartLocation();
         switch (peekType()) {
           case OPEN_PAREN:
             ArgumentListTree arguments = parseArguments();

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1891,7 +1891,7 @@ public final class CommandLineRunnerTest extends TestCase {
     assertThat(output).isEqualTo("[{\"src\":\"alert(\\\"foo\\\");\\n\","
         + "\"path\":\"compiled.js\",\"source_map\":\"{\\n\\\"version\\\":3,"
         + "\\n\\\"file\\\":\\\"compiled.js\\\",\\n\\\"lineCount\\\":1,"
-        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAA,CAAM,KAAN;\\\","
+        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAK,CAAC,KAAD;\\\","
         + "\\n\\\"sources\\\":[\\\"stdin\\\"],"
         + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
   }
@@ -1919,7 +1919,7 @@ public final class CommandLineRunnerTest extends TestCase {
     assertThat(output).isEqualTo("[{\"src\":\"alert(\\\"foo\\\");\\n\","
         + "\"path\":\"bar.js\",\"source_map\":\"{\\n\\\"version\\\":3,"
         + "\\n\\\"file\\\":\\\"bar.js\\\",\\n\\\"lineCount\\\":1,"
-        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAA,CAAM,KAAN;\\\","
+        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAK,CAAC,KAAD;\\\","
         + "\\n\\\"sources\\\":[\\\"foo.js\\\"],"
         + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
   }
@@ -1997,7 +1997,7 @@ public final class CommandLineRunnerTest extends TestCase {
     assertThat(output).isEqualTo("[{\"src\":\"alert(\\\"foo\\\");\\n\","
         + "\"path\":\"./foo--bar.baz.js\",\"source_map\":\"{\\n\\\"version\\\":3,"
         + "\\n\\\"file\\\":\\\"./foo--bar.baz.js\\\",\\n\\\"lineCount\\\":1,"
-        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAA,CAAM,KAAN;\\\","
+        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAK,CAAC,KAAD;\\\","
         + "\\n\\\"sources\\\":[\\\"foo.js\\\"],"
         + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
   }

--- a/test/com/google/javascript/jscomp/ScopedAliasesTest.java
+++ b/test/com/google/javascript/jscomp/ScopedAliasesTest.java
@@ -1081,7 +1081,7 @@ public final class ScopedAliasesTest extends CompilerTestCase {
     assertThat(spy.observedPositions).containsKey("testcode");
     List<SourcePosition<AliasTransformation>> positions = spy.observedPositions.get("testcode");
     assertThat(positions).hasSize(1);
-    verifyAliasTransformationPosition(1, 0, 2, 1, positions.get(0));
+    verifyAliasTransformationPosition(1, 10, 2, 1, positions.get(0));
 
     assertThat(spy.constructedAliases).hasSize(1);
     AliasSpy aliasSpy = (AliasSpy) spy.constructedAliases.get(0);
@@ -1101,7 +1101,7 @@ public final class ScopedAliasesTest extends CompilerTestCase {
     assertThat(spy.observedPositions).containsKey("testcode");
     List<SourcePosition<AliasTransformation>> positions = spy.observedPositions.get("testcode");
     assertThat(positions).hasSize(1);
-    verifyAliasTransformationPosition(1, 0, 2, 1, positions.get(0));
+    verifyAliasTransformationPosition(1, 10, 2, 1, positions.get(0));
 
     assertThat(spy.constructedAliases).hasSize(1);
     AliasSpy aliasSpy = (AliasSpy) spy.constructedAliases.get(0);
@@ -1122,7 +1122,7 @@ public final class ScopedAliasesTest extends CompilerTestCase {
     assertThat(spy.observedPositions).containsKey("testcode");
     List<SourcePosition<AliasTransformation>> positions = spy.observedPositions.get("testcode");
     assertThat(positions).hasSize(1);
-    verifyAliasTransformationPosition(1, 0, 3, 1, positions.get(0));
+    verifyAliasTransformationPosition(1, 10, 3, 1, positions.get(0));
 
     assertThat(spy.constructedAliases).hasSize(1);
     AliasSpy aliasSpy = (AliasSpy) spy.constructedAliases.get(0);
@@ -1152,9 +1152,9 @@ public final class ScopedAliasesTest extends CompilerTestCase {
     List<SourcePosition<AliasTransformation>> positions = spy.observedPositions.get("testcode");
     assertThat(positions).hasSize(2);
 
-    verifyAliasTransformationPosition(1, 0, 6, 0, positions.get(0));
+    verifyAliasTransformationPosition(1, 10, 6, 0, positions.get(0));
 
-    verifyAliasTransformationPosition(8, 0, 11, 4, positions.get(1));
+    verifyAliasTransformationPosition(8, 10, 11, 4, positions.get(1));
 
     assertThat(spy.constructedAliases).hasSize(2);
     AliasSpy aliasSpy = (AliasSpy) spy.constructedAliases.get(0);

--- a/test/com/google/javascript/jscomp/SourceMapTest.java
+++ b/test/com/google/javascript/jscomp/SourceMapTest.java
@@ -45,7 +45,7 @@ public final class SourceMapTest extends SourceMapTestCase {
         "\"version\":3,\n" +
         "\"file\":\"testcode\",\n" +
         "\"lineCount\":1,\n" +
-        "\"mappings\":\"AAAAA,KAAA,CAAM,CAAN,C,CCAAA,KAAA,CAAM,CAAN;\",\n" +
+        "\"mappings\":\"AAAAA,KAAK,CAAC,CAAD,C,CCALA,KAAK,CAAC,CAAD;\",\n" +
         "\"sources\":[\"file1\",\"file2\"],\n" +
         "\"names\":[\"alert\"]\n" +
         "}\n");
@@ -60,7 +60,7 @@ public final class SourceMapTest extends SourceMapTestCase {
         "\"version\":3,\n" +
         "\"file\":\"testcode\",\n" +
         "\"lineCount\":1,\n" +
-        "\"mappings\":\"AAAAA,KAAA,CAAM,CAAN,C,CCAAA,KAAA,CAAM,CAAN;\",\n" +
+        "\"mappings\":\"AAAAA,KAAK,CAAC,CAAD,C,CCALA,KAAK,CAAC,CAAD;\",\n" +
         "\"sources\":[\"src1\",\"src2\"],\n" +
         "\"names\":[\"alert\"]\n" +
         "}\n");
@@ -74,7 +74,7 @@ public final class SourceMapTest extends SourceMapTestCase {
         "\"version\":3,\n" +
         "\"file\":\"testcode\",\n" +
         "\"lineCount\":1,\n" +
-        "\"mappings\":\"AAAAA,KAAA,CAAM,CAAN,C,CCAAA,KAAA,CAAM,CAAN;\",\n" +
+        "\"mappings\":\"AAAAA,KAAK,CAAC,CAAD,C,CCALA,KAAK,CAAC,CAAD;\",\n" +
         "\"sources\":[\"x\",\"y\"],\n" +
         "\"names\":[\"alert\"]\n" +
         "}\n");
@@ -88,7 +88,7 @@ public final class SourceMapTest extends SourceMapTestCase {
         "\"version\":3,\n" +
         "\"file\":\"testcode\",\n" +
         "\"lineCount\":1,\n" +
-        "\"mappings\":\"AAAAA,KAAA,CAAM,CAAN,C,CCAAA,KAAA,CAAM,CAAN;\",\n" +
+        "\"mappings\":\"AAAAA,KAAK,CAAC,CAAD,C,CCALA,KAAK,CAAC,CAAD;\",\n" +
         "\"sources\":[\"x\",\"y2\"],\n" +
         "\"names\":[\"alert\"]\n" +
         "}\n");

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -303,6 +303,14 @@ public final class ParserTest extends BaseJSTypeTestCase {
 
     assertNode(call).hasType(Token.CALL);
     assertNode(call).hasLineno(2);
+    assertNode(call).hasCharno(4);
+  }
+
+  public void testLinenoCharnoCall2() throws Exception {
+    Node call = parse("(function(){})\n ();").getFirstFirstChild();
+
+    assertNode(call).hasType(Token.CALL);
+    assertNode(call).hasLineno(2);
     assertNode(call).hasCharno(1);
   }
 
@@ -345,7 +353,7 @@ public final class ParserTest extends BaseJSTypeTestCase {
 
     assertNode(call).hasType(Token.GETELEM);
     assertNode(call).hasLineno(3);
-    assertNode(call).hasCharno(1);
+    assertNode(call).hasCharno(6);
   }
 
   public void testLinenoCharnoGetelem3() throws Exception {


### PR DESCRIPTION
Currently, location information for some expressions is in the wrong place:

**Before change**
```js
console.log('foo');
^
```
The location information for both the `.` and the `(` symbols is the start of the line.

**After change**
Correct location info
```js
console.log('foo');
       ^   ^
```

Because of this we can't provide suspicious code checks for missing semicolons between function calls and source mappings don't match other tools.

There are several broken tests. In particular, I have yet to determine why the ProcessCommonJS test failure is even related to this change.