### PR TITLE
Refactor handling of `package.json` alias fields

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1194,6 +1194,9 @@ public class CompilerOptions implements Serializable {
   /** Which entries to look for in package.json files when processing modules */
   List<String> packageJsonEntryNames;
 
+  /** Which alias fields to look for in package.json files when processing modules */
+  List<String> packageJsonAliasFields;
+
   /**
    * Should the compiler print its configuration options to stderr when they are initialized?
    *
@@ -1220,6 +1223,7 @@ public class CompilerOptions implements Serializable {
     // Modules
     moduleResolutionMode = ModuleLoader.ResolutionMode.BROWSER;
     packageJsonEntryNames = ImmutableList.of("browser", "module", "main");
+    packageJsonAliasFields = ImmutableList.of("browser");
 
     // Checks
     skipNonTranspilationPasses = false;
@@ -2814,6 +2818,14 @@ public class CompilerOptions implements Serializable {
 
   public void setPackageJsonEntryNames(List<String> names) {
     this.packageJsonEntryNames = names;
+  }
+
+  public List<String> getPackageJsonAliasFields() {
+    return this.packageJsonAliasFields;
+  }
+
+  public void setPackageJsonAliasFields(List<String> fields) {
+    this.packageJsonAliasFields = fields;
   }
 
   /** Serializes compiler options to a stream. */

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -51,7 +51,7 @@ public final class ModuleLoader {
   /** The default module root, the current directory. */
   public static final String DEFAULT_FILENAME_PREFIX = "." + MODULE_SLASH;
 
-  public static final String JSC_BROWSER_BLACKLISTED_MARKER = "$jscomp$browser$blacklisted";
+  public static final String JSC_ALIAS_BLACKLISTED_MARKER = "$jscomp$browser$blacklisted";
 
   public static final DiagnosticType LOAD_WARNING =
       DiagnosticType.error("JSC_JS_MODULE_LOAD_WARNING", "Failed to load module \"{0}\"");
@@ -83,7 +83,8 @@ public final class ModuleLoader {
       Iterable<? extends DependencyInfo> inputs,
       PathResolver pathResolver,
       ResolutionMode resolutionMode,
-      Map<String, String> packageJsonMainEntries) {
+      Map<String, String> packageJsonMainEntries,
+      Map<String, String> packageJsonAliasedEntries) {
     checkNotNull(moduleRoots);
     checkNotNull(inputs);
     checkNotNull(pathResolver);
@@ -103,7 +104,11 @@ public final class ModuleLoader {
       case NODE:
         this.moduleResolver =
             new NodeModuleResolver(
-                this.modulePaths, this.moduleRootPaths, packageJsonMainEntries, this.errorHandler);
+                this.modulePaths,
+                this.moduleRootPaths,
+                packageJsonMainEntries,
+                packageJsonAliasedEntries,
+                this.errorHandler);
         break;
       default:
         throw new RuntimeException("Unexpected resolution mode " + resolutionMode);
@@ -124,12 +129,17 @@ public final class ModuleLoader {
       Iterable<? extends DependencyInfo> inputs,
       PathResolver pathResolver,
       ResolutionMode resolutionMode) {
-    this(errorHandler, moduleRoots, inputs, pathResolver, resolutionMode, null);
+    this(errorHandler, moduleRoots, inputs, pathResolver, resolutionMode, null, null);
   }
 
   @VisibleForTesting
   public Map<String, String> getPackageJsonMainEntries() {
     return this.moduleResolver.getPackageJsonMainEntries();
+  }
+
+  @VisibleForTesting
+  public Map<String, String> getPackageJsonAliasedEntries() {
+    return this.moduleResolver.getPackageJsonAliasedEntries();
   }
 
   /**

--- a/src/com/google/javascript/jscomp/deps/ModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleResolver.java
@@ -46,6 +46,10 @@ public abstract class ModuleResolver {
     return ImmutableMap.of();
   }
 
+  Map<String, String> getPackageJsonAliasedEntries() {
+    return ImmutableMap.of();
+  }
+
   @Nullable
   public abstract String resolveJsModule(
       String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno);

--- a/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
+++ b/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
@@ -130,14 +130,19 @@ public final class RewriteJsonToModuleTest extends CompilerTestCase {
 
     Map<String, String> packageJsonMainEntries =
         getLastCompiler().getModuleLoader().getPackageJsonMainEntries();
-    assertThat(packageJsonMainEntries).hasSize(5);
+    assertThat(packageJsonMainEntries).hasSize(1);
     assertThat(packageJsonMainEntries).containsEntry("/package.json", "/foo/bar/baz.js");
-    assertThat(packageJsonMainEntries).containsEntry("/foo/bar/baz.js", "/replaced/main.js");
+
+    Map<String, String> packageJsonAliasedEntries =
+      getLastCompiler().getModuleLoader().getPackageJsonAliasedEntries();
+
+    assertThat(packageJsonAliasedEntries).hasSize(4);
+    assertThat(packageJsonAliasedEntries).containsEntry("/foo/bar/baz.js", "/replaced/main.js");
     // NodeModuleResolver knows how to normalize this entry's value
-    assertThat(packageJsonMainEntries).containsEntry("/override/relative.js", "/./with/this.js");
-    assertThat(packageJsonMainEntries)
-        .containsEntry("/dont/include.js", ModuleLoader.JSC_BROWSER_BLACKLISTED_MARKER);
-    assertThat(packageJsonMainEntries).containsEntry("/override/explicitly.js", "/with/other.js");
+    assertThat(packageJsonAliasedEntries).containsEntry("/override/relative.js", "/./with/this.js");
+    assertThat(packageJsonAliasedEntries)
+        .containsEntry("/dont/include.js", ModuleLoader.JSC_ALIAS_BLACKLISTED_MARKER);
+    assertThat(packageJsonAliasedEntries).containsEntry("/override/explicitly.js", "/with/other.js");
   }
 
   public void testPackageJsonBrowserFieldAdvancedUsageGH2625() {
@@ -163,10 +168,14 @@ public final class RewriteJsonToModuleTest extends CompilerTestCase {
     Map<String, String> packageJsonMainEntries =
         getLastCompiler().getModuleLoader().getPackageJsonMainEntries();
     assertThat(packageJsonMainEntries).containsExactly(
-        "/package.json", "/foo/bar/baz.js",
-    
+        "/package.json", "/foo/bar/baz.js");
+
+    Map<String, String> packageJsonAliasedEntries =
+      getLastCompiler().getModuleLoader().getPackageJsonAliasedEntries();
+    assertThat(packageJsonAliasedEntries).containsExactly(
         // Test that we have normalized the key, value is normalized by NodeModuleResolver
         "/a/b.js", "/./c/d.js",
         "/server.js", "/client.js");
+
   }
 }

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -31,6 +31,7 @@ public final class ModuleLoaderTest extends TestCase {
       ImmutableMap.of(
           "/B/package.json", "/B/lib/b",
           "/node_modules/B/package.json", "/node_modules/B/lib/b.js");
+  private final ImmutableMap<String, String> packageJsonAliasedEntries = ImmutableMap.of();
 
   public void testWindowsAddresses() {
     ModuleLoader loader =
@@ -51,7 +52,8 @@ public final class ModuleLoaderTest extends TestCase {
             inputs("js/a.js", "js/b.js"),
             ModuleLoader.PathResolver.RELATIVE,
             ModuleLoader.ResolutionMode.NODE,
-            packageJsonMainEntries);
+            packageJsonMainEntries,
+            packageJsonAliasedEntries);
     assertUri("js/a.js", loader.resolve("js/a.js"));
     assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b"));
     assertUri("js/b.js", loader.resolve("js/a.js").resolveJsModule("./b.js"));
@@ -65,7 +67,8 @@ public final class ModuleLoaderTest extends TestCase {
             inputs("A/index.js", "B/index.js", "app.js"),
             ModuleLoader.PathResolver.RELATIVE,
             ModuleLoader.ResolutionMode.NODE,
-            packageJsonMainEntries);
+            packageJsonMainEntries,
+            packageJsonAliasedEntries);
 
     input("A/index.js");
     input("B/index.js");
@@ -100,7 +103,8 @@ public final class ModuleLoaderTest extends TestCase {
             compilerInputs,
             ModuleLoader.PathResolver.RELATIVE,
             ModuleLoader.ResolutionMode.NODE,
-            packageJsonMainEntries);
+            packageJsonMainEntries,
+            packageJsonAliasedEntries);
 
     assertUri("/A/index.js", loader.resolve(" /foo.js").resolveJsModule("/A"));
     assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index.js"));
@@ -266,7 +270,8 @@ public final class ModuleLoaderTest extends TestCase {
             compilerInputs,
             ModuleLoader.PathResolver.RELATIVE,
             ModuleLoader.ResolutionMode.NODE,
-            packageJsonMainEntries);
+            packageJsonMainEntries,
+            packageJsonAliasedEntries);
 
     assertUri("/A/index.js", loader.resolve(" /foo.js").resolveJsModule("/A"));
     assertUri("/A/index.js", loader.resolve("/foo.js").resolveJsModule("/A/index.js"));
@@ -294,14 +299,17 @@ public final class ModuleLoaderTest extends TestCase {
     //   {"main": "server.js",
     //    "browser": {"server.js": "client.js",
     //                "exclude/this.js": false,
+    //                "override/relative.js", "./with/this.js"
     //                "replace/other.js": "with/alternative.js"}}
     ImmutableMap<String, String> packageJsonMainEntries =
         ImmutableMap.of(
-            "/node_modules/mymodule/package.json", "/node_modules/mymodule/server.js",
+            "/node_modules/mymodule/package.json", "/node_modules/mymodule/server.js");
+    ImmutableMap<String, String> packageJsonAliasedEntries =
+        ImmutableMap.of(
             "/node_modules/mymodule/server.js", "/node_modules/mymodule/client.js",
             "/node_modules/mymodule/override/relative.js", "/node_modules/mymodule/./with/this.js",
             "/node_modules/mymodule/exclude/this.js",
-                ModuleLoader.JSC_BROWSER_BLACKLISTED_MARKER,
+            ModuleLoader.JSC_ALIAS_BLACKLISTED_MARKER,
             "/node_modules/mymodule/replace/other.js",
             "/node_modules/mymodule/with/alternative.js");
 
@@ -320,7 +328,8 @@ public final class ModuleLoaderTest extends TestCase {
             compilerInputs,
             ModuleLoader.PathResolver.RELATIVE,
             ModuleLoader.ResolutionMode.NODE,
-            packageJsonMainEntries);
+            packageJsonMainEntries,
+            packageJsonAliasedEntries);
 
     assertUri(
         "/node_modules/mymodule/client.js", loader.resolve("/foo.js").resolveJsModule("mymodule"));


### PR DESCRIPTION
This patch separates the concept of `main` entries in `package.json` files from the one of `alias` fields, as per Webpack's [resolver](https://github.com/webpack/enhanced-resolve#resolver-options).

For example, a `"browser"` entry can either be a `main` entry, or an `alias` field when used to ignore or replace specific files ([source](https://github.com/defunctzombie/package-browser-field-spec#replace-specific-files---advanced)).

cc @ChadKillingsworth

I will provide a follow-up patch allowing the `packageJsonAliasFields` to be set from the command line.