### PR TITLE
Fix for ambiguous import resolution during AOT ngfactory file compilation

### DIFF
--- a/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/NodeModuleResolver.java
@@ -147,10 +147,9 @@ public class NodeModuleResolver extends ModuleResolver {
   public String resolveJsModule(
       String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
     String loadAddress;
-    if (ModuleLoader.isAbsoluteIdentifier(moduleAddress)
-        || ModuleLoader.isRelativeIdentifier(moduleAddress)) {
-      loadAddress = resolveJsModuleNodeFileOrDirectory(scriptAddress, moduleAddress);
-    } else {
+    // Try resolveJsModuleNodeFileOrDirectory first, if not resolved then try resolveJsModuleFromRegistry
+    loadAddress = resolveJsModuleNodeFileOrDirectory(scriptAddress, moduleAddress);
+    if (loadAddress == null) {
       loadAddress = resolveJsModuleFromRegistry(scriptAddress, moduleAddress);
     }
 


### PR DESCRIPTION
This fixes an issue with ambiguous import resolution that can come up when compiling `ngfactory` files with ambiguous import statements that are generated by the Angular ngc compiler for AOT.

//cc @alexeagle 

The issue was seen on the repo https://github.com/gregmagolan/abc-demo-build-with-aot-universal. To reproduce with the current closure-compiler HEAD, one additional patch to CompilerInput.java is needed to get the abc-demo-build-with-aot-universal build to work (as seen in this commit https://github.com/gregmagolan/closure-compiler/commit/5f21b3bbdc37572122dd030583043c24020a9f3d). PR #2641, which has not been merged yet, resolves the need for this additional patch so its not included in the PR for that reason.

The compiler error seen is:

```
./closure-bin/src/browser/app/app.component.ngfactory.closure.js:4: ERROR - Failed to load module "src/browser/app/app.component.closure"
import * as i3 from 'src/browser/app/app.component.closure';
^
```

The import `'src/browser/app/app.component.closure'` is ambiguous so the current HEAD doesn't attempt to resolve using `resolveJsModuleNodeFileOrDirectory`. The fix is to try `resolveJsModuleNodeFileOrDirectory` first for all import types (absolute, relative and ambiguous) and then `resolveJsModuleFromRegistry` if the first doesn't resolve.

To reproduce, you can point `package.json` in `abc-demo-build-with-aot-universal` to a closure build from https://github.com/gregmagolan/closure-compiler/tree/angular-closure-fixes.

```
    "build:browser:closure": "yarn build:closure-bin && java -jar <patch to compiler>/compiler.jar --flagfile closure.browser.conf",
```

Undo the patch in NodeModuleResolver.java from https://github.com/gregmagolan/closure-compiler/tree/angular-closure-fixes and you should see the above compile error.
