### PR TITLE
Properly report invalid source map state errors

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
@@ -243,7 +243,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer,
       this.content = new StringCharIterator(lineMap);
     }
 
-    void build() {
+    void build() throws SourceMapParseException {
       int [] temp = new int[MAX_ENTRY_VALUES];
       ArrayList<Entry> entries = new ArrayList<>();
       while (content.hasNext()) {
@@ -309,7 +309,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer,
      * @param entryValues The number of entries in the array.
      * @return The entry object.
      */
-    private Entry decodeEntry(int[] vals, int entryValues) {
+    private Entry decodeEntry(int[] vals, int entryValues) throws SourceMapParseException {
       Entry entry;
       switch (entryValues) {
         // The first values, if present are in the following order:
@@ -363,7 +363,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer,
           return entry;
 
         default:
-          throw new IllegalStateException(
+          throw new SourceMapParseException(
               "Unexpected number of values for entry:" + entryValues);
       }
     }


### PR DESCRIPTION
Invalid source maps in client code could crash the compiler. Simply changing the exception type thrown for this case is all that was needed to leverage exiting error handling.