### PR TITLE
Add support for browser field advanced usage to package.json processing

### DIFF
--- a/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.ErrorHandler;
 import com.google.javascript.jscomp.JSError;
+import com.google.javascript.jscomp.deps.NodeModuleResolver;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.SortedSet;
@@ -42,6 +43,7 @@ public class NodeModuleResolver extends ModuleResolver {
     ModuleLoader.MODULE_SLASH + "index.js",
     ModuleLoader.MODULE_SLASH + "index.json"
   };
+  public static final String JSC_BROWSER_BLACKLISTED_MARKER = "$jscomp$browser$blacklisted";
 
   /** Named modules found in node_modules folders */
   private final ImmutableMap<String, String> packageJsonMainEntries;
@@ -165,7 +167,20 @@ public class NodeModuleResolver extends ModuleResolver {
     for (int i = 0; i < FILE_EXTENSIONS_TO_SEARCH.length; i++) {
       String loadAddress = locate(scriptAddress, moduleAddress + FILE_EXTENSIONS_TO_SEARCH[i]);
       if (loadAddress != null) {
-        return loadAddress;
+        // Also look for mappings in packageJsonMainEntries because browser field
+        // advanced usage allows to override / blacklist specific files, including
+        // the main entry.
+        if (packageJsonMainEntries.containsKey(loadAddress)) {
+          String packageJsonEntry = packageJsonMainEntries.get(loadAddress);
+
+          if (packageJsonEntry != JSC_BROWSER_BLACKLISTED_MARKER) {
+            return resolveJsModuleFile(scriptAddress, packageJsonEntry);
+          } else {
+            return null;
+          }
+        } else {
+          return loadAddress;
+        }
       }
     }
 

--- a/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
+++ b/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
@@ -20,7 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.deps.ModuleLoader;
+import com.google.javascript.jscomp.deps.NodeModuleResolver;
 import com.google.javascript.rhino.Node;
+import java.util.Map;
 
 /** Unit tests for {@link RewriteJsonToModule} */
 public final class RewriteJsonToModuleTest extends CompilerTestCase {
@@ -102,5 +104,39 @@ public final class RewriteJsonToModuleTest extends CompilerTestCase {
     assertThat(getLastCompiler().getModuleLoader().getPackageJsonMainEntries()).hasSize(1);
     assertThat(getLastCompiler().getModuleLoader().getPackageJsonMainEntries())
         .containsEntry("/package.json", "/browser/foo.js");
+  }
+
+    public void testPackageJsonFileBrowserFieldAdvancedUsage() {
+      test(
+          srcs(
+              SourceFile.fromCode(
+                  "/package.json",
+                  lines("{ 'main': 'foo/bar/baz.js',",
+                        "  'browser': { 'dont/include.js': false,",
+                        "               'foo/bar/baz.js': 'replaced/main.js',",
+                        "               'override/relative.js': './with/this.js',",
+                        "               'override/explicitly.js': 'with/other.js'} }"))),
+          expected(
+              lines(
+                  "goog.provide('module$package_json')",
+                  "var module$package_json = {",
+                  "  'main': 'foo/bar/baz.js',",
+                  "  'browser': {",
+                  "    'dont/include.js': false,",
+                  "    'foo/bar/baz.js': 'replaced/main.js',",
+                  "    'override/relative.js': './with/this.js',",
+                  "    'override/explicitly.js': 'with/other.js'",
+                  "  }",
+                  "};")));
+
+      Map<String, String> packageJsonMainEntries = getLastCompiler().getModuleLoader().getPackageJsonMainEntries();
+      assertThat(packageJsonMainEntries).hasSize(5);
+      assertThat(packageJsonMainEntries).containsEntry("/package.json", "/foo/bar/baz.js");
+      assertThat(packageJsonMainEntries).containsEntry("/foo/bar/baz.js", "/replaced/main.js");
+      // NodeModuleResolver knows how to normalize this entry's value
+      assertThat(packageJsonMainEntries).containsEntry("/override/relative.js", "/./with/this.js");
+      assertThat(packageJsonMainEntries).
+        containsEntry("/dont/include.js", NodeModuleResolver.JSC_BROWSER_BLACKLISTED_MARKER);
+      assertThat(packageJsonMainEntries).containsEntry("/override/explicitly.js", "/with/other.js");
   }
 }

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.javascript.jscomp.CompilerInput;
 import com.google.javascript.jscomp.SourceFile;
+import com.google.javascript.jscomp.deps.NodeModuleResolver;
 import junit.framework.TestCase;
 
 /** Tests for {@link ModuleLoader}. */
@@ -287,6 +288,55 @@ public final class ModuleLoaderTest extends TestCase {
     assertUri("/B/lib/b.js", loader.resolve("/app.js").resolveJsModule("/B"));
 
     assertUri("/node_modules/B/lib/b.js", loader.resolve("/app.js").resolveJsModule("B"));
+  }
+
+  public void testLocateNodeModulesBrowserFieldAdvancedUsage() throws Exception {
+    // case where the package.json looks like the following:
+    //   {"main": "server.js",
+    //    "browser": {"server.js": "client.js",
+    //                "exclude/this.js": false,
+    //                "replace/other.js": "with/alternative.js"}}
+    ImmutableMap<String, String> packageJsonMainEntries =
+      ImmutableMap.of(
+                      "/node_modules/mymodule/package.json", "/node_modules/mymodule/server.js",
+                      "/node_modules/mymodule/server.js", "/node_modules/mymodule/client.js",
+                      "/node_modules/mymodule/override/relative.js", "/node_modules/mymodule/./with/this.js",
+                      "/node_modules/mymodule/exclude/this.js", NodeModuleResolver.JSC_BROWSER_BLACKLISTED_MARKER,
+                      "/node_modules/mymodule/replace/other.js", "/node_modules/mymodule/with/alternative.js");
+
+    ImmutableList<CompilerInput> compilerInputs =
+        inputs(
+            "node_modules/mymodule/package.json",
+            "node_modules/mymodule/server.js",
+            "node_modules/mymodule/client.js",
+            "node_modules/mymodule/exclude/this.js",
+            "node_modules/mymodule/replace/other.js",
+            "node_modules/mymodule/with/alternative.js",
+            "/node_modules/mymodule/override/relative.js",
+            "/node_modules/mymodule/with/this.js",
+            "/foo.js");
+
+    ModuleLoader loader =
+        new ModuleLoader(
+            null,
+            (new ImmutableList.Builder<String>()).build(),
+            compilerInputs,
+            ModuleLoader.PathResolver.RELATIVE,
+            ModuleLoader.ResolutionMode.NODE,
+            packageJsonMainEntries);
+
+    assertUri("/node_modules/mymodule/client.js", loader.resolve("/foo.js").resolveJsModule("mymodule"));
+
+    assertUri(
+        "/node_modules/mymodule/with/alternative.js",
+        loader.resolve("/foo.js").resolveJsModule("mymodule/replace/other.js"));
+    assertUri(
+        "/node_modules/mymodule/with/alternative.js",
+        loader.resolve("/node_modules/mymodule/client.js").resolveJsModule("./replace/other.js"));
+    assertUri(
+        "/node_modules/mymodule/with/this.js",
+        loader.resolve("/foo.js").resolveJsModule("mymodule/override/relative.js"));
+    assertNull(loader.resolve("/node_modules/mymodule/client.js").resolveJsModule("./exclude/this.js"));
   }
 
   CompilerInput input(String name) {


### PR DESCRIPTION
this is the last milestone in adding full support for the browser field when processing `package.json` files.

Fixes #2433 

cc @ChadKillingsworth 