### PR TITLE
Adds the PolymerElement.prototype.create method to externs

### DIFF
--- a/contrib/externs/polymer-1.0.js
+++ b/contrib/externs/polymer-1.0.js
@@ -646,6 +646,14 @@ PolymerElement.prototype.updateStyles = function(properties) {};
 PolymerElement.prototype.customStyle;
 
 /**
+ * Convenience method for creating an element and configuring it.
+ * @param {string} tagName HTML tag name
+ * @param {IObject<string, *>=} properties Object of properties to configure on the instance
+ * @return {!Element}
+ */
+PolymerElement.prototype.create = function(tagName, properties) {};
+
+/**
  * Returns the computed style value for the given property.
  * @param {string} property
  * @return {string} the computed value


### PR DESCRIPTION
 https://www.polymer-project.org/1.0/docs/api/Polymer.Base#method-create

Otherwise, compiling this.create() in a PolymerElement results in 'Property create never defined on WhateverElement', despite working at run-time