### PR TITLE
Fixed incorrect OnClickData definitions

### DIFF
--- a/contrib/externs/chrome_extensions.js
+++ b/contrib/externs/chrome_extensions.js
@@ -6944,11 +6944,11 @@ CookieStore.prototype.tabIds;
 function OnClickData() {}
 
 
-/** @type {number} */
+/** @type {number|string} */
 OnClickData.prototype.menuItemId;
 
 
-/** @type {number} */
+/** @type {number|string} */
 OnClickData.prototype.parentMenuItemId;
 
 
@@ -6972,12 +6972,24 @@ OnClickData.prototype.pageUrl;
 OnClickData.prototype.frameUrl;
 
 
+/** @type {number} */
+OnClickData.prototype.frameId;
+
+
 /** @type {string} */
 OnClickData.prototype.selectionText;
 
 
-/** @type {string} */
+/** @type {boolean} */
 OnClickData.prototype.editable;
+
+
+/** @type {boolean} */
+OnClickData.prototype.wasChecked;
+
+
+/** @type {boolean} */
+OnClickData.prototype.checked;
 
 
 


### PR DESCRIPTION
**Added**:
OnClickData.prototype.frameId
OnClickData.prototype.wasChecked
OnClickData.prototype.checked

**Changed**:
OnClickData.prototype.menuItemId (type: number to number|string)
OnClickData.prototype.parentMenuItemId (type: number to number|string)
OnClickData.prototype.editable (type: string to boolean)