### PR TITLE
Improved UMD wrapper support

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -101,11 +101,15 @@ public final class ProcessCommonJSModules implements CompilerPass {
       finder.reportModuleErrors();
 
       if (!finder.umdPatterns.isEmpty()) {
-        finder.replaceUmdPatterns();
+        boolean needsRetraverse = finder.replaceUmdPatterns();
 
-        // Removing the IIFE rewrites vars. We need to re-traverse
+        if (!needsRetraverse) {
+          needsRetraverse = removeIIFEWrapper(root);
+        }
+
+        // Inlining functions rewrites vars. We need to re-traverse
         // to get the new references.
-        if (removeIIFEWrapper(root)) {
+        if (needsRetraverse) {
           finder = new FindImportsAndExports();
           NodeTraversal.traverseEs6(compiler, root, finder);
         }
@@ -184,6 +188,13 @@ public final class ProcessCommonJSModules implements CompilerPass {
     // and it must be an expression statement.
     if (n == null || !n.isExprResult() || n.getNext() != null) {
       return false;
+    }
+
+    // Function expression can be forced with !, just skip !
+    // FIXME: Expression could also be forced with: + - ~ void
+    // FIXME: ! ~ void can be repeated any number of times
+    if (n != null && n.getFirstChild() != null && n.getFirstChild().isNot()) {
+      n = n.getFirstChild();
     }
 
     Node call = n.getFirstChild();
@@ -486,8 +497,10 @@ public final class ProcessCommonJSModules implements CompilerPass {
           Node rValue = NodeUtil.getRValueOfLValue(export.node);
           if (rValue == null || !rValue.isObjectLit()) {
             directAssignments++;
-            if (export.node.getParent().getParent().isExprResult()
-                && NodeUtil.isTopLevel(export.node.getParent().getParent().getParent())) {
+            Node expr = export.node.getParent().getParent();
+            if (expr.isExprResult()
+                && (NodeUtil.isTopLevel(expr.getParent())
+                || (expr.getParent().isNormalBlock() && NodeUtil.isTopLevel(expr.getGrandparent())))) {
               directAssignmentsAtTopLevel++;
             }
           }
@@ -569,7 +582,9 @@ public final class ProcessCommonJSModules implements CompilerPass {
         return null;
       }
 
-      if (parent.isIf() && parent.getFirstChild() == n) {
+      // When walking up ternary operations (hook), don't check if parent is the condition,
+      // because one ternary operation can be then/else branch of another.
+      if ((parent.isIf() && parent.getFirstChild() == n) || parent.isHook()) {
         Node outerIf = getOutermostIfAncestor(parent);
         if (outerIf != null) {
           return outerIf;
@@ -582,7 +597,9 @@ public final class ProcessCommonJSModules implements CompilerPass {
     }
 
     /** Remove a Universal Module Definition and leave just the commonjs export statement */
-    void replaceUmdPatterns() {
+    boolean replaceUmdPatterns() {
+      boolean needsRetraverse = false;
+      Node changeScope;
       for (UmdPattern umdPattern : umdPatterns) {
         Node parent = umdPattern.ifRoot.getParent();
         Node newNode = umdPattern.activeBranch;
@@ -590,7 +607,7 @@ public final class ProcessCommonJSModules implements CompilerPass {
         if (newNode == null) {
           parent.removeChild(umdPattern.ifRoot);
           compiler.reportChangeToEnclosingScope(parent);
-          return;
+          continue;
         }
 
         // Remove redundant block node. Not strictly necessary, but makes tests more legible.
@@ -602,12 +619,94 @@ public final class ProcessCommonJSModules implements CompilerPass {
           umdPattern.ifRoot.detachChildren();
         }
         parent.replaceChild(umdPattern.ifRoot, newNode);
-        // TODO(johnlenz): don't work on detached nodes
-        Node changeScope = NodeUtil.getEnclosingChangeScopeRoot(parent);
+        changeScope = NodeUtil.getEnclosingChangeScopeRoot(newNode);
         if (changeScope != null) {
-          compiler.reportChangeToEnclosingScope(parent);
+          compiler.reportChangeToEnclosingScope(newNode);
+        }
+
+        Node block = parent;
+        if (block.isExprResult()) {
+          block = block.getParent();
+        }
+
+        // Detect UMD Factory Patterns and inline the functions
+        if (block.isNormalBlock() && block.getParent().isFunction()
+            && block.getGrandparent().isCall()
+            && parent.hasOneChild()) {
+          Node enclosingFnCall = block.getGrandparent();
+          Node fn = block.getParent();
+
+          Node enclosingScript = NodeUtil.getEnclosingScript(enclosingFnCall);
+          if (enclosingScript == null) {
+            continue;
+          }
+          CompilerInput ci = compiler.getInput(NodeUtil.getEnclosingScript(enclosingFnCall).getInputId());
+          ModulePath modulePath = ci.getPath();
+          if (modulePath == null) {
+            continue;
+          }
+          needsRetraverse = true;
+          String factoryLabel = modulePath.toModuleName() + "_factory";
+
+          FunctionToBlockMutator mutator =
+              new FunctionToBlockMutator(compiler, compiler.getUniqueNameIdSupplier());
+          Node newStatements = mutator.mutate(factoryLabel, fn, enclosingFnCall, null, false, false);
+
+          // Check to see if the returned block is of the form:
+          // {
+          //   var jscomp$inline = function() {};
+          //   jscomp$inline();
+          // }
+          //
+          // If so, inline again
+          if (newStatements.isNormalBlock()
+              && newStatements.hasTwoChildren()
+              && newStatements.getFirstChild().isVar()
+              && newStatements.getFirstFirstChild().hasOneChild()
+              && newStatements.getFirstFirstChild().getFirstChild().isFunction()
+              && newStatements.getSecondChild().isExprResult()) {
+            Node inlinedFn = newStatements.getFirstFirstChild().getFirstChild();
+            String fnName = newStatements.getFirstFirstChild().getString();
+            Node expr = newStatements.getSecondChild().getFirstChild();
+            Node call = null;
+            if (expr.isAssign() && expr.getSecondChild().isCall()) {
+              call = expr.getSecondChild();
+            } else if (expr.isCall()) {
+              call = expr;
+            }
+
+            if (call != null) {
+              newStatements = mutator.mutate(factoryLabel, inlinedFn, call, null, false, false);
+              if (expr.isAssign() && newStatements.hasOneChild() && newStatements.getFirstChild().isExprResult()) {
+                expr.replaceChild(expr.getSecondChild(), newStatements.getFirstFirstChild().detach());
+                newStatements = expr.getParent().detach();
+              }
+            }
+          }
+
+          Node callRoot = enclosingFnCall.getParent();
+          if (callRoot.isNot()) {
+            callRoot = callRoot.getParent();
+          }
+          if (callRoot.isExprResult()) {
+            callRoot = callRoot.getParent();
+
+            callRoot.detachChildren();
+            callRoot.addChildToFront(newStatements);
+            changeScope = NodeUtil.getEnclosingChangeScopeRoot(callRoot);
+            if (changeScope != null) {
+              compiler.reportChangeToEnclosingScope(callRoot);
+            }
+          } else {
+            parent.replaceChild(umdPattern.ifRoot, newNode);
+            changeScope = NodeUtil.getEnclosingChangeScopeRoot(newNode);
+            if (changeScope != null) {
+              compiler.reportChangeToEnclosingScope(newNode);
+            }
+          }
         }
       }
+      return needsRetraverse;
     }
   }
 
@@ -856,7 +955,8 @@ public final class ProcessCommonJSModules implements CompilerPass {
           Node parent = root.getParent();
           Node var = IR.var(updatedExport, rValue.detach()).useSourceInfoFrom(root.getParent());
           parent.getParent().replaceWith(var);
-        } else if (root.getNext() != null && root.getNext().isName() && rValueVar.isGlobal()) {
+        } else if (root.getNext() != null && root.getNext().isName()
+            && rValueVar != null && rValueVar.isGlobal()) {
           // This is a where a module export assignment is used in a complex expression.
           // Before: `SOME_VALUE !== undefined && module.exports = SOME_VALUE`
           // After: `SOME_VALUE !== undefined && module$name`

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -643,6 +643,22 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "test.js",
         LINE_JOINER.join(
+            "!function(){",
+            "var foobar = {foo: 'bar'};",
+            "if (typeof module === 'object' && module.exports) {",
+            "  module.exports = foobar;",
+            "} else if (typeof define === 'function' && define.amd) {",
+            "  define([], function() {return foobar;});",
+            "} else {",
+            "  this.foobar = foobar;",
+            "}}()"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "var module$test = {foo: 'bar'};"));
+
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
             ";;;(function(){",
             "var foobar = {foo: 'bar'};",
             "if (typeof module === 'object' && module.exports) {",
@@ -927,6 +943,65 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "var third$$module$test=3;",
             "var fourth$$module$test=4;",
             "var fifth$$module$test=5;"));
+  }
+
+  public void testTernaryUMDWrapper() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "var foobar = {foo: 'bar'};",
+            "typeof module === 'object' && module.exports ? module.exports = foobar :",
+            "typeof define === 'function' && define.amd ? define([], function() {return foobar;}) :",
+            "this.foobar = foobar;"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "var module$test = {foo: 'bar'};"));
+  }
+
+  public void testLeafletUMDWrapper() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "(function (global, factory) {",
+            "  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :",
+            "  typeof define === 'function' && define.amd ? define(['exports'], factory) :",
+            "  (factory((global.L = {})));",
+            "}(this, (function (exports) {",
+            "  'use strict';",
+            "  var webkit = userAgentContains('webkit');",
+            "  function userAgentContains(str) {",
+            "    return navigator.userAgent.toLowerCase().indexOf(str) >= 0;",
+            "  }",
+            "  exports.webkit = webkit",
+            "})));"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "/** @const */ var module$test={};",
+            "{",
+            "  var exports$jscomp$inline_3$$module$test=module$test;",
+            "  var userAgentContains$jscomp$inline_5$$module$test=function(str$jscomp$inline_6){",
+            "    return navigator.userAgent.toLowerCase().indexOf(str$jscomp$inline_6)>=0;",
+            "  };",
+            "  var webkit$jscomp$inline_4$$module$test=userAgentContains$jscomp$inline_5$$module$test('webkit');",
+            "  exports$jscomp$inline_3$$module$test.webkit=webkit$jscomp$inline_4$$module$test;",
+            "}"));
+  }
+
+  public void testBowserUMDWrapper() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "!function (root, name, definition) {",
+            "  if (typeof module != 'undefined' && module.exports) module.exports = definition()",
+            "  else if (typeof define == 'function' && define.amd) define(name, definition)",
+            "  else root[name] = definition()",
+            "}(this, 'foobar', function () {",
+            "  return {foo: 'bar'};",
+            "});"),
+        LINE_JOINER.join(
+            "goog.provide('module$test');",
+            "/** @const */ var module$test={};",
+            "module$test.foo = 'bar';"));
   }
 
   public void testDontSplitVarsInFor() {


### PR DESCRIPTION
WIP: #2586 

## Before:

Leaflet wrapper, UMD check is not removed:
```
Expected: goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={foo:"bar"}
Result:   goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={};(function(global,factory){typeof module$test==="object"&&typeof module!=="undefined"?factory(module$test):typeof define==="function"&&define.amd?define(["exports"],factory):factory(global.foobar=global.foobar||{})})(this,function(exports){exports.foo="bar"})
```

Bowser wrapper, IIFE is not removed:
```
Expected: goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={foo:"bar"}
Result:   goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={};!function(root,name,definition){var module$test=definition()}(this,"foobar",function(){return{foo:"bar"}})
```

## After

Leaflet wrapper

Problem with this one was use of ternary operator instead of `if` statements. I fixed this by adding a `isHook` check to `getOutermostIfAncestor`.

```
Expected: goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={foo:"bar"}
Result:   goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={};var factory$$module$test=function(exports){exports.foo="bar"};factory$$module$test(module$test)
```

Bowser wrapper

Problem with this one was that the IIFE was created using `!` instead of wrapping the expression in parentheses. I fixed this by adding check on `removeIIFEWrapper` to check if node is Not expression and select the first children instead. Probably this should also support other ways to invoke IIFEs? Like `+`, `-`, `~`, `void`. Not sure if best way to support this would be to check for these five tokens or something else? Some of these can also be repeated but no reasonable wrapped does that...

```
Expected: goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var module$test={foo:"bar"}
Result:   goog.provide("module$other");goog.provide("module$yet_another");goog.provide("module$test");var definition$$module$test=function(){return{foo:"bar"}};var module$test=definition$$module$test()
```

## Next

I didn't yet try to run the code generated with these changes, but my understanding is that it won't work yet. I think the return value of function call in `module.exports` assignment should be inlined in case of Bowser, and the function body lifted and exported names renamed in case of Leaflet:

```
// leaflet
function foo(a) {
  a.foo = 'bar';
}
foo(exports);
// =>
var module$test = {};
module$test.a = 'bar';

// bowser
function foo() {
  return {foo: 'bar'};
}
module.exports = foo();
// =>
var module$test = {foo: 'bar'};
```

I will need some help to continue with this (ping @ChadKillingsworth). My understanding is that this replacement would need to be done after `removeIIFEWrapper` in `process`?