### PR TITLE
Fix shorthand object literal referencing import in Es6RewriteModules

### DIFF
--- a/test/com/google/javascript/jscomp/Es6RewriteModulesTest.java
+++ b/test/com/google/javascript/jscomp/Es6RewriteModulesTest.java
@@ -634,4 +634,30 @@ public final class Es6RewriteModulesTest extends CompilerTestCase {
                 Compiler.joinPathParts("base", "test", "sub.js"),
                 "goog.provide('module$test$sub'); goog.require('module$mod$name');")));
   }
+
+  public void testUseImportInEs6ObjectLiteralShorthand() {
+    testModules(
+        "import {f} from './other.js';\nvar bar = {a: 1, f};",
+        LINE_JOINER.join(
+            "goog.require('module$other');",
+            "var bar$$module$testcode={a: 1, f: module$other.f};"));
+
+    testModules(
+        "import {f as foo} from './other.js';\nvar bar = {a: 1, foo};",
+        LINE_JOINER.join(
+            "goog.require('module$other');",
+            "var bar$$module$testcode={a: 1, foo: module$other.f};"));
+
+    testModules(
+        "import f from './other.js';\nvar bar = {a: 1, f};",
+        LINE_JOINER.join(
+            "goog.require('module$other');",
+            "var bar$$module$testcode={a: 1, f: module$other.default};"));
+
+    testModules(
+        "import * as f from './other.js';\nvar bar = {a: 1, f};",
+        LINE_JOINER.join(
+            "goog.require('module$other');",
+            "var bar$$module$testcode={a: 1, f: module$other};"));
+  }
 }


### PR DESCRIPTION
This fixes the case where an object literal references an imported module or
a named property in that module. E.g.:

```js
import {foo} from './bar.js';

const qux = {foo};
```

This was previously producing an `IllegalStateException`.