### PR TITLE
Fixed maven not cleaning generated sources

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -202,6 +202,20 @@
       </plugin>
 
       <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>target</directory>
+            </fileset>
+            <fileset>
+              <directory>gen/target</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
           <version>2.19.1</version>
         </plugin>


### PR DESCRIPTION
Executing `mvn clean` will now properly delete  the `gen/target` directory.  
(I had problems with IntelliJ Idea due to old files duplicating this way.)