### PR TITLE
Don't warn about goog.base calls in a Class if its not related

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessClosurePrimitives.java
+++ b/src/com/google/javascript/jscomp/ProcessClosurePrimitives.java
@@ -720,11 +720,6 @@ class ProcessClosurePrimitives extends AbstractPostOrderCallback
     // Most of the logic here is just to make sure the AST's
     // structure is what we expect it to be.
 
-    if (baseUsedInClass(n)){
-      reportBadGoogBaseUse(t, n, "goog.base in ES6 class is not allowed. Use super instead.");
-      return;
-    }
-
     Node callTarget = n.getFirstChild();
     Node baseContainerNode = callTarget.getFirstChild();
     if (!baseContainerNode.isUnscopedQualifiedName()) {
@@ -740,7 +735,20 @@ class ProcessClosurePrimitives extends AbstractPostOrderCallback
       if (knownClosureSubclasses.contains(baseContainer)) {
         reportBadBaseMethodUse(t, n, baseContainer,
             "Could not find enclosing method.");
+      } else if (baseUsedInClass(n)) {
+        Node clazz = NodeUtil.getEnclosingClass(n);
+        if ((clazz.getFirstChild().isName()
+                && clazz.getFirstChild().getString().equals(baseContainer))
+            || (clazz.getSecondChild().isName()
+            && clazz.getSecondChild().getString().equals(baseContainer))) {
+          reportBadGoogBaseUse(t, n, "goog.base in ES6 class is not allowed. Use super instead.");
+        }
       }
+      return;
+    }
+
+    if (baseUsedInClass(n)){
+      reportBadGoogBaseUse(t, n, "goog.base in ES6 class is not allowed. Use super instead.");
       return;
     }
 

--- a/test/com/google/javascript/jscomp/ProcessClosurePrimitivesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessClosurePrimitivesTest.java
@@ -1338,4 +1338,8 @@ public final class ProcessClosurePrimitivesTest extends CompilerTestCase {
     testError("var CLOSURE_DEFINES = {'TEMPLATE': `template`};", CLOSURE_DEFINES_ERROR);
     testError("var CLOSURE_DEFINES = {'TEMPLATE': `${template}Sub`};", CLOSURE_DEFINES_ERROR);
   }
+
+  public void testOtherBaseCall() {
+    testSame("class Foo extends BaseFoo { method() { baz.base('arg'); } }");
+  }
 }


### PR DESCRIPTION
Warnings were being raised when calling any method named "base" on an object in an ES6 class. This restricts the warning down to just cases where the base object is the class name or the extends name.