### PR TITLE
Update the default language levels

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -584,9 +584,9 @@ public class CommandLineRunner extends
           "Sets what language spec that input sources conform. "
               + "Options: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT, "
               + "ECMASCRIPT6_TYPED (experimental), ECMASCRIPT_2015, ECMASCRIPT_2016, "
-              + "ECMASCRIPT_NEXT"
+              + "ECMASCRIPT_2017, ECMASCRIPT_NEXT"
     )
-    private String languageIn = "ECMASCRIPT_NEXT";
+    private String languageIn = "ECMASCRIPT_2017";
 
     @Option(
       name = "--language_out",
@@ -594,7 +594,7 @@ public class CommandLineRunner extends
           "Sets what language spec the output should conform to. "
               + "Options: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT, "
               + "ECMASCRIPT6_TYPED (experimental), ECMASCRIPT_2015, ECMASCRIPT_2016, "
-              + "ECMASCRIPT_NEXT"
+              + "ECMASCRIPT_2017, ECMASCRIPT_NEXT"
     )
     private String languageOut = "ECMASCRIPT5";
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -583,15 +583,20 @@ public class CommandLineRunner extends
       usage =
           "Sets what language spec that input sources conform. "
               + "Options: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT, "
-              + "ECMASCRIPT6 (default), ECMASCRIPT6_STRICT, ECMASCRIPT6_TYPED (experimental)"
+              + "ECMASCRIPT6_TYPED (experimental), ECMASCRIPT_2015, ECMASCRIPT_2016, "
+              + "ECMASCRIPT_NEXT"
     )
-    private String languageIn = "ECMASCRIPT6";
+    private String languageIn = "ECMASCRIPT_NEXT";
 
-    @Option(name = "--language_out",
-        usage = "Sets what language spec the output should conform to. "
-        + "Options: ECMASCRIPT3 (default), ECMASCRIPT5, ECMASCRIPT5_STRICT, "
-        + "ECMASCRIPT6_TYPED (experimental)")
-    private String languageOut = "ECMASCRIPT3";
+    @Option(
+      name = "--language_out",
+      usage =
+          "Sets what language spec the output should conform to. "
+              + "Options: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT, "
+              + "ECMASCRIPT6_TYPED (experimental), ECMASCRIPT_2015, ECMASCRIPT_2016, "
+              + "ECMASCRIPT_NEXT"
+    )
+    private String languageOut = "ECMASCRIPT5";
 
     @Option(name = "--version",
         handler = BooleanOptionHandler.class,
@@ -800,6 +805,7 @@ public class CommandLineRunner extends
                     "jscomp_off",
                     "jscomp_warning",
                     "new_type_inf",
+                    "strict_mode_input",
                     "warnings_whitelist_file"))
             .putAll(
                 "Output",

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -2493,6 +2493,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       case ECMASCRIPT_2016:
         return Config.LanguageMode.ECMASCRIPT7;
       case ECMASCRIPT8:
+      case ECMASCRIPT_2017:
       case ECMASCRIPT_NEXT:
         return Config.LanguageMode.ECMASCRIPT8;
       default:

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -3009,13 +3009,14 @@ public class CompilerOptions implements Serializable {
      */
     ECMASCRIPT_2016,
 
-    /** @deprecated Use {@code ECMASCRIPT_NEXT} */
+    /** @deprecated Use {@code ECMASCRIPT_2017} */
     @Deprecated
     ECMASCRIPT8,
 
-    /**
-     * ECMAScript latest draft standard.
-     */
+    /** ECMAScript standard approved in 2017. Adds async/await. */
+    ECMASCRIPT_2017,
+
+    /** ECMAScript latest draft standard. */
     ECMASCRIPT_NEXT,
 
     /**

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -528,6 +528,7 @@ public final class CommandLineRunnerTest extends TestCase {
   public void testIssue115() {
     args.add("--compilation_level=SIMPLE_OPTIMIZATIONS");
     args.add("--jscomp_off=es5Strict");
+    args.add("--strict_mode_input=false");
     args.add("--warning_level=VERBOSE");
     test("function f() { " +
          "  var arguments = Array.prototype.slice.call(arguments, 0);" +
@@ -1490,6 +1491,7 @@ public final class CommandLineRunnerTest extends TestCase {
 
   public void testES3() {
     args.add("--language_in=ECMASCRIPT3");
+    args.add("--language_out=ECMASCRIPT3");
     useStringComparison = true;
     test(
         "var x = f.function",
@@ -1544,6 +1546,7 @@ public final class CommandLineRunnerTest extends TestCase {
 
   public void testWithKeywordWithEs5ChecksOff() {
     args.add("--jscomp_off=es5Strict");
+    args.add("--strict_mode_input=false");
     testSame("var x = {}; with (x) {}");
   }
 


### PR DESCRIPTION
It's becoming increasingly common for modern apps to target no less than IE 11. This updates the command line runner to reflect that reality. Input language default is set to `ECMASCRIPT_NEXT` and the default output language is set to `ECMASCRIPT5`.