### PR TITLE
Let stamp() take an optional model param

### DIFF
--- a/contrib/externs/polymer-1.0.js
+++ b/contrib/externs/polymer-1.0.js
@@ -1087,7 +1087,7 @@ Polymer.Templatizer = {
   ctor: function() {},
 
   /**
-   * @param {?Object} model
+   * @param {?Object=} model
    * @return {?Element}
    */
   stamp: function(model) {},


### PR DESCRIPTION
this.stamp() actually takes an optional param, e.g., https://github.com/Polymer/polymer/blob/07786b8612d8b0602cc63bab9098843e27a94cb1/lib/legacy/templatizer-behavior.html#L109

Optionally, we could make this {Object=} as well.