### PR TITLE
General use of persistent input store

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -632,12 +632,12 @@ public abstract class AbstractCompiler implements SourceExcerptProvider {
 
   private @Nullable PersistentInputStore persistentInputStore;
 
-  void setPersistentInputStore(PersistentInputStore persistentInputStore) {
+  public void setPersistentInputStore(PersistentInputStore persistentInputStore) {
     this.persistentInputStore = persistentInputStore;
   }
 
   @Nullable
-  PersistentInputStore getPersistentInputStore() {
+  public PersistentInputStore getPersistentInputStore() {
     return persistentInputStore;
   }
 }

--- a/src/com/google/javascript/jscomp/PersistentInputStore.java
+++ b/src/com/google/javascript/jscomp/PersistentInputStore.java
@@ -93,9 +93,9 @@ public class PersistentInputStore {
   public CompilerInput getCachedCompilerInput(SourceFile source) {
     String originalPath = source.getOriginalPath();
     // For zip files.
-    if (originalPath.contains(".js.zip!/")) {
-      int indexOf = originalPath.indexOf(".js.zip!/");
-      String zipPath = originalPath.substring(0, indexOf + ".js.zip".length());
+    if (originalPath.contains(".zip!/")) {
+      int indexOf = originalPath.indexOf(".zip!/");
+      String zipPath = originalPath.substring(0, indexOf + ".zip".length());
       Preconditions.checkState(store.containsKey(zipPath));
       return store.get(zipPath).getCachedZipEntry(source);
     }


### PR DESCRIPTION
Allow this newly added class to be used from other packages, instead of requiring that all tool authors write code in `com.google...` packages. Additionally, rather than assume that only `--jszip` params which end with ".js.zip" might be persistent, allow any ".zip" file (as `--jszip` itself does, via `setMixedJsSources()`).