### PR TITLE
Fix NPEs in ProcessCommonJSModules caused by multiple var declarations

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -830,12 +830,18 @@ public final class ProcessCommonJSModules implements CompilerPass {
       if (root.matchesQualifiedName("module.exports")
           && rValue != null
           && t.getScope().getVar("module.exports") == null
-          && root.getParent().isAssign()
-          && root.getParent().getParent().isExprResult()) {
-        // Rewrite "module.exports = foo;" to "var moduleName = foo;"
-        Node parent = root.getParent();
-        Node var = IR.var(updatedExport, rValue.detach()).useSourceInfoFrom(root.getParent());
-        parent.getParent().replaceWith(var);
+          && root.getParent().isAssign()) {
+        if (root.getParent().getParent().isExprResult()) {
+          // Rewrite "module.exports = foo;" to "var moduleName = foo;"
+          Node parent = root.getParent();
+          Node var = IR.var(updatedExport, rValue.detach()).useSourceInfoFrom(root.getParent());
+          parent.getParent().replaceWith(var);
+        } else if (root.getNext() != null && root.getNext().isName() && rValueVar.isGlobal()) {
+          // This is a where a module export assignment is used in a complex expression.
+          root.getParent().replaceWith(updatedExport);
+        } else {
+          export.replaceWith(updatedExport);
+        }
       } else {
         // Other references to "module.exports" are just replaced with the module name.
         export.replaceWith(updatedExport);
@@ -1062,6 +1068,13 @@ public final class ProcessCommonJSModules implements CompilerPass {
         case VAR:
         case LET:
         case CONST:
+          // Multiple declaration - needs split apart.
+          if (parent.getChildCount() > 1) {
+            splitMultipleDeclarations(parent);
+            parent = nameRef.getParent();
+            newNameDeclaration = t.getScope().getVar(newName);
+          }
+
           if (newNameIsQualified) {
             // Refactor a var declaration to a getprop assignment
             Node getProp = NodeUtil.newQName(compiler, newName, nameRef, originalName);
@@ -1078,6 +1091,11 @@ public final class ProcessCommonJSModules implements CompilerPass {
             }
           } else if (newNameDeclaration != null) {
             // Variable is already defined. Convert this to an assignment.
+            if (!nameRef.hasChildren()) {
+              parent.detachFromParent();
+              break;
+            }
+
             Node name = NodeUtil.newName(compiler, newName, nameRef, originalName);
             Node assign = IR.assign(name, nameRef.removeFirstChild());
             JSDocInfo info = parent.getJSDocInfo();
@@ -1380,6 +1398,28 @@ public final class ProcessCommonJSModules implements CompilerPass {
       for (Node child = typeNode.getFirstChild(); child != null;
            child = child.getNext()) {
         fixTypeNode(t, child);
+      }
+    }
+
+    private void splitMultipleDeclarations(Node var) {
+      checkState(var.isVar() || var.isLet() || var.isConst());
+      while (var.getSecondChild() != null) {
+        Node newVar;
+        Node nameToSplit = var.removeFirstChild();
+        switch (var.getToken()) {
+          default:
+          case VAR:
+            newVar = IR.var(nameToSplit);
+            break;
+          case LET:
+            newVar = IR.var(nameToSplit);
+            break;
+          case CONST:
+            newVar = IR.var(nameToSplit);
+            break;
+        }
+        newVar.useSourceInfoFrom(var);
+        var.getParent().addChildBefore(newVar, var);
       }
     }
   }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -190,13 +190,12 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "test.js",
         LINE_JOINER.join(
-            "module.exports = {};",
-            "var a = 1, b = 2;",
-            "(function() { var a; b = 4})();"),
+            "module.exports = {};", "var a = 1, b = 2;", "(function() { var a; b = 4})();"),
         LINE_JOINER.join(
             "goog.provide('module$test');",
             "/** @const */ var module$test={};",
-            "var a$$module$test = 1, b$$module$test = 2;",
+            "var a$$module$test = 1;",
+            "var b$$module$test = 2;",
             "(function() { var a; b$$module$test = 4})();"));
   }
 
@@ -867,5 +866,43 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  get b() { return 2; }",
             "}",
             "module$test.a = 1"));
+  }
+
+  public void testIssue2450() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "var BCRYPT_BLOCKS = 8,",
+            "    BCRYPT_HASHSIZE = 32;",
+            "",
+            "module.exports = {",
+            "  BLOCKS: BCRYPT_BLOCKS,",
+            "  HASHSIZE: BCRYPT_HASHSIZE,",
+            "};"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "/** @const */ var module$test={};",
+            "module$test.BLOCKS = 8;",
+            "module$test.HASHSIZE = 32;"));
+  }
+
+  public void testWebpackAmdPattern() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+            "!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(1), __webpack_require__(2)],",
+            "      __WEBPACK_AMD_DEFINE_RESULT__ = function (b, c) {",
+            "          console.log(b, c.exportA, c.exportB);",
+            "      }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),",
+            "    __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "var module$test = {};",
+            "var __WEBPACK_AMD_DEFINE_ARRAY__$$module$test;",
+            "!(__WEBPACK_AMD_DEFINE_ARRAY__$$module$test = [__webpack_require__(1), __webpack_require__(2)],",
+            "    module$test = function(b,c){console.log(b,c.exportA,c.exportB)}",
+            "        .apply(module$test,__WEBPACK_AMD_DEFINE_ARRAY__$$module$test),",
+            "    module$test!==undefined && module$test)"));
   }
 }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -895,12 +895,14 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "      __WEBPACK_AMD_DEFINE_RESULT__ = function (b, c) {",
             "          console.log(b, c.exportA, c.exportB);",
             "      }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),",
-            "    __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));"),
+            "    __WEBPACK_AMD_DEFINE_RESULT__ !== undefined",
+            "    && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));"),
         LINE_JOINER.join(
             "goog.provide('module$test');",
             "var module$test = {};",
             "var __WEBPACK_AMD_DEFINE_ARRAY__$$module$test;",
-            "!(__WEBPACK_AMD_DEFINE_ARRAY__$$module$test = [__webpack_require__(1), __webpack_require__(2)],",
+            "!(__WEBPACK_AMD_DEFINE_ARRAY__$$module$test = ",
+            "    [__webpack_require__(1), __webpack_require__(2)],",
             "    module$test = function(b,c){console.log(b,c.exportA,c.exportB)}",
             "        .apply(module$test,__WEBPACK_AMD_DEFINE_ARRAY__$$module$test),",
             "    module$test!==undefined && module$test)"));


### PR DESCRIPTION
Fixes #2450 and replaces #2509.

Splits apart multiple var declarations in CommonJS modules to prevent an NPE.