### PR TITLE
Fix NPE in ProcessCommonJSModules

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -1061,7 +1061,11 @@ public final class ProcessCommonJSModules implements CompilerPass {
               Node assign = IR.assign(getProp, nameRef.getFirstChild().detachFromParent());
               assign.setJSDocInfo(info);
               Node expr = IR.exprResult(assign).useSourceInfoIfMissingFromForTree(nameRef);
-              parent.replaceWith(expr);
+              if (parent.getParent() != null) {
+                  parent.replaceWith(expr);
+              } else {
+                  t.getScope().getRootNode().addChildToBack(expr);
+              }
             } else {
               getProp.setJSDocInfo(info);
               parent.replaceWith(IR.exprResult(getProp).useSourceInfoFrom(getProp));

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -829,4 +829,20 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
                     "var name = module$mod$name;",
                     "(function() { module$mod$name(); })();"))));
   }
+
+  public void testIssue2450() {
+    setFilename("test");
+    testModules(
+        LINE_JOINER.join(
+            "var x = 1, y = 2;",
+            "module.exports = {",
+            "a: x,",
+            "b: y,",
+            "};"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "/** @const */ var module$test = {};",
+            "module$test.a = 1;",
+            "module$test.b = 2;"));
+  }
 }


### PR DESCRIPTION
This fixes #2450 

When exporting vars declared in a multi-var statement (e.g `var x = 1, y = 2`) the compiler would crash when refactoring  the `VAR` node and using the refactored first `NAME` node to replace the whole `VAR` node, prompting an NPE when it tried to replace the `VAR` node again with the refactored second `NAME` node.

This works around the crash by appending the refactored expression to the root node if there's no parent to replace.

If this is acceptable, I'd be happy to squash the commits in the PR.