### PR TITLE
Add some extra checks to ES6 modules.

### DIFF
--- a/src/com/google/javascript/jscomp/NodeUtil.java
+++ b/src/com/google/javascript/jscomp/NodeUtil.java
@@ -3339,6 +3339,11 @@ public final class NodeUtil {
     return parent.isImport() || (parent.isImportSpec() && parent.getLastChild() == n);
   }
 
+  public static boolean isExportedName(Node n) {
+    Node parent = n.getParent();
+    return parent.isExport() || (parent.isExportSpec() && parent.getFirstChild() == n);
+  }
+
   /**
    * Returns true if the node is a lhs value of a destructuring assignment
    * For example,

--- a/src/com/google/javascript/jscomp/Var.java
+++ b/src/com/google/javascript/jscomp/Var.java
@@ -202,6 +202,10 @@ public class Var implements StaticSlot, StaticRef {
     return parent.getParent().isParamList() && parent.isDefaultValue()
         && parent.getFirstChild() == nameNode;
   }
+  
+  boolean isImport() { 
+    return declarationType() == Token.IMPORT; 
+  }
 
   public boolean isArguments() {
     return false;

--- a/src/com/google/javascript/jscomp/VariableReferenceCheck.java
+++ b/src/com/google/javascript/jscomp/VariableReferenceCheck.java
@@ -332,6 +332,7 @@ class VariableReferenceCheck implements HotSwapCompilerPass {
     boolean shadowCatchVar = v.getParentNode().isCatch() && !isVarNodeSameAsReferenceNode;
     boolean shadowParam = v.isParam() && NodeUtil.isBlockScopedDeclaration(referenceNode)
         && v.getScope() == reference.getScope().getParent();
+    boolean shadowsImport = v.isImport();
     boolean shadowDetected = false;
     if (!allowDupe) {
       // Look through all the declarations we've found so far, and
@@ -342,7 +343,7 @@ class VariableReferenceCheck implements HotSwapCompilerPass {
           DiagnosticType diagnosticType;
           Node warningNode = referenceNode;
           if (v.isLet() || v.isConst() || v.isClass() || letConstShadowsVar || shadowCatchVar
-              || shadowParam) {
+              || shadowParam || shadowsImport) {
             // These cases are all hard errors that violate ES6 semantics
             diagnosticType = REDECLARED_VARIABLE_ERROR;
           } else if (reference.getNode().getParent().isCatch() || allowDupe) {

--- a/test/com/google/javascript/jscomp/Es6CheckModuleTest.java
+++ b/test/com/google/javascript/jscomp/Es6CheckModuleTest.java
@@ -56,4 +56,68 @@ public final class Es6CheckModuleTest extends CompilerTestCase {
             "",
             "exports = Foo;"));
   }
+  
+  public void testCannotRenameImport() {
+    testError(
+        lines(
+            "import { p } from 'other'",
+            "p = 2;"),
+        Es6CheckModule.IMPORT_CANNOT_BE_REASSIGNED);
+
+    testSame(
+        lines(
+            "import { p } from 'other'",
+            "p.x = 2;"));
+
+    testError(
+        lines(
+            "import Default from 'other'",
+            "Default = 2;"),
+        Es6CheckModule.IMPORT_CANNOT_BE_REASSIGNED);
+
+    testSame(
+        lines(
+            "import Default from 'other'",
+            "Default.x = 2;"));
+
+    testError(
+        lines(
+            "import * as Module from 'other'",
+            "Module = 2;"),
+        Es6CheckModule.IMPORT_CANNOT_BE_REASSIGNED);
+
+    testError(
+        lines(
+            "import * as Module from 'other'",
+            "Module.x = 2;"),
+        Es6CheckModule.IMPORT_CANNOT_BE_REASSIGNED);
+
+    testSame(
+        lines(
+            "import * as Module from 'other'",
+            "Module.x.y = 2;"));
+
+
+    // Handled by VariableReferenceCheck.
+    testSame(
+        lines(
+            "import { p } from 'other'",
+            "let p = 0;"));
+    testSame(
+        lines(
+            "import { p } from 'other'",
+            "var {p} = {};"));
+    testSame(
+        lines(
+            "import { p } from 'other'",
+            "var [p] = [];"));
+    testSame(
+        lines(
+            "import { p } from 'other'",
+            "function p() {};"));
+    testSame(
+        lines(
+            "import { p } from 'other'",
+            "class p {};"));
+  }
 }

--- a/test/com/google/javascript/jscomp/VariableReferenceCheckTest.java
+++ b/test/com/google/javascript/jscomp/VariableReferenceCheckTest.java
@@ -1175,6 +1175,28 @@ public final class VariableReferenceCheckTest extends CompilerTestCase {
     testSame("export let x = 1; for (let y of [x]);");
   }
 
+  public void testRedeclareVariableFromImport() {
+    assertRedeclareError(lines("import {x} from 'whatever';", "let x = 0;"));
+    assertRedeclareError(lines("import {x} from 'whatever';", "const x = 0;"));
+    assertRedeclareError(lines("import {x} from 'whatever';", "var x = 0;"));
+    assertRedeclareError(lines("import {x} from 'whatever';", "function x() {}"));
+    assertRedeclareError(lines("import {x} from 'whatever';", "class x {}"));
+
+    assertRedeclareError(lines("import x from 'whatever';", "let x = 0;"));
+
+    assertRedeclareError(lines("import {y as x} from 'whatever';", "let x = 0;"));
+
+    assertRedeclareError(lines("import {x} from 'whatever';", "let {x} = {};"));
+
+    assertRedeclareError(lines("import {x} from 'whatever';", "let [x] = [];"));
+
+    testSame(lines(
+        "import {x} from 'whatever';",
+        "function f() { ",
+        "  let x = 0;",
+        "}"));
+  }
+
   /**
    * Expects the JS to generate one bad-read error.
    */


### PR DESCRIPTION
- Check for reassigning imports.
- Check for redeclaring imported variables.
- Check for mutated exports outside of top level scope (not supported yet).

Closes #2713