### PR TITLE
Re-add externs for the Pointer Lock API

### DIFF
--- a/externs/browser/w3c_pointerlock.js
+++ b/externs/browser/w3c_pointerlock.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's Pointer Lock API.
+ * @see https://w3c.github.io/pointerlock/
+ *
+ * @externs
+ */
+
+
+/**
+ * @see https://w3c.github.io/pointerlock/#widl-Element-requestPointerLock-void
+ * @return {void}
+ */
+Element.prototype.requestPointerLock = function() {};
+
+/**
+ * @see https://w3c.github.io/pointerlock/#widl-Document-pointerLockElement
+ * @type {?Element}
+ */
+Document.prototype.pointerLockElement;
+
+/**
+ * @see https://w3c.github.io/pointerlock/#widl-Document-exitPointerLock-void
+ * @return {void}
+ */
+Document.prototype.exitPointerLock = function() {};
+
+/**
+ * @see https://w3c.github.io/pointerlock/#widl-MouseEvent-movementX
+ * @type {number}
+ */
+MouseEvent.prototype.movementX;
+
+/**
+ * @see https://w3c.github.io/pointerlock/#widl-MouseEvent-movementY
+ * @type {number}
+ */
+MouseEvent.prototype.movementY;


### PR DESCRIPTION
Originally https://github.com/google/closure-compiler/commit/8ae20da89ef2de361e670a4116d409fbfd109707, merged in https://github.com/google/closure-compiler/pull/1085 and erroneously deleted in https://github.com/google/closure-compiler/commit/fc0125c7ef146576d0ee2b6d11ba47d33224e1e5