### PR TITLE
Restore ES6 module processing of input

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1785,6 +1785,11 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
         if (!inputsToRewrite.isEmpty()) {
           forceToEs6Modules(inputsToRewrite.values());
         }
+
+        if (options.needsTranspilationFrom(FeatureSet.ES6_MODULES)) {		
+          processEs6Modules(parsePotentialModules(inputs));		
+        }
+
       } else {
         // Use an empty module loader if we're not actually dealing with modules.
         this.moduleLoader = ModuleLoader.EMPTY;
@@ -2029,6 +2034,20 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       Es6RewriteModules moduleRewriter = new Es6RewriteModules(this);
       moduleRewriter.forceToEs6Module(root);
     }
+  }
+
+  void processEs6Modules(List<CompilerInput> inputsToProcess) {		
+    for (CompilerInput input : inputsToProcess) {		
+      input.setCompiler(this);		
+      Node root = input.getAstRoot(this);		
+      if (root == null) {		
+        continue;		
+      }		
+      if (Es6RewriteModules.isEs6ModuleRoot(root)) {		
+        new Es6RewriteModules(this).processFile(root);		
+      }		
+    }		
+    setFeatureSet(featureSet.without(Feature.MODULES));		
   }
 
   private List<CompilerInput> parsePotentialModules(List<CompilerInput> inputsToProcess) {

--- a/src/com/google/javascript/jscomp/Es6RewriteModules.java
+++ b/src/com/google/javascript/jscomp/Es6RewriteModules.java
@@ -142,7 +142,7 @@ public final class Es6RewriteModules extends AbstractPostOrderCallback
   /**
    * Rewrite a single ES6 module file to a global script version.
    */
-  private void processFile(Node root) {
+  public void processFile(Node root) {
     checkArgument(isEs6ModuleRoot(root), root);
     clearState();
     NodeTraversal.traverseEs6(compiler, root, this);


### PR DESCRIPTION
With this I am proposing a fix to a problem we have been having when integrating Angular builds with versions of Closure Compiler > 20170409.0.0. 

It appears that Input processing of ES6 modules was removed in the following commit: https://github.com/google/closure-compiler/commit/d24d175572ebf97b06e480f04c3f452bb6355afa

Putting parts of this back fixes the issue.

The test repo for this can be found here: https://github.com/angular/closure-demo

Some of the input files in the flag file are written in ES6 JavaScript (all the Angular bundles). 

With the current release of CC the ES6 input files are not resolved. The compilation fails with errors messages like: 
```
ERROR - required "module$$angular$core" namespace never provided
import * as import0 from '@angular/core';
```
cc: @alexeagle  
