### PR TITLE
At the top of every bundle, print all defines, if any

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -41,6 +41,7 @@ import com.google.javascript.jscomp.CompilerOptions.OutputJs;
 import com.google.javascript.jscomp.CompilerOptions.TweakProcessing;
 import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.jscomp.deps.SourceCodeEscapers;
+import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.TokenStream;
 import com.google.protobuf.CodedOutputStream;
@@ -69,6 +70,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.zip.ZipEntry;
@@ -2008,6 +2010,18 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   @VisibleForTesting
   void printBundleTo(Iterable<CompilerInput> inputs, Appendable out)
       throws IOException {
+
+    // First, print all defines passed in
+    Set<Entry<String, Node>> defines = compiler.getOptions().getDefineReplacements().entrySet();
+    if (!defines.isEmpty()) {
+      Node[] defineNodes = defines.stream()
+              .map((entry) -> IR.propdef(IR.stringKey(entry.getKey()), entry.getValue()))
+              .toArray(Node[]::new);
+
+      Node wrapper = IR.objectlit(defineNodes);
+      Node assign = IR.assign(IR.getprop(IR.thisNode(), IR.string("CLOSURE_UNCOMPILED_DEFINES")), wrapper);
+      out.append(new CodePrinter.Builder(assign).setPrettyPrint(true).build());
+    }
 
     for (CompilerInput input : inputs) {
       // Every module has an empty file in it. This makes it easier to implement


### PR DESCRIPTION
When in `--compilationLevel=BUNDLE`, any `--define` flags are ignored, and the output may not be helpful to run in a browser. In particular, `goog.ENABLE_DEBUG_LOADER=false` seems necessary for BUNDLE to make sense, but other defines can be helpful as well.