### PR TITLE
If a commonjs module import cannot be located, provide a fallback

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
+++ b/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
@@ -178,6 +178,7 @@ jsdoc.suppressions =\
     missingProvide,\
     missingRequire,\
     missingReturn,\
+    moduleLoad,\
     newCheckTypes,\
     newCheckTypesAllChecks,\
     nonStandardJsDocs,\

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -941,5 +941,20 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
 
   public void testMissingRequire() {
     ModulesTestUtils.testModulesError(this, "require('missing');", ModuleLoader.LOAD_WARNING);
+
+    testModules(
+        "test.js",
+        lines(
+            "/**",
+            " * @fileoverview",
+            " * @suppress {moduleLoad}",
+            " */",
+            "var foo = require('missing');"),
+        lines(
+            "/**",
+            " * @fileoverview",
+            " * @suppress {moduleLoad}",
+            " */",
+            "var foo = module$missing;"));
   }
 }


### PR DESCRIPTION
If a `require(path)` call cannot be located by the module loader, provide a fallback module name so that the require call is still rewritten. Useful for per-file rewriting for analysis.