### PR TITLE
Hoist rewritten function expressions to the top of the block

### DIFF
--- a/src/com/google/javascript/jscomp/FunctionToBlockMutator.java
+++ b/src/com/google/javascript/jscomp/FunctionToBlockMutator.java
@@ -21,11 +21,13 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.javascript.jscomp.FunctionArgumentInjector.THIS_MARKER;
 
+import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.javascript.jscomp.MakeDeclaredNamesUnique.InlineRenamer;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -166,7 +168,7 @@ class FunctionToBlockMutator {
   /**
    * @param n The node to inspect
    */
-  private static void rewriteFunctionDeclarations(Node n) {
+  private static Node rewriteFunctionDeclarations(Node n) {
     if (n.isFunction()) {
       if (NodeUtil.isFunctionDeclaration(n)) {
         // Rewrite: function f() {} ==> var f = function() {}
@@ -180,14 +182,31 @@ class FunctionToBlockMutator {
         n.replaceWith(var);
         // readd the function as a function expression
         name.addChildToFront(n);
+
+        return var;
       }
-      return;
+      return null;
     }
 
+    // Keep track of any rewritten functions and hoist them to the top
+    // of the block they are defined in. This isn't fully compliant hoisting
+    // but it does address a large set of use cases.
+    List<Node> functionsToHoist = new ArrayList<>();
     for (Node c = n.getFirstChild(), next; c != null; c = next) {
       next = c.getNext(); // We may rewrite "c"
-      rewriteFunctionDeclarations(c);
+      Node fnExpr = rewriteFunctionDeclarations(c);
+      if (fnExpr != null) {
+        functionsToHoist.add(0, fnExpr);
+      }
     }
+
+    for (Node fnExpr : functionsToHoist) {
+      if (n.getFirstChild() != fnExpr) {
+        n.addChildToFront(fnExpr.detach());
+      }
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
When using the FunctionToBlockMutator, any nested functions are rewritten to an expression. However they are not currently hoisted. Proper hoisting would be difficult in this case, but we can at least move them to the top of the defining block.