### PR TITLE
Allow to disable renaming for the JS compiler

### DIFF
--- a/src/com/google/javascript/jscomp/gwt/client/GwtRunner.java
+++ b/src/com/google/javascript/jscomp/gwt/client/GwtRunner.java
@@ -37,9 +37,11 @@ import com.google.javascript.jscomp.DependencyOptions;
 import com.google.javascript.jscomp.DiagnosticType;
 import com.google.javascript.jscomp.JSError;
 import com.google.javascript.jscomp.ModuleIdentifier;
+import com.google.javascript.jscomp.PropertyRenamingPolicy;
 import com.google.javascript.jscomp.SourceFile;
 import com.google.javascript.jscomp.SourceMap;
 import com.google.javascript.jscomp.SourceMapInput;
+import com.google.javascript.jscomp.VariableRenamingPolicy;
 import com.google.javascript.jscomp.WarningLevel;
 import com.google.javascript.jscomp.deps.ModuleLoader.ResolutionMode;
 import com.google.javascript.jscomp.deps.SourceCodeEscapers;
@@ -97,6 +99,7 @@ public final class GwtRunner implements EntryPoint {
     boolean preserveTypeAnnotations;
     boolean processClosurePrimitives;
     boolean processCommonJsModules;
+    boolean renaming;
     public String renamePrefixNamespace;
     boolean rewritePolyfills;
     String warningLevel;
@@ -141,6 +144,7 @@ public final class GwtRunner implements EntryPoint {
     defaultFlags.processClosurePrimitives = true;
     defaultFlags.processCommonJsModules = false;
     defaultFlags.renamePrefixNamespace = null;
+    defaultFlags.renaming = true;
     defaultFlags.rewritePolyfills = true;
     defaultFlags.warningLevel = "DEFAULT";
     defaultFlags.useTypesForOptimization = true;
@@ -332,6 +336,10 @@ public final class GwtRunner implements EntryPoint {
         throw new RuntimeException(
             "Bad value for compilationLevel: " + flags.compilationLevel);
       }
+      if (level == CompilationLevel.ADVANCED_OPTIMIZATIONS && !flags.renaming) {
+        throw new RuntimeException(
+            "renaming cannot be disabled when ADVANCED_OPTMIZATIONS is used");
+      }
     }
     level.setOptionsForCompilationLevel(options);
     if (flags.assumeFunctionWrapper) {
@@ -417,6 +425,10 @@ public final class GwtRunner implements EntryPoint {
     options.setClosurePass(flags.processClosurePrimitives);
     options.setProcessCommonJSModules(flags.processCommonJsModules);
     options.setRenamePrefixNamespace(flags.renamePrefixNamespace);
+    if (flags.renaming == false) {
+      options.setVariableRenaming(VariableRenamingPolicy.OFF);
+      options.setPropertyRenaming(PropertyRenamingPolicy.OFF);
+    }
     options.setRewritePolyfills(flags.rewritePolyfills);
   }
 


### PR DESCRIPTION
Fixes https://github.com/google/closure-compiler/issues/2690.

I used the approach suggested by @ChadKillingsworth in https://github.com/google/closure-compiler/issues/2690#issuecomment-340186286, but apply it to `GwtRunner` (since I need this to be exposed in the JS version) as suggested by @anmonteiro in https://github.com/google/closure-compiler/issues/2690#issuecomment-340212450.

**This adds a new `renaming` option to the JS version.**

It defaults to `true`:

<img width="692" alt="screen shot 2017-11-07 at 4 07 33 pm" src="https://user-images.githubusercontent.com/810438/32503694-cbb36958-c3d5-11e7-920e-4520457e5541.png">

When set to `false`, it produces a build that doesn't minify variable or property names:

<img width="685" alt="screen shot 2017-11-07 at 4 06 42 pm" src="https://user-images.githubusercontent.com/810438/32503646-ad68f80a-c3d5-11e7-901c-bcdfa580c8a5.png">

It can only be set to `false` for `SIMPLE` mode. Doing so in `ADVANCED` mode throws:

<img width="1313" alt="screen shot 2017-11-07 at 4 08 21 pm" src="https://user-images.githubusercontent.com/810438/32503742-e92123d6-c3d5-11e7-8c6f-303a3e6e00b2.png">

I need this option to move React builds completely to Google Closure Compiler. I’m happy to also include changes to expose this option to Java consumers, if you’d like, but I figured it’s best to send a PR with the minimal scope.

I’m sending this PR on the individual behalf not on company time. The code belongs to me.