### PR TITLE
Fix arity of setInterval and setImmediate.

### DIFF
--- a/externs/browser/window.js
+++ b/externs/browser/window.js
@@ -172,20 +172,22 @@ function prompt(message, opt_value) {}
 
 /**
  * @param {function()} callback
+ * @param {...*} var_args
  * @return {number}
  * @see https://developer.mozilla.org/en-US/docs/DOM/window.setImmediate
  * @see http://msdn.microsoft.com/en-us/library/ie/hh773176(v=vs.85).aspx
  */
-function setImmediate(callback) {}
+function setImmediate(callback, var_args) {}
 
 /**
  * @param {Function|string} callback
  * @param {number=} opt_delay
+ * @param {...*} var_args
  * @return {number}
  * @see https://developer.mozilla.org/en/DOM/window.setInterval
  * @see https://html.spec.whatwg.org/multipage/webappapis.html#timers
  */
-function setInterval(callback, opt_delay) {}
+function setInterval(callback, opt_delay, var_args) {}
 
 /**
  * @param {Function|string} callback


### PR DESCRIPTION
setInterval() and setImmediate(), like setTimeout(), take a fixed
number of mandatory arguments, and, if other arguments are present
after them, they are passed to the handler when it is called.

See https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
and https://w3c.github.io/setImmediate/#si-setImmediate

The current externs definition of setTimeout is correct in this regard.
But this is not the case for the definitions of setInterval/setImmediate.
This commit fixes that.