### PR TITLE
Add browser and module field support to package.json processing

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1169,6 +1169,9 @@ public class CompilerOptions implements Serializable {
   /** Which algorithm to use for locating ES6 and CommonJS modules */
   ModuleLoader.ResolutionMode moduleResolutionMode;
 
+  /** Which entries to look for in package.json files when processing modules */
+  List<String> packageJsonEntryNames;
+
   /**
    * Should the compiler print its configuration options to stderr when they are initialized?
    *
@@ -1194,6 +1197,7 @@ public class CompilerOptions implements Serializable {
 
     // Modules
     moduleResolutionMode = ModuleLoader.ResolutionMode.BROWSER;
+    packageJsonEntryNames = ImmutableList.of(RewriteJsonToModule.PACKAGE_JSON_MAIN);
 
     // Checks
     skipNonTranspilationPasses = false;
@@ -2779,6 +2783,14 @@ public class CompilerOptions implements Serializable {
 
   public void setModuleResolutionMode(ModuleLoader.ResolutionMode mode) {
     this.moduleResolutionMode = mode;
+  }
+
+  public List<String> getPackageJsonEntryNames() {
+    return this.packageJsonEntryNames;
+  }
+
+  public void setPackageJsonEntryNames(List<String> names) {
+    this.packageJsonEntryNames = names;
   }
 
   /** Serializes compiler options to a stream. */

--- a/src/com/google/javascript/jscomp/RewriteJsonToModule.java
+++ b/src/com/google/javascript/jscomp/RewriteJsonToModule.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,6 +36,7 @@ public class RewriteJsonToModule extends NodeTraversal.AbstractPostOrderCallback
     implements CompilerPass {
   public static final DiagnosticType JSON_UNEXPECTED_TOKEN =
       DiagnosticType.error("JSC_JSON_UNEXPECTED_TOKEN", "Unexpected JSON token");
+  public static final String PACKAGE_JSON_MAIN = "main";
 
   private final Map<String, String> packageJsonMainEntries;
   private final AbstractCompiler compiler;
@@ -136,10 +138,16 @@ public class RewriteJsonToModule extends NodeTraversal.AbstractPostOrderCallback
 
     String inputPath = t.getInput().getSourceFile().getOriginalPath();
     if (inputPath.endsWith("/package.json") && jsonObject.isObjectLit()) {
-      Node main = NodeUtil.getFirstPropMatchingKey(jsonObject, "main");
-      if (main != null && main.isString()) {
-        String dirName = inputPath.substring(0, inputPath.length() - "package.json".length());
-        packageJsonMainEntries.put(inputPath, dirName + main.getString());
+      List<String> possibleMainEntries = compiler.getOptions().getPackageJsonEntryNames();
+
+      for (String entryName : possibleMainEntries) {
+        Node entry = NodeUtil.getFirstPropMatchingKey(jsonObject, entryName);
+
+        if (entry != null && entry.isString()) {
+          String dirName = inputPath.substring(0, inputPath.length() - "package.json".length());
+          packageJsonMainEntries.put(inputPath, dirName + entry.getString());
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
This PR fixes #2433 by introducing a new option, `packageJsonEntryNames`, which allows specifying a list of ordered entries which the compiler should look for when resolving Node modules. The default is the single entry `"main"`.

When compiling for the web, however, we would pass in a list of `"browser", "main"` which tells the compiler to look for a `"browser"` entry before checking the `"main"` entry.

This also allows people who want to consume packages that instead rely on `es2015:main` or `esnext:main` to include those too in the order of precedence they prefer.