### PR TITLE
Fixed and clarified the Blink-specific performance.memory situation

### DIFF
--- a/externs/browser/w3c_navigation_timing.js
+++ b/externs/browser/w3c_navigation_timing.js
@@ -94,13 +94,6 @@ function PerformanceNavigation() {}
 /** @type {number} */ PerformanceNavigation.prototype.type;
 /** @type {number} */ PerformanceNavigation.prototype.redirectCount;
 
-// Only available in WebKit, and only with the --enable-memory-info flag.
-/** @constructor */
-function PerformanceMemory() {}
-/** @type {number} */ PerformanceMemory.prototype.jsHeapSizeLimit;
-/** @type {number} */ PerformanceMemory.prototype.totalJSHeapSize;
-/** @type {number} */ PerformanceMemory.prototype.usedJSHeapSize;
-
 /** @constructor */
 function Performance() {}
 /** @type {PerformanceTiming} */ Performance.prototype.timing;
@@ -153,8 +146,9 @@ Performance.prototype.getEntriesByType = function(entryType) {};
  */
 Performance.prototype.getEntriesByName = function(name, opt_entryType) {};
 
-// Only available in WebKit, and only with the --enable-memory-info flag.
-/** @type {PerformanceMemory} */ Performance.prototype.memory;
+// Nonstandard. Only available in Blink.
+// Returns more granular results with the --enable-memory-info flag.
+/** @type {MemoryInfo} */ Performance.prototype.memory;
 
 /**
  * @return {number}

--- a/externs/browser/webkit_dom.js
+++ b/externs/browser/webkit_dom.js
@@ -32,8 +32,7 @@ Element.prototype.scrollIntoViewIfNeeded = function(opt_center) {};
 
 /**
  * @constructor
- * @see http://trac.webkit.org/browser/trunk/Source/WebCore/page/MemoryInfo.idl
- * @see http://trac.webkit.org/browser/trunk/Source/WebCore/page/MemoryInfo.cpp
+ * @see https://cs.chromium.org/search/?q=%22interface+MemoryInfo%22+file:idl+file:WebKit+package:chromium&type=cs
  */
 function MemoryInfo() {};
 


### PR DESCRIPTION
Hopefully, this can be deprecated soon.

See https://bugs.chromium.org/p/chromium/issues/detail?id=709008 for some context.