### PR TITLE
Robust source map resolver (prevent exception when source map contains invalid entry)

### DIFF
--- a/src/com/google/javascript/jscomp/SourceMapResolver.java
+++ b/src/com/google/javascript/jscomp/SourceMapResolver.java
@@ -15,6 +15,7 @@
  */
 package com.google.javascript.jscomp;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
@@ -22,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 /** Utility class for resolving source maps and files referenced in source maps. */
@@ -69,8 +71,10 @@ public class SourceMapResolver {
    */
   @Nullable
   static SourceFile getRelativePath(String baseFilePath, String relativePath) {
-    return SourceFile.fromPath(
-        FileSystems.getDefault().getPath(baseFilePath).resolveSibling(relativePath).normalize(),
-        StandardCharsets.UTF_8);
+    Path sourceFilePath = FileSystems.getDefault().getPath(baseFilePath).resolveSibling(relativePath).normalize();
+    if (isNullOrEmpty(sourceFilePath.toString())) {
+      return null;
+    }
+    return SourceFile.fromPath(sourceFilePath, StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
Change prevents exception in SourceMapResolver when there is an invalid entry in the source map such as `"../../"` seen here https://github.com/angular/closure-demo/issues/25.


