### PR TITLE
Revisit vars after splitting when processing CommonJS Modules

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -694,8 +694,28 @@ public final class ProcessCommonJSModules implements CompilerPass {
           }
           break;
 
+        case VAR:
+        case LET:
+        case CONST:
+          // Multiple declarations need split apart so that they can be refactored into
+          // property assignments or removed altogether.
+          if (n.hasMoreThanOneChild()) {
+            List<Node> vars = splitMultipleDeclarations(n);
+            t.reportCodeChange();
+            for (Node var : vars) {
+              visit(t, var.getFirstChild(), var);
+            }
+          }
+          break;
+
         case NAME:
           {
+            // If this is a name declaration with multiple names, it will be split apart when
+            // the parent is visited and then revisit the children.
+            if (NodeUtil.isNameDeclaration(n.getParent()) && n.getParent().hasMoreThanOneChild()) {
+              break;
+            }
+
             String qName = n.getQualifiedName();
             if (qName == null) {
               break;
@@ -1071,13 +1091,6 @@ public final class ProcessCommonJSModules implements CompilerPass {
         case VAR:
         case LET:
         case CONST:
-          // Multiple declaration - needs split apart.
-          if (parent.getChildCount() > 1) {
-            splitMultipleDeclarations(parent);
-            parent = nameRef.getParent();
-            newNameDeclaration = t.getScope().getVar(newName);
-          }
-
           if (newNameIsQualified) {
             // Refactor a var declaration to a getprop assignment
             Node getProp = NodeUtil.newQName(compiler, newName, nameRef, originalName);
@@ -1407,13 +1420,17 @@ public final class ProcessCommonJSModules implements CompilerPass {
       }
     }
 
-    private void splitMultipleDeclarations(Node var) {
+    private List<Node> splitMultipleDeclarations(Node var) {
       checkState(NodeUtil.isNameDeclaration(var));
+      List<Node> vars = new ArrayList<>();
       while (var.getSecondChild() != null) {
         Node newVar = new Node(var.getToken(), var.removeFirstChild());
         newVar.useSourceInfoFrom(var);
         var.getParent().addChildBefore(newVar, var);
+        vars.add(newVar);
       }
+      vars.add(var);
+      return vars;
     }
   }
 }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -907,4 +907,25 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "        .apply(module$test,__WEBPACK_AMD_DEFINE_ARRAY__$$module$test),",
             "    module$test!==undefined && module$test)"));
   }
+
+  public void testIssue2593() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "var first = 1,",
+            "    second = 2,",
+            "    third = 3,",
+            "    fourth = 4,",
+            "    fifth = 5;",
+            "",
+            "module.exports = {};"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "/** @const */ var module$test={};",
+            "var first$$module$test=1;",
+            "var second$$module$test=2;",
+            "var third$$module$test=3;",
+            "var fourth$$module$test=4;",
+            "var fifth$$module$test=5;"));
+  }
 }


### PR DESCRIPTION
Fixes #2593 

Because rewriting commonjs modules is a post-order traversal, we need to specifically revisit vars after splitting multiple declarations apart.