### PR TITLE
Recognize entry points that are specified as goog.module or provide

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1934,7 +1934,10 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       }
     }
     for (ModuleIdentifier moduleIdentifier : options.getDependencyOptions().getEntryPoints()) {
-      CompilerInput input = inputsByIdentifier.get(moduleIdentifier.toString());
+      CompilerInput input = inputsByProvide.get(moduleIdentifier.toString());
+      if (input == null) {
+        input = inputsByIdentifier.get(moduleIdentifier.toString());
+      }
       if (input != null) {
         entryPoints.add(input);
       }


### PR DESCRIPTION
When finding dependencies, recognize entry points specified in the `goog:` style.

Fixes #2692 