### PR TITLE
Add `--package_json_entry_names` command line flag

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -767,6 +767,13 @@ public class CommandLineRunner extends
     )
     private ModuleLoader.ResolutionMode moduleResolutionMode = ModuleLoader.ResolutionMode.BROWSER;
 
+    @Option(name = "--package_json_entry_names",
+        usage = "Ordered list of entries to look for in package.json files when processing "
+        + "modules with the NODE module resolution strategy (i.e. esnext:main,browser,main). "
+        + "Defaults to a list with the following entries: \"browser\", \"module\", \"main\"."
+    )
+    private String packageJsonEntryNames = null;
+
     @Argument
     private List<String> arguments = new ArrayList<>();
     private final CmdLineParser parser;
@@ -844,7 +851,8 @@ public class CommandLineRunner extends
                     "js_module_root",
                     "module_resolution",
                     "process_common_js_modules",
-                    "transform_amd_modules"))
+                    "transform_amd_modules",
+                    "package_json_entry_names"))
             .putAll(
                 "Library and Framework Specific",
                 ImmutableList.of(
@@ -1074,6 +1082,10 @@ public class CommandLineRunner extends
       }
 
       return result.build();
+    }
+
+    List<String> getPackageJsonEntryNames() throws CmdLineException {
+      return Splitter.on(',').splitToList(packageJsonEntryNames);
     }
 
     // Our own option parser to be backwards-compatible.
@@ -1759,6 +1771,15 @@ public class CommandLineRunner extends
     }
     options.setSourceMapIncludeSourcesContent(flags.sourceMapIncludeSourcesContent);
     options.setModuleResolutionMode(flags.moduleResolutionMode);
+
+    if (flags.packageJsonEntryNames != null) {
+      try {
+        List<String> packageJsonEntryNames = flags.getPackageJsonEntryNames();
+        options.setPackageJsonEntryNames(packageJsonEntryNames);
+      } catch (CmdLineException e) {
+        reportError("ERROR - invalid package_json_entry_names format specified.");
+      }
+    }
 
     return options;
   }

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1173,12 +1173,6 @@ public class CompilerOptions implements Serializable {
   List<String> packageJsonEntryNames;
 
   /**
-   * Needed by {@link RewriteJsonToModule}, but defined here because RewriteJsonToModule is not
-   * part of the core build.
-   */
-  public static final String PACKAGE_JSON_MAIN = "main";
-
-  /**
    * Should the compiler print its configuration options to stderr when they are initialized?
    *
    * <p>Default {@code false}.
@@ -1203,7 +1197,7 @@ public class CompilerOptions implements Serializable {
 
     // Modules
     moduleResolutionMode = ModuleLoader.ResolutionMode.BROWSER;
-    packageJsonEntryNames = ImmutableList.of(CompilerOptions.PACKAGE_JSON_MAIN);
+    packageJsonEntryNames = ImmutableList.of("browser", "module", "main");
 
     // Checks
     skipNonTranspilationPasses = false;

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1904,6 +1904,41 @@ public final class CommandLineRunnerTest extends TestCase {
         });
   }
 
+  /**
+   * override the order of the entries that the module loader should look for
+   */
+  public void testProcessCJSWithPackageJsonBrowserField() {
+    useStringComparison = true;
+    args.add("--process_common_js_modules");
+    args.add("--dependency_mode=STRICT");
+    args.add("--entry_point=app");
+    args.add("--module_resolution=NODE");
+    args.add("--package_json_entry_names=browser,main");
+    setFilename(0, "app.js");
+    setFilename(1, "node_modules/foo/package.json");
+    setFilename(2, "node_modules/foo/browser.js");
+
+    test(
+        new String[] {
+          "var Foo = require('foo');",
+          "{\"browser\":\"browser.js\",\"name\":\"foo\"}",
+          LINE_JOINER.join(
+              "function Foo() {}",
+              "Foo.prototype = {",
+              "  bar: function () {",
+              "    return 4 + 4;",
+              "  }",
+              "};",
+              "module.exports = Foo;")
+        },
+
+        new String[] {
+          "var module$node_modules$foo$browser=function(){};",
+          "module$node_modules$foo$browser.prototype={bar:function(){return 8}};",
+          "var Foo=module$node_modules$foo$browser;",
+        });
+  }
+
   public void testFormattingSingleQuote() {
     testSame("var x = '';");
     assertThat(lastCompiler.toSource()).isEqualTo("var x=\"\";");

--- a/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
+++ b/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
@@ -42,7 +42,7 @@ public final class RewriteJsonToModuleTest extends CompilerTestCase {
     options.setProcessCommonJSModules(true);
     options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
     options.setPackageJsonEntryNames(
-        ImmutableList.of("browser", CompilerOptions.PACKAGE_JSON_MAIN));
+        ImmutableList.of("browser", "main"));
     return options;
   }
 


### PR DESCRIPTION
This PR builds on #2598 and adds a command line flag that allows specifying the ordered entries which `RewriteJsonToModule` should look for when computing the main entry in `package.json` files.

refs #2433 