### PR TITLE
Ensure that dependency pruning doesn't remove modules which were force rewritten as ES6

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1825,7 +1825,9 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
         }
 
         if (options.needsTranspilationFrom(FeatureSet.ES6_MODULES)) {
-          processEs6Modules();
+          List<CompilerInput> parsedInputs = parsePotentialModules(inputs);
+          parsedInputs.addAll(inputsToRewrite.values());
+          processEs6Modules(parsedInputs);
         }
       } else {
         // Use an empty module loader if we're not actually dealing with modules.

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1831,7 +1831,8 @@ public final class CommandLineRunnerTest extends TestCase {
   }
 
   public void testES6ImportOfFileWithoutImportsOrExports() {
-    args.add("--dependency_mode=NONE");
+    args.add("--dependency_mode=STRICT");
+    args.add("--entry_point='./app.js'");
     args.add("--language_in=ECMASCRIPT6");
     setFilename(0, "foo.js");
     setFilename(1, "app.js");
@@ -1851,7 +1852,8 @@ public final class CommandLineRunnerTest extends TestCase {
 
   public void testCommonJSRequireOfFileWithoutExports() {
     args.add("--process_common_js_modules");
-    args.add("--dependency_mode=NONE");
+    args.add("--dependency_mode=STRICT");
+    args.add("--entry_point='./app.js'");
     args.add("--language_in=ECMASCRIPT6");
     setFilename(0, "foo.js");
     setFilename(1, "app.js");


### PR DESCRIPTION
Fixes #2535

Modules which do not import or export anything can only be recognized by the fact that they were imported by another module or script. Changes to the force rewriting were pre-parsing the file and marking it as a module body, but the dependency information was not included and then wasn't regenerated because it had already been parsed.