### PR TITLE
Add the ability to output compiler error information in a JSON format

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -439,6 +439,12 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     options.angularPass = config.angularPass;
     options.setNewTypeInference(config.useNewTypeInference);
     options.instrumentationTemplateFile = config.instrumentationTemplateFile;
+
+    if (config.errorFormat == CommandLineConfig.ErrorFormatOption.JSON) {
+      PrintStreamJSONErrorManager printer =
+          new PrintStreamJSONErrorManager(getErrorPrintStream(), compiler);
+      compiler.setErrorManager(printer);
+    }
   }
 
   protected final A getCompiler() {
@@ -2681,6 +2687,18 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       return this;
     }
 
+    /** Set of options that can be used with the --formatting flag. */
+    protected enum ErrorFormatOption {
+      STANDARD,
+      JSON
+    }
+
+    private ErrorFormatOption errorFormat = ErrorFormatOption.STANDARD;
+
+    public CommandLineConfig setErrorFormat(ErrorFormatOption errorFormat) {
+      this.errorFormat = errorFormat;
+      return this;
+    }
   }
 
   /**

--- a/src/com/google/javascript/jscomp/BasicErrorManager.java
+++ b/src/com/google/javascript/jscomp/BasicErrorManager.java
@@ -35,7 +35,7 @@ import java.util.Set;
  *
  */
 public abstract class BasicErrorManager implements ErrorManager {
-  private final PriorityQueue<ErrorWithLevel> messages =
+  protected final PriorityQueue<ErrorWithLevel> messages =
       new PriorityQueue<>(1, new LeveledJSErrorComparator());
   private final Set<ErrorWithLevel> alreadyAdded = new HashSet<>();
   private int errorCount = 0;

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.io.Files;
+import com.google.javascript.jscomp.AbstractCommandLineRunner.CommandLineConfig.ErrorFormatOption;
 import com.google.javascript.jscomp.CompilerOptions.IsolationMode;
 import com.google.javascript.jscomp.SourceMap.LocationMapping;
 import com.google.javascript.jscomp.deps.ModuleLoader;
@@ -790,6 +791,9 @@ public class CommandLineRunner extends
     )
     private String packageJsonEntryNames = null;
 
+    @Option(name = "--error_format", usage = "Specifies format for error messages.")
+    private ErrorFormatOption errorFormat = ErrorFormatOption.STANDARD;
+
     @Option(name = "--renaming",
         handler = BooleanOptionHandler.class,
         usage = "Disables variable renaming. Cannot be used with ADVANCED optimizations.")
@@ -833,6 +837,7 @@ public class CommandLineRunner extends
                 "Warning and Error Management",
                 ImmutableList.of(
                     "conformance_configs",
+                    "error_format",
                     "extra_annotation_name",
                     "hide_warnings_for",
                     "jscomp_error",
@@ -1615,7 +1620,8 @@ public class CommandLineRunner extends
           .setAngularPass(flags.angularPass)
           .setInstrumentationTemplateFile(flags.instrumentationFile)
           .setNewTypeInference(flags.useNewTypeInference)
-          .setJsonStreamMode(flags.jsonStreamMode);
+          .setJsonStreamMode(flags.jsonStreamMode)
+          .setErrorFormat(flags.errorFormat);
     }
     errorStream = null;
   }

--- a/src/com/google/javascript/jscomp/PrintStreamJSONErrorManager.java
+++ b/src/com/google/javascript/jscomp/PrintStreamJSONErrorManager.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import com.google.common.annotations.GwtIncompatible;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
+import com.google.gson.stream.JsonWriter;
+import com.google.javascript.jscomp.LightweightMessageFormatter.LineNumberingFormatter;
+import com.google.javascript.jscomp.SourceExcerptProvider.SourceExcerpt;
+import com.google.javascript.jscomp.parsing.parser.util.format.SimpleFormat;
+import com.google.javascript.rhino.TokenUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An error manager that prints error and warning data to the print stream as an array of JSON
+ * objects provided in addition to the functionality of the {@link BasicErrorManager}.
+ */
+public class PrintStreamJSONErrorManager extends BasicErrorManager {
+  private final PrintStream stream;
+  private final SourceExcerptProvider sourceExcerptProvider;
+  private static final LineNumberingFormatter excerptFormatter = new LineNumberingFormatter();
+
+  /**
+   * Creates an error manager.
+   *
+   * @param stream the stream on which the errors and warnings should be printed. This class does
+   *     not close the stream
+   * @param sourceExcerptProvider used to retrieve the source context which generated the error
+   */
+  public PrintStreamJSONErrorManager(
+      PrintStream stream, SourceExcerptProvider sourceExcerptProvider) {
+    this.stream = stream;
+    this.sourceExcerptProvider = sourceExcerptProvider;
+  }
+
+  @Override
+  @GwtIncompatible
+  public void generateReport() {
+    ByteArrayOutputStream bufferedStream = new ByteArrayOutputStream();
+    List<ErrorWithLevel> list = new ArrayList<>();
+    try (JsonWriter jsonWriter = new JsonWriter(new OutputStreamWriter(bufferedStream, "UTF-8"))) {
+      jsonWriter.beginArray();
+      for (ErrorWithLevel message = messages.poll(); message != null; message = messages.poll()) {
+        String sourceName = message.error.sourceName;
+        int lineNumber = message.error.getLineNumber();
+        int charno = message.error.getCharno();
+
+        jsonWriter.beginObject();
+        jsonWriter.name("level").value(message.level == CheckLevel.ERROR ? "error" : "warning");
+        jsonWriter.name("description").value(message.error.description);
+        jsonWriter.name("source").value(sourceName);
+        jsonWriter.name("line").value(lineNumber);
+        jsonWriter.name("column").value(charno);
+
+        // extract source excerpt
+        String sourceExcerpt =
+            SourceExcerpt.LINE.get(sourceExcerptProvider, sourceName, lineNumber, excerptFormatter);
+        if (sourceExcerpt != null) {
+          StringBuilder b = new StringBuilder(sourceExcerpt);
+          b.append("\n");
+
+          // padding equal to the excerpt and arrow at the end
+          // charno == sourceExcerpt.length() means something is missing
+          // at the end of the line
+          if (0 <= charno && charno <= sourceExcerpt.length()) {
+            for (int i = 0; i < charno; i++) {
+              char c = sourceExcerpt.charAt(i);
+              if (TokenUtil.isWhitespace(c)) {
+                b.append(c);
+              } else {
+                b.append(' ');
+              }
+            }
+            if (message.error.node == null) {
+              b.append("^");
+            } else {
+              int length =
+                  Math.max(
+                      1, Math.min(message.error.node.getLength(), sourceExcerpt.length() - charno));
+              for (int i = 0; i < length; i++) {
+                b.append("^");
+              }
+            }
+          }
+
+          jsonWriter.name("context").value(b.toString());
+        }
+
+        OriginalMapping mapping =
+            sourceExcerptProvider.getSourceMapping(
+                sourceName, message.error.lineNumber, message.error.getCharno());
+
+        if (mapping != null) {
+          jsonWriter.name("originalLocation").beginObject();
+          jsonWriter.name("source").value(mapping.getOriginalFile());
+          jsonWriter.name("line").value(mapping.getLineNumber());
+          jsonWriter.name("column").value(mapping.getColumnPosition());
+          jsonWriter.endObject();
+        }
+
+        jsonWriter.endObject();
+        list.add(message);
+      }
+
+      StringBuilder summaryBuilder = new StringBuilder();
+      if (getTypedPercent() > 0.0) {
+        summaryBuilder.append(
+            SimpleFormat.format(
+                "%d error(s), %d warning(s), %.1f%% typed",
+                getErrorCount(), getWarningCount(), getTypedPercent()));
+      } else {
+        summaryBuilder.append(
+            SimpleFormat.format("%d error(s), %d warning(s)", getErrorCount(), getWarningCount()));
+      }
+      jsonWriter.beginObject();
+      jsonWriter.name("level").value("info");
+      jsonWriter.name("description").value(summaryBuilder.toString());
+      jsonWriter.endObject();
+
+      jsonWriter.endArray();
+      jsonWriter.flush();
+      jsonWriter.close();
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    stream.append(bufferedStream.toString());
+
+    // Restore the messages since some tests assert the values after generating the report.
+    messages.addAll(list);
+  }
+
+  // This class overrides generateReport(), so nothing will call println().
+  @Override
+  public void println(CheckLevel level, JSError error) {}
+
+  // This class overrides generateReport(), so nothing will call printSummary().
+  @Override
+  public void printSummary() {}
+}


### PR DESCRIPTION
In external command line tools, it's often preferred to receive the error information as raw data rather than a formatted string. This allows better usage of the native error reporting mechanisms in tools like Webpack.