### PR TITLE
Make NodeModuleResolver able to find aliased modules when server inpu…

### DIFF
--- a/src/com/google/javascript/jscomp/RewriteJsonToModule.java
+++ b/src/com/google/javascript/jscomp/RewriteJsonToModule.java
@@ -18,7 +18,7 @@ package com.google.javascript.jscomp;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.javascript.jscomp.deps.NodeModuleResolver;
+import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import java.util.HashMap;
@@ -176,12 +176,18 @@ public class RewriteJsonToModule extends NodeTraversal.AbstractPostOrderCallback
 
       checkState(child.isStringKey() && (value.isString() || value.isFalse()));
 
-      String val =
+      String path = child.getString();
+
+      if (path.startsWith(ModuleLoader.DEFAULT_FILENAME_PREFIX)) {
+        path = path.substring(ModuleLoader.DEFAULT_FILENAME_PREFIX.length());
+      }
+
+      String replacement =
           value.isString()
               ? dirName + value.getString()
-              : NodeModuleResolver.JSC_BROWSER_BLACKLISTED_MARKER;
-      // TODO: handle dots in paths (relative paths)
-      packageJsonMainEntries.put(dirName + child.getString(), val);
+              : ModuleLoader.JSC_BROWSER_BLACKLISTED_MARKER;
+
+      packageJsonMainEntries.put(dirName + path, replacement);
     }
   }
 }

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -51,6 +51,8 @@ public final class ModuleLoader {
   /** The default module root, the current directory. */
   public static final String DEFAULT_FILENAME_PREFIX = "." + MODULE_SLASH;
 
+  public static final String JSC_BROWSER_BLACKLISTED_MARKER = "$jscomp$browser$blacklisted";
+
   public static final DiagnosticType LOAD_WARNING =
       DiagnosticType.warning("JSC_JS_MODULE_LOAD_WARNING", "Failed to load module \"{0}\"");
 

--- a/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
@@ -42,7 +42,6 @@ public class NodeModuleResolver extends ModuleResolver {
     ModuleLoader.MODULE_SLASH + "index.js",
     ModuleLoader.MODULE_SLASH + "index.json"
   };
-  public static final String JSC_BROWSER_BLACKLISTED_MARKER = "$jscomp$browser$blacklisted";
 
   /** Named modules found in node_modules folders */
   private final ImmutableMap<String, String> packageJsonMainEntries;
@@ -164,22 +163,23 @@ public class NodeModuleResolver extends ModuleResolver {
 
   public String resolveJsModuleFile(String scriptAddress, String moduleAddress) {
     for (int i = 0; i < FILE_EXTENSIONS_TO_SEARCH.length; i++) {
-      String loadAddress = locate(scriptAddress, moduleAddress + FILE_EXTENSIONS_TO_SEARCH[i]);
-      if (loadAddress != null) {
-        // Also look for mappings in packageJsonMainEntries because browser field
-        // advanced usage allows to override / blacklist specific files, including
-        // the main entry.
-        if (packageJsonMainEntries.containsKey(loadAddress)) {
-          String packageJsonEntry = packageJsonMainEntries.get(loadAddress);
+      String moduleAddressCandidate = moduleAddress + FILE_EXTENSIONS_TO_SEARCH[i];
+      String canonicalizedCandidatePath = canonicalizePath(scriptAddress, moduleAddressCandidate);
 
-          if (packageJsonEntry != JSC_BROWSER_BLACKLISTED_MARKER) {
-            return resolveJsModuleFile(scriptAddress, packageJsonEntry);
-          } else {
-            return null;
-          }
-        } else {
-          return loadAddress;
+      // Also look for mappings in packageJsonMainEntries because browser field
+      // advanced usage allows to override / blacklist specific files, including
+      // the main entry.
+      if (packageJsonMainEntries.containsKey(canonicalizedCandidatePath)) {
+        moduleAddressCandidate = packageJsonMainEntries.get(canonicalizedCandidatePath);
+
+        if (moduleAddressCandidate == ModuleLoader.JSC_BROWSER_BLACKLISTED_MARKER) {
+          return null;
         }
+      }
+
+      String loadAddress = locate(scriptAddress, moduleAddressCandidate);
+      if (loadAddress != null) {
+        return loadAddress;
       }
     }
 

--- a/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
+++ b/test/com/google/javascript/jscomp/RewriteJsonToModuleTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.deps.ModuleLoader;
-import com.google.javascript.jscomp.deps.NodeModuleResolver;
 import com.google.javascript.rhino.Node;
 import java.util.Map;
 
@@ -137,7 +136,36 @@ public final class RewriteJsonToModuleTest extends CompilerTestCase {
     // NodeModuleResolver knows how to normalize this entry's value
     assertThat(packageJsonMainEntries).containsEntry("/override/relative.js", "/./with/this.js");
     assertThat(packageJsonMainEntries)
-        .containsEntry("/dont/include.js", NodeModuleResolver.JSC_BROWSER_BLACKLISTED_MARKER);
+        .containsEntry("/dont/include.js", ModuleLoader.JSC_BROWSER_BLACKLISTED_MARKER);
     assertThat(packageJsonMainEntries).containsEntry("/override/explicitly.js", "/with/other.js");
+  }
+
+  public void testPackageJsonBrowserFieldAdvancedUsageGH2625() {
+    test(
+        srcs(
+            SourceFile.fromCode(
+                "/package.json",
+                lines(
+                    "{ 'main': 'foo/bar/baz.js',",
+                    "  'browser': { './a/b.js': './c/d.js',",
+                    "               './server.js': 'client.js'} }"))),
+        expected(
+            lines(
+                "goog.provide('module$package_json')",
+                "var module$package_json = {",
+                "  'main': 'foo/bar/baz.js',",
+                "  'browser': {",
+                "    './a/b.js': './c/d.js',",
+                "    './server.js': 'client.js'",
+                "  }",
+                "};")));
+
+    Map<String, String> packageJsonMainEntries =
+        getLastCompiler().getModuleLoader().getPackageJsonMainEntries();
+    assertThat(packageJsonMainEntries).hasSize(3);
+    assertThat(packageJsonMainEntries).containsEntry("/package.json", "/foo/bar/baz.js");
+    // Test that we have normalized the key, value is normalized by NodeModuleResolver
+    assertThat(packageJsonMainEntries).containsEntry("/a/b.js", "/./c/d.js");
+    assertThat(packageJsonMainEntries).containsEntry("/server.js", "/client.js");
   }
 }

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -301,19 +301,15 @@ public final class ModuleLoaderTest extends TestCase {
             "/node_modules/mymodule/server.js", "/node_modules/mymodule/client.js",
             "/node_modules/mymodule/override/relative.js", "/node_modules/mymodule/./with/this.js",
             "/node_modules/mymodule/exclude/this.js",
-                NodeModuleResolver.JSC_BROWSER_BLACKLISTED_MARKER,
+                ModuleLoader.JSC_BROWSER_BLACKLISTED_MARKER,
             "/node_modules/mymodule/replace/other.js",
-                "/node_modules/mymodule/with/alternative.js");
+            "/node_modules/mymodule/with/alternative.js");
 
     ImmutableList<CompilerInput> compilerInputs =
         inputs(
-            "node_modules/mymodule/package.json",
-            "node_modules/mymodule/server.js",
-            "node_modules/mymodule/client.js",
-            "node_modules/mymodule/exclude/this.js",
-            "node_modules/mymodule/replace/other.js",
-            "node_modules/mymodule/with/alternative.js",
-            "/node_modules/mymodule/override/relative.js",
+            "/node_modules/mymodule/package.json",
+            "/node_modules/mymodule/client.js",
+            "/node_modules/mymodule/with/alternative.js",
             "/node_modules/mymodule/with/this.js",
             "/foo.js");
 
@@ -328,7 +324,6 @@ public final class ModuleLoaderTest extends TestCase {
 
     assertUri(
         "/node_modules/mymodule/client.js", loader.resolve("/foo.js").resolveJsModule("mymodule"));
-
     assertUri(
         "/node_modules/mymodule/with/alternative.js",
         loader.resolve("/foo.js").resolveJsModule("mymodule/replace/other.js"));
@@ -338,6 +333,9 @@ public final class ModuleLoaderTest extends TestCase {
     assertUri(
         "/node_modules/mymodule/with/this.js",
         loader.resolve("/foo.js").resolveJsModule("mymodule/override/relative.js"));
+    assertUri(
+        "/node_modules/mymodule/with/this.js",
+        loader.resolve("/node_modules/mymodule/client.js").resolveJsModule("./override/relative.js"));
     assertNull(
         loader.resolve("/node_modules/mymodule/client.js").resolveJsModule("./exclude/this.js"));
   }


### PR DESCRIPTION
…ts are not passed in

fixes #2625

This is going to cause conflicts with #2622 but I can take care of that later.

This is actually more prioritary because we're using `module-deps` downstream to figure out which JS files in `node_modules` to pass to Closure and it currently has basically the same problem as if browser field advanced usage wasn't implemented.