### PR TITLE
Change Symbol polyfill to adhere to ECMAScript 2015 specification

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/symbol.js
+++ b/src/com/google/javascript/jscomp/js/es6/symbol.js
@@ -46,8 +46,30 @@ $jscomp.symbolCounter_ = 0;
  * @suppress {reportUnknownTypes}
  */
 $jscomp.Symbol = function(opt_description) {
-  return /** @type {symbol} */ (
-      $jscomp.SYMBOL_PREFIX + (opt_description || '') + ($jscomp.symbolCounter_++));
+  // List of ECMAScript 2015 "Well-known Symbols"
+  // See Table 1 in https://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols
+  /** @const @dict @type {!Object<string, string>} */
+  var WELL_KNOWN_SYMBOLS = {
+    'hasInstance': '@@hasInstance',
+    'isConcatSpreadable': '@@isConcatSpreadable',
+    'iterator': '@@iterator',
+    'match': '@@match',
+    'replace': '@@replace',
+    'search': '@@search',
+    'species': '@@species',
+    'split': '@@split',
+    'toPrimitive': '@@toPrimitive',
+    'toStringTag': '@@toStringTag',
+    'unscopables': '@@unscopables',
+  };
+
+  var description = opt_description || '';
+  var symbolName = $jscomp.SYMBOL_PREFIX + description + ($jscomp.symbolCounter_++);
+  if (WELL_KNOWN_SYMBOLS.hasOwnProperty(description)) {
+    symbolName = WELL_KNOWN_SYMBOLS[description];
+  }
+
+  return /** @type {symbol} */(symbolName);
 };
 
 


### PR DESCRIPTION
This PR changes the `Symbol` polyfill to use the ECMAScript 2015 specification string values for "Well-known Symbols" so that Closure-produced polyfills play nicely with vendor code on browsers that do not have a native `Symbol` implementation.

When browsers do not have a `Symbol` implementation, such as on IE, Closure uses its own `Symbol` polyfill by generating a randomish string for all asked-for symbols. This polyfill does not adhere to the ECMAScript 2015 specification where the [table of Well-known Symbols](https://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols) have specific values. Other third-party libraries which work with and without a `Symbol` implementation do the correct thing and fall back to these specific string values.

Since Closure currently does not adhere to the specification, Closure-produced polyfills *do not* work with vendor code that sets the `@@iterator` property when `Symbol.iterator` does not exist.

Here's an example to demonstrate.

Consider the following example `vendor.js`:
```javascript
(function(context) {
  'use strict';

  var HAS_SYMBOL_ITERATOR = typeof Symbol === 'function' && !!Symbol.iterator;
  var ITERATOR_SYMBOL = HAS_SYMBOL_ITERATOR ? Symbol.iterator : '@@iterator';

  // Define some class which attempts to implement the ES6 iterator protocol.
  var OlympicColoursCollection = function() {
    this._items = ['blue', 'yellow', 'black', 'green', 'red', 'white'];
  };

  OlympicColoursCollection.prototype[ITERATOR_SYMBOL] = function() {
    var collection = this;
    return {
      _index: 0,
      next: function() {
        if (this._index === collection._items.length) {
          return {done: true};
        }
        else {
          var value = collection._items[this._index++];
          return {value: value, done: false};
        }
      },
    };
  };

  // Export the class.
  context['OlympicColoursCollection'] = OlympicColoursCollection;
}(this));
```

with `vendor.extern.js`:
```javascript
/**
 * @constructor
 * @implements {Iterable<string>}
 **/
var OlympicColoursCollection = function() { };
```

and with `code.es6`:
```javascript
const container = new OlympicColoursCollection();

const log = [];
let count = 0;
for (const item of container) {
  log.push(`item = ${item}`);
  ++count;
}
log.push(`count = ${count}`);

document.getElementById('log').value = log.join('\n');
```

and `test.html`:
```html
<!doctype html>
<html lang="en">
  <head>
    <title>Iterator test</title>
  </head>
  <body>
    <textarea id="log" cols="100" rows="20"></textarea>
    <script type="text/javascript" src="vendor.js"></script>
    <script type="text/javascript" src="code.js"></script>
  </body>
</html>
```

I use Closure to transpile `code.es6` into strict ES5 code:
```bash
java -jar closure-without-patch.jar \
  --compilation_level ADVANCED \
  --externs vendor.extern.js \
  --js code.es6 \
  --js_output_file code.js \
  --language_in ECMASCRIPT_2017 \
  --language_out ECMASCRIPT5_STRICT \
  --rewrite_polyfills true \
  --warning_level VERBOSE \
  --isolation_mode IIFE \
  --charset UTF-8
```

When running on a browser with a native `Symbol` implementation, such as up to date Chrome, this works as expected:
<img width="648" alt="screen shot 2017-05-13 at 10 55 30" src="https://cloud.githubusercontent.com/assets/812019/26021307/25a834a0-37ce-11e7-8f0b-463211a41fe6.png">

When running on IE11 however, where there is no native `Symbol` implementation, the Closure-transpiled code *does not* work with the vendor code:
<img width="1466" alt="screen shot 2017-05-13 at 10 55 53" src="https://cloud.githubusercontent.com/assets/812019/26021313/337b8104-37ce-11e7-8274-a5f7ba666b1c.png">

The reason it does not work is because the string value for `Symbol.iterator` produced by the Closure polyfill for `Symbol` is `jscomp_symbol_iterator0` instead of the well-defined value `@@iterator`.

When using Closure built with the patch provided by this PR, the resulting Closure transpiled code runs as expected against the vendor code with both a native `Symbol` implementation and a Closure-polyfilled `Symbol` implementation:
<img width="1466" alt="screen shot 2017-05-13 at 11 02 39" src="https://cloud.githubusercontent.com/assets/812019/26021332/71632468-37ce-11e7-9c71-65bfc26bd5b4.png">
