### PR TITLE
Support proper interop between CommonJS and ES6 modules

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -591,6 +591,9 @@ public abstract class AbstractCompiler implements SourceExcerptProvider {
    */
   abstract ModuleLoader getModuleLoader();
 
+  /** Lookup the type of a module from its name. */
+  abstract CompilerInput.ModuleType getModuleTypeByName(String moduleName);
+
   /**
    * Sets an annotation for the given key.
    *

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -140,8 +140,8 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   // The JS source inputs
   private List<CompilerInput> inputs;
 
-  // The JS source inputs
-  private Map<String, CompilerInput.ModuleType> moduleTypesByName;
+  // Map of module names to module types - used for module rewriting
+  private final Map<String, CompilerInput.ModuleType> moduleTypesByName;
 
   // error manager to which error management is delegated
   private ErrorManager errorManager;

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -140,6 +140,9 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   // The JS source inputs
   private List<CompilerInput> inputs;
 
+  // The JS source inputs
+  private Map<String, CompilerInput.ModuleType> moduleTypesByName;
+
   // error manager to which error management is delegated
   private ErrorManager errorManager;
 
@@ -290,6 +293,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   public Compiler(PrintStream outStream) {
     addChangeHandler(recentChange);
     this.outStream = outStream;
+    this.moduleTypesByName = new HashMap<>();
   }
 
   /**
@@ -1986,6 +1990,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     if (wasImportedByModule && input.getJsModuleType() == CompilerInput.ModuleType.NONE) {
       input.setJsModuleType(CompilerInput.ModuleType.IMPORTED_SCRIPT);
     }
+    this.moduleTypesByName.put(input.getPath().toModuleName(), input.getJsModuleType());
 
     for (String requiredNamespace : input.getRequires()) {
       CompilerInput requiredInput = null;
@@ -2141,6 +2146,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       input.setCompiler(this);
       // Call getRequires to force regex-based dependency parsing to happen.
       input.getRequires();
+      input.setJsModuleType(CompilerInput.ModuleType.ES6);
     }
     return filteredInputs;
   }
@@ -3696,5 +3702,12 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     for (CompilerInput input : this.externs) {
       input.reset();
     }
+  }
+
+  /** Returns the module type for the provided namespace. */
+  @Override
+  @Nullable
+  CompilerInput.ModuleType getModuleTypeByName(String moduleName) {
+    return moduleTypesByName.get(moduleName);
   }
 }

--- a/src/com/google/javascript/jscomp/CompilerInput.java
+++ b/src/com/google/javascript/jscomp/CompilerInput.java
@@ -519,6 +519,7 @@ public class CompilerInput implements SourceAst, DependencyInfo {
     this.ast.clearAst();
   }
 
+  /** JavaScript module type. */
   public enum ModuleType {
     NONE,
     GOOG,

--- a/src/com/google/javascript/jscomp/CompilerInput.java
+++ b/src/com/google/javascript/jscomp/CompilerInput.java
@@ -519,7 +519,7 @@ public class CompilerInput implements SourceAst, DependencyInfo {
     this.ast.clearAst();
   }
 
-  enum ModuleType {
+  public enum ModuleType {
     NONE,
     GOOG,
     ES6,

--- a/src/com/google/javascript/jscomp/FunctionToBlockMutator.java
+++ b/src/com/google/javascript/jscomp/FunctionToBlockMutator.java
@@ -71,19 +71,33 @@ class FunctionToBlockMutator {
   }
 
   /**
-   * Used when an IIFE wrapper is being removed
+   * Used where the inlining occurs into an isolated scope such as a module. Renaming is avoided
+   * since the associated JSDoc annotations are not updated.
    *
    * @param fnName The name to use when preparing human readable names.
    * @param fnNode The function to prepare.
    * @param callNode The call node that will be replaced.
-   * @return A clone of the function body mutated to be suitable for injection as a statement into a
-   *     script root
+   * @param resultName Function results should be assigned to this name.
+   * @param needsDefaultResult Whether the result value must be set.
+   * @param isCallInLoop Whether the function body must be prepared to be injected into the body of
+   *     a loop.
+   * @return A clone of the function body mutated to be suitable for injection as a statement into
+   *     another code block.
    */
-  Node unwrapIifeInModule(String fnName, Node fnNode, Node callNode) {
-    return mutateInternal(fnName, fnNode, callNode,
-        /* resultName */ null,
-        /* needsDefaultResult */ false,
-        /* isCallInLoop */ false,
+  Node mutateWithoutRenaming(
+      String fnName,
+      Node fnNode,
+      Node callNode,
+      String resultName,
+      boolean needsDefaultResult,
+      boolean isCallInLoop) {
+    return mutateInternal(
+        fnName,
+        fnNode,
+        callNode,
+        resultName,
+        needsDefaultResult,
+        isCallInLoop,
         /* renameLocals */ false);
   }
 

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -44,7 +44,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
   private static final String EXPORTS = "exports";
   private static final String MODULE = "module";
   private static final String REQUIRE = "require";
-  private static final String exportPropertyName = "default";
+  private static final String EXPORT_PROPERTY_NAME = "default";
 
   public static final DiagnosticType UNKNOWN_REQUIRE_ENSURE =
       DiagnosticType.warning(
@@ -155,7 +155,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       return moduleName;
     }
 
-    return moduleName + "." + exportPropertyName;
+    return moduleName + "." + EXPORT_PROPERTY_NAME;
   }
 
   /**
@@ -652,7 +652,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       builder.recordConstancy();
       initModule.setJSDocInfo(builder.build());
       if (directAssignments == 0) {
-        Node defaultProp = IR.stringKey(exportPropertyName);
+        Node defaultProp = IR.stringKey(EXPORT_PROPERTY_NAME);
         defaultProp.addChildToFront(IR.objectlit());
         initModule.getFirstFirstChild().addChildToFront(defaultProp);
         builder = new JSDocInfoBuilder(true);
@@ -1164,7 +1164,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
         return;
       }
 
-      moduleName = moduleName + "." + exportPropertyName;
+      moduleName = moduleName + "." + EXPORT_PROPERTY_NAME;
 
       Node updatedExport =
           NodeUtil.newQName(compiler, moduleName, export.node, export.node.getQualifiedName());
@@ -1279,7 +1279,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
           visitExport(t, newExport);
         } else {
           String moduleName = getModuleName(t.getInput());
-          Var moduleVar = t.getScope().getVar(moduleName + "." + exportPropertyName);
+          Var moduleVar = t.getScope().getVar(moduleName + "." + EXPORT_PROPERTY_NAME);
           Node defaultProp = null;
           if (moduleVar == null) {
             moduleVar = t.getScope().getVar(moduleName);
@@ -1288,7 +1288,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
                 && moduleVar.getNode().getFirstChild().isObjectLit()) {
               defaultProp =
                   NodeUtil.getFirstPropMatchingKey(
-                      moduleVar.getNode().getFirstChild(), exportPropertyName);
+                      moduleVar.getNode().getFirstChild(), EXPORT_PROPERTY_NAME);
             }
           } else if (moduleVar.getNode().getFirstChild() != null
               && moduleVar.getNode().getFirstChild().isObjectLit()) {

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -1106,7 +1106,6 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
      * module. By this point all references to the import alias should have already been renamed.
      */
     private void visitRequireCall(NodeTraversal t, Node require, Node parent) {
-      String requireName = getCommonJsImportPath(require);
       String moduleName = getImportedModuleName(t, require);
       Node moduleRef =
           NodeUtil.newQName(compiler, getBasePropertyImport(moduleName))
@@ -1181,7 +1180,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
           && rValue != null
           && export.scope.getVar("module.exports") == null
           && root.getParent().isAssign()) {
-        if (root.getParent().getParent().isExprResult() && moduleInitialization == null) {
+        if (root.getGrandparent().isExprResult() && moduleInitialization == null) {
           // Rewrite "module.exports = foo;" to "var moduleName = foo;"
           Node parent = root.getParent();
           Node exportName = IR.exprResult(IR.assign(updatedExport, rValue.detach()));

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -81,8 +81,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       FindImportsAndExports finder = new FindImportsAndExports();
       NodeTraversal.traverseEs6(compiler, n, finder);
 
-      CompilerInput.ModuleType moduleType =
-          compiler.getModuleTypeByName(getModuleName(compiler.getInput(n.getInputId())));
+      CompilerInput.ModuleType moduleType = compiler.getInput(n.getInputId()).getJsModuleType();
 
       boolean forceModuleDetection = moduleType == CompilerInput.ModuleType.IMPORTED_SCRIPT;
       boolean defaultExportIsConst = true;

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -1169,8 +1169,8 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
           NodeUtil.newQName(compiler, moduleName, export.node, export.node.getQualifiedName());
       boolean exportIsConst =
           defaultExportIsConst
-              && getBasePropertyImport(getModuleName(t.getInput()))
-                  .equals(updatedExport.getQualifiedName())
+              && updatedExport.matchesQualifiedName(
+                  getBasePropertyImport(getModuleName(t.getInput())))
               && root == export.node
               && NodeUtil.isLValue(export.node);
 

--- a/src/com/google/javascript/rhino/IR.java
+++ b/src/com/google/javascript/rhino/IR.java
@@ -636,6 +636,10 @@ public class IR {
     return new Node(Token.NULL);
   }
 
+  public static Node typeof(Node expr) {
+    return unaryOp(Token.TYPEOF, expr);
+  }
+
   // helper methods
 
   private static Node binaryOp(Token token, Node expr1, Node expr2) {

--- a/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
@@ -30,12 +30,12 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join("/** @constructor */ function Hello() {}", "module.exports = Hello;"),
-          LINE_JOINER.join("var Hello = require('./i0');", "var hello = new Hello();")
+          "/** @constructor */ function Hello() {} module.exports = Hello;",
+          "var Hello = require('./i0'); var hello = new Hello();"
         },
         new String[] {
-          "var module$i0 = function (){};",
-          LINE_JOINER.join("var Hello = module$i0;", "var hello = new module$i0();")
+          "/** @const */ var module$i0 = {}; /** @const */ module$i0.default = function (){};",
+          LINE_JOINER.join("var Hello = module$i0.default;", "var hello = new module$i0.default();")
         });
   }
 
@@ -59,20 +59,21 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
             "/** @type {!Hello} */ var hello = new Hello();",
             "module.exports = Hello;"),
         LINE_JOINER.join(
-            "var module$i0 = function () {};", "var hello$$module$i0 = new module$i0();"));
+            "/** @const */ var module$i0 = {};",
+            "module$i0.default = function () {};",
+            "var hello$$module$i0 = new module$i0.default();"));
   }
 
   public void testCrossModuleTypeAnnotation2() {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join("/** @constructor */ function Hello() {}", "module.exports = Hello;"),
-          LINE_JOINER.join(
-              "var Hello = require('./i0');", "/** @type {!Hello} */ var hello = new Hello();")
+          "/** @constructor */ function Hello() {} module.exports = Hello;",
+          "var Hello = require('./i0'); /** @type {!Hello} */ var hello = new Hello();"
         },
         new String[] {
-          "var module$i0 = function() {};",
-          LINE_JOINER.join("var Hello = module$i0;", "var hello = new module$i0();")
+          "/** @const */ var module$i0 = {}; /** @const */ module$i0.default = /** @constructor */ function() {};",
+          "var Hello = module$i0.default; var hello = new module$i0.default();"
         });
   }
 
@@ -80,82 +81,10 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join("/** @constructor */ function Hello() {}", "module.exports = Hello;"),
-          LINE_JOINER.join("var Hello = require('./i0');", "/** @type {!Hello} */ var hello = 1;")
+          "/** @constructor */ function Hello() {} module.exports = Hello;",
+          "var Hello = require('./i0'); /** @type {!Hello} */ var hello = 1;"
         },
         TypeValidator.TYPE_MISMATCH_WARNING);
-  }
-
-  public void testMultipleExportAssignments1() {
-    test(
-        createCompilerOptions(),
-        new String[] {
-          LINE_JOINER.join(
-              "/** @constructor */ function Hello() {}",
-              "module.exports = Hello;",
-              "/** @constructor */ function Bar() {}",
-              "Bar.prototype.foobar = function() { alert('foobar'); };",
-              "module.exports = Bar;"),
-          LINE_JOINER.join(
-              "var Foobar = require('./i0');", "var show = new Foobar();", "show.foobar();")
-        },
-        new String[] {
-          LINE_JOINER.join(
-              "var module$i0",
-              "module$i0 = function () {};",
-              "module$i0 = function () {};",
-              "module$i0.prototype.foobar = function() { alert('foobar') };"),
-          LINE_JOINER.join(
-              "var Foobar = module$i0;", "var show = new module$i0();", "show.foobar();")
-        });
-  }
-
-  public void testMultipleExportAssignments2() {
-    test(
-        createCompilerOptions(),
-        new String[] {
-          LINE_JOINER.join(
-              "/** @constructor */ function Hello() {}",
-              "module.exports.foo = Hello;",
-              "/** @constructor */ function Bar() {} ",
-              "Bar.prototype.foobar = function() { alert('foobar'); };",
-              "module.exports.foo = Bar;"),
-          LINE_JOINER.join(
-              "var Foobar = require('./i0');", "var show = new Foobar.foo();", "show.foobar();")
-        },
-        new String[] {
-          LINE_JOINER.join(
-              "var module$i0 = {};",
-              "module$i0.foo = function (){};",
-              "module$i0.foo = function (){};",
-              "module$i0.foo.prototype.foobar = function(){ alert('foobar') };"),
-          LINE_JOINER.join(
-              "var Foobar = module$i0;", "var show = new module$i0.foo();", "show.foobar();")
-        });
-  }
-
-  public void testMultipleExportAssignments3() {
-    test(
-        createCompilerOptions(),
-        new String[] {
-          LINE_JOINER.join(
-              "/** @constructor */ function Hello() {}",
-              "module.exports.foo = Hello;",
-              "/** @constructor */ function Bar() {} ",
-              "Bar.prototype.foobar = function() { alert('foobar'); };",
-              "exports.foo = Bar;"),
-          LINE_JOINER.join(
-              "var Foobar = require('./i0');", "var show = new Foobar.foo();", "show.foobar();")
-        },
-        new String[] {
-          LINE_JOINER.join(
-              "var module$i0 = {};",
-              "module$i0.foo = function(){};",
-              "module$i0.foo = function(){};",
-              "module$i0.foo.prototype.foobar = function(){ alert('foobar') };"),
-          LINE_JOINER.join(
-              "var Foobar = module$i0;", "var show = new module$i0.foo();", "show.foobar();")
-        });
   }
 
   public void testCrossModuleSubclass1() {
@@ -174,12 +103,12 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, Hello);")
         },
         new String[] {
-          "var module$i0 = function (){};",
+          "/** @const */ var module$i0 = {}; /** @const */ module$i0.default = function (){};",
           LINE_JOINER.join(
-              "var Hello = module$i0;",
+              "var Hello = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",
               "var SubHello = function() {};",
-              "util.inherits(SubHello, module$i0);")
+              "util.inherits(SubHello, module$i0.default);")
         });
   }
 
@@ -187,7 +116,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join("/** @constructor */ function Hello() {}", "module.exports = Hello;"),
+          "/** @constructor */ function Hello() {} module.exports = Hello;",
           LINE_JOINER.join(
               "var Hello = require('./i0');",
               "var util = {inherits: function (x, y){}};",
@@ -199,12 +128,12 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, Hello);")
         },
         new String[] {
-          "var module$i0 = function (){};",
+          "/** @const */ var module$i0 = {}; module$i0.default = function (){};",
           LINE_JOINER.join(
-              "var Hello = module$i0;",
+              "var Hello = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",
               "function SubHello(){}",
-              "util.inherits(SubHello, module$i0);")
+              "util.inherits(SubHello, module$i0.default);")
         });
   }
 
@@ -212,7 +141,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join("/** @constructor */ function Hello() {} ", "module.exports = Hello;"),
+          "/** @constructor */ function Hello() {}  module.exports = Hello;",
           LINE_JOINER.join(
               "var Hello = require('./i0');",
               "var util = {inherits: function (x, y){}};",
@@ -224,12 +153,12 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, Hello);")
         },
         new String[] {
-          "var module$i0 = function (){};",
+          "/** @const */ var module$i0 = {}; /** @constructor */ module$i0.default = function (){};",
           LINE_JOINER.join(
-              "var Hello = module$i0;",
+              "var Hello = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",
-              "function SubHello(){ module$i0.call(this); }",
-              "util.inherits(SubHello, module$i0);")
+              "function SubHello(){ module$i0.default.call(this); }",
+              "util.inherits(SubHello, module$i0.default);")
         });
   }
 
@@ -237,8 +166,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join(
-              "/** @constructor */ function Hello() {} ", "module.exports = {Hello: Hello};"),
+          "/** @constructor */ function Hello() {}  module.exports = {Hello: Hello};",
           LINE_JOINER.join(
               "var i0 = require('./i0');",
               "var util = {inherits: function (x, y) {}};",
@@ -251,13 +179,13 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
         },
         new String[] {
           LINE_JOINER.join(
-              "/** @const */ var module$i0 = {};",
-              "module$i0.Hello = /** @constructor */ function (){};"),
+              "/** @const */ var module$i0 = { /** @const */ default: {}};",
+              "module$i0.default.Hello = /** @constructor */ function (){};"),
           LINE_JOINER.join(
-              "var i0 = module$i0;",
+              "var i0 = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",
-              "function SubHello(){ module$i0.Hello.call(this); }",
-              "util.inherits(SubHello, module$i0.Hello);")
+              "function SubHello(){ module$i0.default.Hello.call(this); }",
+              "util.inherits(SubHello, module$i0.default.Hello);")
         });
   }
 
@@ -265,7 +193,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join("/** @constructor */ function Hello() {}", "module.exports = Hello;"),
+          "/** @constructor */ function Hello() {} module.exports = Hello;",
           LINE_JOINER.join(
               "var Hello = require('./i0');",
               "var util = {inherits: function (x, y){}};",
@@ -277,12 +205,12 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, Hello);")
         },
         new String[] {
-          "var module$i0 = function (){};",
+          "/** @const */ var module$i0 = {}; /** @constructor */ module$i0.default = function (){};",
           LINE_JOINER.join(
-              "var Hello = module$i0;",
+              "var Hello = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",
-              "function SubHello(){ module$i0.call(this); }",
-              "util.inherits(SubHello, module$i0);")
+              "function SubHello(){ module$i0.default.call(this); }",
+              "util.inherits(SubHello, module$i0.default);")
         });
   }
 
@@ -290,8 +218,7 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
     test(
         createCompilerOptions(),
         new String[] {
-          LINE_JOINER.join(
-              "/** @constructor */ function Hello() {}", "module.exports = {Hello: Hello};"),
+          "/** @constructor */ function Hello() {} module.exports = {Hello: Hello};",
           LINE_JOINER.join(
               "var i0 = require('./i0');",
               "var util = {inherits: function (x, y){}};",
@@ -303,19 +230,22 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, i0.Hello);")
         },
         new String[] {
-          LINE_JOINER.join("var module$i0 = {};", "module$i0.Hello = function (){};"),
           LINE_JOINER.join(
-              "var i0 = module$i0;",
+              "/** @const */ var module$i0 = { /** @const */ default: {}};",
+              "module$i0.default.Hello = /** @constructor */ function (){};"),
+          LINE_JOINER.join(
+              "var i0 = module$i0.default;",
               "var util = {inherits:function(x,y){}};",
-              "function SubHello(){ module$i0.Hello.call(this); }",
-              "util.inherits(SubHello, module$i0.Hello);")
+              "function SubHello(){ module$i0.default.Hello.call(this); }",
+              "util.inherits(SubHello, module$i0.default.Hello);")
         });
   }
 
   @Override
   protected CompilerOptions createCompilerOptions() {
     CompilerOptions options = new CompilerOptions();
-    options.setLanguageIn(LanguageMode.ECMASCRIPT3);
+    options.setLanguageIn(LanguageMode.ECMASCRIPT5);
+    options.setLanguageOut(LanguageMode.ECMASCRIPT3);
     options.setCodingConvention(new GoogleCodingConvention());
     WarningLevel.VERBOSE.setOptionsForWarningLevel(options);
     options.setProcessCommonJSModules(true);

--- a/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/CommonJSIntegrationTest.java
@@ -72,7 +72,9 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
           "var Hello = require('./i0'); /** @type {!Hello} */ var hello = new Hello();"
         },
         new String[] {
-          "/** @const */ var module$i0 = {}; /** @const */ module$i0.default = /** @constructor */ function() {};",
+          LINE_JOINER.join(
+          "/** @const */ var module$i0 = {};",
+          "/** @const */ module$i0.default = /** @constructor */ function() {};"),
           "var Hello = module$i0.default; var hello = new module$i0.default();"
         });
   }
@@ -153,7 +155,9 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, Hello);")
         },
         new String[] {
-          "/** @const */ var module$i0 = {}; /** @constructor */ module$i0.default = function (){};",
+          LINE_JOINER.join(
+              "/** @const */ var module$i0 = {};",
+              "/** @constructor */ module$i0.default = function (){};"),
           LINE_JOINER.join(
               "var Hello = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",
@@ -205,7 +209,9 @@ public final class CommonJSIntegrationTest extends IntegrationTestCase {
               "util.inherits(SubHello, Hello);")
         },
         new String[] {
-          "/** @const */ var module$i0 = {}; /** @constructor */ module$i0.default = function (){};",
+          LINE_JOINER.join(
+              "/** @const */ var module$i0 = {};",
+              "/** @constructor */ module$i0.default = function (){};"),
           LINE_JOINER.join(
               "var Hello = module$i0.default;",
               "var util = { inherits : function(x,y) {} };",

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -1005,7 +1005,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  var Fingerprint2 = function() {",
             "    if (!(this instanceof Fingerprint2)) { return new Fingerprint2(); }",
             "  };",
-            "  return Fingerprint2$$module$test;",
+            "  return Fingerprint2;",
             "})"),
         lines(
             "/** @const */ var module$test = {};",

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -316,11 +316,15 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "test.js",
         lines(
-            "(function (global, factory) {",
-            "  true ? module.exports = factory(typeof angular === 'undefined' ? require('./other') : angular) :",
-            "  typeof define === 'function' && define.amd ? define('angular-cache', ['angular'], factory) :",
-            "  (global.angularCacheModuleName = factory(global.angular));",
-            "}(this, function (angular) { 'use strict';",
+            "(function(global, factory) {",
+            "  true ? module.exports = factory(",
+            "             typeof angular === 'undefined' ? require('./other') :",
+            "                                              angular) :",
+            "         typeof define === 'function' && define.amd ?",
+            "         define('angular-cache', ['angular'], factory) :",
+            "         (global.angularCacheModuleName = factory(global.angular));",
+            "}(this, function(angular) {",
+            "  'use strict';",
             "  console.log(angular);",
             "  return angular;",
             "}));"),
@@ -828,11 +832,15 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "test.js",
         lines(
             "var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-            "!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(1), __webpack_require__(2)],",
-            "      __WEBPACK_AMD_DEFINE_RESULT__ = function (b, c) {",
-            "          console.log(b, c.exportA, c.exportB);",
+            "!(__WEBPACK_AMD_DEFINE_ARRAY__ =",
+            "      [__webpack_require__(1), __webpack_require__(2)],",
+            "  __WEBPACK_AMD_DEFINE_RESULT__ =",
+            "      function(b, c) {",
+            "        console.log(b, c.exportA, c.exportB);",
             "      }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),",
-            "    __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));"),
+            "  __WEBPACK_AMD_DEFINE_RESULT__ !== undefined &&",
+            "      (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));",
+            ""),
         lines(
             "/** @const */ var module$test = {};",
             "var __WEBPACK_AMD_DEFINE_ARRAY__$$module$test;",
@@ -956,7 +964,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "/** @const */ var module$test = {};",
             "var tinymce$$module$test = { foo: 'bar' };",
             "function register$$module$test(cb) { cb(tinymce$$module$test); }",
-            "register$$module$test(function(tinymce) { /** @const */ module$test.default = tinymce; });"));
+            "register$$module$test(function(tinymce) {",
+            "  /** @const */ module$test.default = tinymce;",
+            "});"));
   }
 
   public void testIssue2616() {
@@ -982,10 +992,15 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         lines(
             "(function (name, context, definition) {",
             "  'use strict';",
-            "  if (typeof define === 'function' && define.amd) { define(definition); }",
-            "  else if (typeof module !== 'undefined' && module.exports) { module.exports = definition(); }",
-            "  else if (context.exports) { context.exports = definition(); }",
-            "  else { context[name] = definition(); }",
+            "  if (typeof define === 'function' && define.amd) {",
+            "    define(definition);",
+            "  } else if (typeof module !== 'undefined' && module.exports) {",
+            "    module.exports = definition();",
+            "  } else if (context.exports) {",
+            "    context.exports = definition();",
+            "  } else {",
+            "    context[name] = definition();",
+            "  }",
             "})('Fingerprint2', this, function() {",
             "  var Fingerprint2 = function() {",
             "    if (!(this instanceof Fingerprint2)) { return new Fingerprint2(); }",

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -57,93 +57,81 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
   public void testWithoutExports() {
     testModules(
         "test.js",
-        "var name = require('./other'); name()",
-        lines(
-            "var name = module$other;",
-            "module$other();"));
+        "var name = require('./other'); name.call(null)",
+        lines("var name = module$other.default;", "module$other.default.call(null);"));
     test(
         ImmutableList.of(
-            SourceFile.fromCode(Compiler.joinPathParts("mod", "name.js"), ""),
+            SourceFile.fromCode(Compiler.joinPathParts("mod", "name.js"), "module.exports = {};"),
             SourceFile.fromCode(
                 Compiler.joinPathParts("test", "sub.js"),
                 lines(
                     "var name = require('../mod/name');",
-                    "(function() { module$mod$name(); })();"))),
+                    "(function() { let foo = name; foo(); })();"))),
         ImmutableList.of(
-            SourceFile.fromCode(Compiler.joinPathParts("mod", "name.js"), ""),
+            SourceFile.fromCode(
+                Compiler.joinPathParts("mod", "name.js"),
+                "/** @const */ var module$mod$name = {/** @const */ default: {}};"),
             SourceFile.fromCode(
                 Compiler.joinPathParts("test", "sub.js"),
                 lines(
-                    "var name = module$mod$name;", "(function() { module$mod$name(); })();"))));
+                    "var name = module$mod$name.default;",
+                    "(function() { let foo = module$mod$name.default; foo(); })();"))));
   }
 
   public void testExports() {
     testModules(
         "test.js",
+        lines("var name = require('./other');", "exports.foo = 1;"),
         lines(
-            "var name = require('./other');",
-            "exports.foo = 1;"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "var name$$module$test = module$other;",
-            "module$test.foo = 1;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "var name$$module$test = module$other.default;",
+            "module$test.default.foo = 1;"));
 
     testModules(
         "test.js",
+        lines("var name = require('./other');", "module.exports = function() {};"),
         lines(
-            "var name = require('./other');",
-            "module.exports = function() {};"),
-        lines(
-            "var name$$module$test = module$other;",
-            "var module$test = function () {};"));
+            "/** @const */ var module$test = {};",
+            "var name$$module$test = module$other.default;",
+            "/** @const */ module$test.default = function () {};"));
   }
 
   public void testExportsInExpression() {
     testModules(
         "test.js",
+        lines("var name = require('./other');", "var e;", "e = module.exports = function() {};"),
         lines(
-            "var name = require('./other');",
-            "var e;",
-            "e = module.exports = function() {};"),
-        lines(
-            "var module$test;",
-            "var name$$module$test = module$other;",
+            "/** @const */ var module$test = {};",
+            "var name$$module$test = module$other.default;",
             "var e$$module$test;",
-            "e$$module$test = module$test = function () {};"));
+            "e$$module$test = /** @const */ module$test.default = function () {};"));
 
     testModules(
         "test.js",
+        lines("var name = require('./other');", "var e = module.exports = function() {};"),
         lines(
-            "var name = require('./other');",
-            "var e = module.exports = function() {};"),
-        lines(
-            "var module$test;",
-            "var name$$module$test = module$other;",
-            "var e$$module$test = module$test = function () {};"));
+            "/** @const */ var module$test = {};",
+            "var name$$module$test = module$other.default;",
+            "var e$$module$test = /** @const */ module$test.default = function () {};"));
 
     testModules(
         "test.js",
+        lines("var name = require('./other');", "(module.exports = function() {})();"),
         lines(
-            "var name = require('./other');",
-            "(module.exports = function() {})();"),
-        lines(
-            "var module$test;",
-            "var name$$module$test = module$other;",
-            "(module$test = function () {})();"));
+            "/** @const */ var module$test = {};",
+            "var name$$module$test = module$other.default;",
+            "(/** @const */ module$test.default = function () {})();"));
   }
 
   public void testPropertyExports() {
     testModules(
         "test.js",
+        lines("exports.one = 1;", "module.exports.obj = {};", "module.exports.obj.two = 2;"),
         lines(
-            "exports.one = 1;",
-            "module.exports.obj = {};",
-            "module.exports.obj.two = 2;"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "module$test.one = 1;",
-            "module$test.obj = {};",
-            "module$test.obj.two = 2;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "" + "module$test.default.one = 1;",
+            "module$test.default.obj = {};",
+            "module$test.default.obj.two = 2;"));
   }
 
   /**
@@ -154,21 +142,18 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
   public void testModuleExportsWrittenWithExportsRefs() {
     testModules(
         "test.js",
+        lines("exports.one = 1;", "module.exports = {};"),
         lines(
-            "exports.one = 1;",
-            "module.exports = {};"),
-        lines(
-            "/** @const */ var module$test={};",
-            "module$test.one = 1;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.one = 1;"));
   }
 
   public void testVarRenaming() {
     testModules(
         "test.js",
+        lines("module.exports = {};", "var a = 1, b = 2;", "(function() { var a; b = 4})();"),
         lines(
-            "module.exports = {};", "var a = 1, b = 2;", "(function() { var a; b = 4})();"),
-        lines(
-            "/** @const */ var module$test={};",
+            "/** @const */ var module$test = {/** @const */ default: {}};",
             "var a$$module$test = 1;",
             "var b$$module$test = 2;",
             "(function() { var a; b$$module$test = 4})();"));
@@ -177,25 +162,21 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
   public void testDash() {
     testModules(
         "test-test.js",
+        lines("var name = require('./other');", "exports.foo = 1;"),
         lines(
-            "var name = require('./other');",
-            "exports.foo = 1;"),
-        lines(
-            "/** @const */ var module$test_test = {};",
-            "var name$$module$test_test = module$other;",
-            "module$test_test.foo = 1;"));
+            "/** @const */ var module$test_test = {/** @const */ default: {}};",
+            "var name$$module$test_test=module$other.default",
+            "module$test_test.default.foo = 1;"));
   }
 
   public void testIndex() {
     testModules(
         "foo/index.js",
+        lines("var name = require('../other');", "exports.bar = 1;"),
         lines(
-            "var name = require('../other');",
-            "exports.bar = 1;"),
-        lines(
-            "/** @const */ var module$foo$index={};",
-            "var name$$module$foo$index = module$other;",
-            "module$foo$index.bar = 1;"));
+            "/** @const */ var module$foo$index = {/** @const */ default: {}};",
+            "var name$$module$foo$index = module$other.default;",
+            "module$foo$index.default.bar = 1;"));
   }
 
   public void testVarJsdocGoesOnAssignment() {
@@ -209,24 +190,22 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "var MyEnum = { ONE: 1, TWO: 2 };",
             "module.exports = {MyEnum: MyEnum};"),
         lines(
-            "/** @const */",
-            "var module$testcode = {};",
+            "/** @const */ var module$testcode = {/** @const */ default: {}};",
             "/**",
             " * @const",
             " * @enum {number}",
             " */",
-            "(module$testcode.MyEnum = {ONE:1, TWO:2});"));
+            "(module$testcode.default.MyEnum = {ONE:1, TWO:2});"));
   }
 
   public void testModuleName() {
     testModules(
         "foo/bar.js",
+        lines("var name = require('../other');", "module.exports = name;"),
         lines(
-            "var name = require('../other');",
-            "module.exports = name;"),
-        lines(
-            "var name$$module$foo$bar = module$other;",
-            "var module$foo$bar = module$other;"));
+            "/** @const */ var module$foo$bar = {};",
+            "var name$$module$foo$bar = module$other.default;",
+            "/** @const */ module$foo$bar.default = module$other.default;"));
 
     test(
         ImmutableList.of(
@@ -239,8 +218,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             SourceFile.fromCode(
                 Compiler.joinPathParts("foo", "bar.js"),
                 lines(
-                    "var name$$module$foo$bar = module$foo$name;",
-                    "var module$foo$bar = module$foo$name;"))));
+                    "/** @const */ var module$foo$bar = {};",
+                    "var name$$module$foo$bar = module$foo$name.default;",
+                    "/** @const */ module$foo$bar.default = module$foo$name.default;"))));
   }
 
   public void testModuleExportsScope() {
@@ -252,7 +232,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "};",
             "module.exports = foo;"),
         lines(
-            "var module$test = function (module) {",
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = function (module) {",
             "  module.exports={};",
             "};"));
 
@@ -265,7 +246,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "};",
             "module.exports = foo;"),
         lines(
-            "var module$test = function() {",
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = function() {",
             "  var module={};",
             "  module.exports={}",
             "};"));
@@ -279,7 +261,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "};",
             "module.exports = foo;"),
         lines(
-            "var module$test = function() {",
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = function() {",
             "  if (true) var module={};",
             "  module.exports={}",
             "};"));
@@ -297,7 +280,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "} else {",
             "  this.foobar = foobar;",
             "}"),
-        "var module$test = {foo: 'bar'};");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
 
     testModules(
         "test.js",
@@ -310,7 +295,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "} else {",
             "  this.foobar = foobar;",
             "}"),
-        "var module$test = {foo: 'bar'};");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
 
     testModules(
         "test.js",
@@ -322,7 +309,27 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "if (typeof define === 'function' && define.amd) {",
             "  define([], function () {return foobar;});",
             "}"),
-        "var module$test = {foo: 'bar'};");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
+
+    testModules(
+        "test.js",
+        lines(
+            "(function (global, factory) {",
+            "  true ? module.exports = factory(typeof angular === 'undefined' ? require('./other') : angular) :",
+            "  typeof define === 'function' && define.amd ? define('angular-cache', ['angular'], factory) :",
+            "  (global.angularCacheModuleName = factory(global.angular));",
+            "}(this, function (angular) { 'use strict';",
+            "  console.log(angular);",
+            "  return angular;",
+            "}));"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "var angular$$module$test = ",
+            "    typeof angular === 'undefined' ? module$other.default : angular;",
+            "console.log(angular$$module$test);",
+            "module$test.default = angular$$module$test;"));
   }
 
   public void testEs6ObjectShorthand() {
@@ -330,16 +337,11 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         CompilerOptions.LanguageMode.ECMASCRIPT_2015, CompilerOptions.LanguageMode.ECMASCRIPT5);
     testModules(
         "test.js",
+        lines("function foo() {}", "module.exports = {", "  prop: 'value',", "  foo", "};"),
         lines(
-            "function foo() {}",
-            "module.exports = {",
-            "  prop: 'value',",
-            "  foo",
-            "};"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "module$test.foo = function () {};",
-            "module$test.prop = 'value';"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.foo = function () {};",
+            "module$test.default.prop = 'value';"));
 
     testModules(
         "test.js",
@@ -351,51 +353,43 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  }",
             "};"),
         lines(
-            "/** @const */ var module$test = {};",
-            "module$test.prop = 'value';",
-            "module$test.foo = function() {",
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.prop = 'value';",
+            "module$test.default.foo = function() {",
             "  console.log('bar');",
             "};"));
 
     testModules(
         "test.js",
+        lines("var a = require('./other');", "module.exports = {a: a};"),
         lines(
-            "var a = require('./other');",
-            "module.exports = {a: a};"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "var a$$module$test = module$other;",
-            "module$test.a = module$other;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "var a$$module$test = module$other.default;",
+            "module$test.default.a = module$other.default;"));
 
     testModules(
         "test.js",
+        lines("var a = require('./other');", "module.exports = {a};"),
         lines(
-            "var a = require('./other');",
-            "module.exports = {a};"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "var a$$module$test = module$other;",
-            "module$test.a = module$other;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "var a$$module$test = module$other.default;",
+            "module$test.default.a = module$other.default;"));
 
     testModules(
         "test.js",
+        lines("var a = 4;", "module.exports = {a};"),
         lines(
-            "var a = 4;",
-            "module.exports = {a};"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "module$test.a = 4;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.a = 4;"));
   }
 
   public void testKeywordsInExports() {
     testModules(
         "testcode.js",
+        lines("var a = 4;", "module.exports = { else: a };"),
         lines(
-            "var a = 4;",
-            "module.exports = { else: a };"),
-        lines(
-            "/** @const */ var module$testcode = {};",
-            "module$testcode.else = 4;"));
+            "/** @const */ var module$testcode = {/** @const */ default: {}};",
+            "module$testcode.default.else = 4;"));
   }
 
   public void testRequireResultUnused() {
@@ -412,44 +406,37 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "});"),
         lines(
             "(function() {",
-            "  var other=module$other;",
-            "  var bar = module$other;",
+            "  var other = module$other.default;",
+            "  var bar = module$other.default;",
             "})()"));
   }
 
   public void testFunctionRewriting() {
     testModules(
         "test.js",
+        lines("function foo() {}", "foo.prototype = new Date();", "module.exports = foo;"),
         lines(
-            "function foo() {}",
-            "foo.prototype = new Date();",
-            "module.exports = foo;"),
-        lines(
-            "var module$test = function() {};",
-            "module$test.prototype = new Date();"));
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = function() {};",
+            "module$test.default.prototype = new Date();"));
 
     testModules(
         "test.js",
+        lines("function foo() {}", "foo.prototype = new Date();", "module.exports = {foo: foo};"),
         lines(
-            "function foo() {}",
-            "foo.prototype = new Date();",
-            "module.exports = {foo: foo};"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "module$test.foo = function () {}",
-            "module$test.foo.prototype = new Date();"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.foo = function () {};",
+            "module$test.default.foo.prototype = new Date();"));
   }
 
   public void testFunctionHoisting() {
     testModules(
         "test.js",
+        lines("module.exports = foo;", "function foo() {}", "foo.prototype = new Date();"),
         lines(
-            "module.exports = foo;",
-            "function foo() {}",
-            "foo.prototype = new Date();"),
-        lines(
-            "var module$test = function() {};",
-            "module$test.prototype = new Date();"));
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = function() {};",
+            "module$test.default.prototype = new Date();"));
 
     testModules(
         "test.js",
@@ -460,9 +447,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "module.exports = foo;",
             "module.exports.bar = foobar;"),
         lines(
-            "var module$test = function () {};",
-            "module$test.bar = function() {};",
-            "Object.assign(module$test, { bar: module$test.bar });"));
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = function () {};",
+            "module$test.default.bar = function() {};",
+            "Object.assign(module$test.default, { bar: module$test.default.bar });"));
   }
 
   public void testClassRewriting() {
@@ -471,21 +459,21 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "test.js",
         lines("class foo extends Array {}", "module.exports = foo;"),
-        "let module$test = class extends Array {}");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = class extends Array {};"));
 
     testModules(
         "test.js",
         lines("class foo {}", "module.exports = foo;"),
-        "let module$test = class {}");
+        "/** @const */ var module$test = {}; /** @const */ module$test.default = class {}");
 
     testModules(
         "test.js",
+        lines("class foo {}", "module.exports.foo = foo;"),
         lines(
-            "class foo {}",
-            "module.exports.foo = foo;"),
-        lines(
-            "/** @const */ var module$test = {};",
-            "module$test.foo = class {};"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.foo = class {};"));
 
     testModules(
         "test.js",
@@ -495,8 +483,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  bar() { return 'bar'; }",
             "};"),
         lines(
-            "var module$test = class {",
-            "  /** @this {module$test} */",
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = class {",
+            "  /** @this {module$test.default} */",
             "  bar() { return 'bar'; }",
             "};"));
   }
@@ -532,12 +521,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         CompilerOptions.LanguageMode.ECMASCRIPT_2015, CompilerOptions.LanguageMode.ECMASCRIPT5);
     testModules(
         "test.js",
+        lines("const {foo, bar} = require('./other');", "var baz = foo + bar;"),
         lines(
-            "const {foo, bar} = require('./other');",
-            "var baz = foo + bar;"),
-        lines(
-            "const {foo, bar} = module$other;",
-            "var baz = module$other.foo + module$other.bar;"));
+            "const {foo, bar} = module$other.default;",
+            "var baz = module$other.default.foo + module$other.default.bar;"));
   }
 
   public void testAnnotationsCopied() {
@@ -550,9 +537,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "/** @type {string} */ a.prototype.foo;",
             "module.exports.a = a;"),
         lines(
-            "/** @const */ var module$test = {};",
-            "/** @interface */ module$test.a;",
-            "/** @type {string} */ module$test.a.prototype.foo;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "/** @interface */ module$test.default.a;",
+            "/** @type {string} */ module$test.default.a.prototype.foo;"));
   }
 
   public void testUMDRemoveIIFE() {
@@ -568,7 +555,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "} else {",
             "  this.foobar = foobar;",
             "}})()"),
-        "var module$test = {foo: 'bar'};");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
 
     testModules(
         "test.js",
@@ -582,7 +571,23 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "} else {",
             "  this.foobar = foobar;",
             "}}()"),
-        "var module$test = {foo: 'bar'};");
+        "/** @const */ var module$test = {}; /** @const */ module$test.default = {foo: 'bar'};");
+
+    testModules(
+        "test.js",
+        lines(
+            "!function(){",
+            "var foobar = {foo: 'bar'};",
+            "if (typeof module === 'object' && module.exports) {",
+            "  module.exports = foobar;",
+            "} else if (typeof define === 'function' && define.amd) {",
+            "  define([], function() {return foobar;});",
+            "} else {",
+            "  this.foobar = foobar;",
+            "}}()"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
 
     testModules(
         "test.js",
@@ -596,7 +601,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "} else {",
             "  this.foobar = foobar;",
             "}})()"),
-        "var module$test = {foo: 'bar'};");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
 
     testModules(
         "test.js",
@@ -610,7 +617,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "} else {",
             "  this.foobar = foobar;",
             "}}.call(this))"),
-        "var module$test = {foo: 'bar'};");
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
 
     testModules(
         "test.js",
@@ -626,8 +635,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  global.foobar = foobar;",
             "}})(this)"),
         lines(
-            "var module$test = {foo: 'bar'};",
-            "this.foobar = module$test;"));
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};",
+            "module$test.default.foobar = module$test.default;"));
 
     testModules(
         "test.js",
@@ -643,8 +653,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  global.foobar = foobar;",
             "}}.call(this, this))"),
         lines(
-            "var module$test = {foo: 'bar'};",
-            "this.foobar = module$test;"));
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};",
+            "module$test.default.foobar = module$test.default;"));
 
     // We can't remove IIFEs explict calls that don't use "this"
     testModules(
@@ -660,9 +671,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  this.foobar = foobar;",
             "}}.call(window))"),
         lines(
-            "var module$test;",
+            "/** @const */ var module$test = {};",
             "(function(){",
-            "  module$test={foo:\"bar\"};",
+            "  /** @const */ module$test.default={foo:'bar'};",
             "}).call(window);"));
 
     // Can't remove IIFEs when there are sibling statements
@@ -680,9 +691,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "}})();",
             "alert('foo');"),
         lines(
-            "var module$test;",
+            "/** @const */ var module$test = {};",
             "(function(){",
-            "  module$test={foo:\"bar\"};",
+            "  /** @const */ module$test.default={foo:\"bar\"};",
             "})();",
             "alert('foo');"));
 
@@ -701,10 +712,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  this.foobar = foobar;",
             "}})();"),
         lines(
-            "var module$test;",
+            "/** @const */ var module$test = {};",
             "alert('foo');",
             "(function(){",
-            "  module$test={foo:\"bar\"};",
+            "  /** @const */ module$test.default={foo:\"bar\"};",
             "})();"));
 
     // Annotations for local names should be preserved
@@ -724,13 +735,14 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  global.foobar = foobar;",
             "}}.call(this, this))"),
         lines(
+            "/** @const */ var module$test = {};",
             "/** @param {...*} var_args */",
             "function log$$module$test(var_args){}",
-            "var module$test = {",
+            "/** @const */ module$test.default = {",
             "  foo: 'bar',",
             "  log: function() { log$$module$test.apply(null,arguments); }",
             "};",
-            "this.foobar = module$test;"));
+            "module$test.default.foobar = module$test.default;"));
   }
 
   public void testParamShadow() {
@@ -742,9 +754,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "Foo.prototype.test = new Bar(Foo);",
             "module.exports = Foo;"),
         lines(
-            "var module$test = /** @constructor */ function () {};",
+            "/** @const */ var module$test = {};",
+            "/** @const @constructor */ module$test.default = function () {};",
             "/** @constructor */ function Bar$$module$test(Foo) { this.foo = new Foo(); }",
-            "module$test.prototype.test = new Bar$$module$test(module$test);"));
+            "module$test.default.prototype.test = new Bar$$module$test(module$test.default);"));
   }
 
   public void testIssue2308() {
@@ -752,42 +765,45 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "test.js",
         "exports.y = null; var x; x = exports.y;",
         lines(
-            "/** @const */ var module$test = {};",
-            "module$test.y = null;",
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.y = null;",
             "var x$$module$test;",
-            "x$$module$test = module$test.y"));
+            "x$$module$test = module$test.default.y"));
   }
 
   public void testAbsoluteImportsWithModuleRoots() {
     moduleRoots = ImmutableList.of("/base");
     test(
         ImmutableList.of(
-            SourceFile.fromCode(Compiler.joinPathParts("base", "mod", "name.js"), ""),
+            SourceFile.fromCode(
+                Compiler.joinPathParts("base", "mod", "name.js"), "module.exports = {}"),
             SourceFile.fromCode(
                 Compiler.joinPathParts("base", "test", "sub.js"),
                 lines(
-                    "var name = require('/mod/name');", "(function() { module$mod$name(); })();"))),
+                    "var name = require('/mod/name');",
+                    "(function() { let foo = name; foo(); })();"))),
         ImmutableList.of(
-            SourceFile.fromCode(Compiler.joinPathParts("base", "mod", "name.js"), ""),
+            SourceFile.fromCode(
+                Compiler.joinPathParts("base", "mod", "name.js"),
+                "/** @const */ var module$mod$name = {/** @const */ default: {}};"),
             SourceFile.fromCode(
                 Compiler.joinPathParts("base", "test", "sub.js"),
                 lines(
-                    "var name = module$mod$name;", "(function() { module$mod$name(); })();"))));
+                    "var name = module$mod$name.default;",
+                    "(function() { let foo = module$mod$name.default; foo(); })();"))));
   }
 
   public void testIssue2510() {
     testModules(
         "test.js",
-        lines(
-            "module.exports = {",
-            "  a: 1,",
-            "  get b() { return 2; }",
-            "};"),
+        lines("module.exports = {", "  a: 1,", "  get b() { return 2; }", "};"),
         lines(
             "/** @const */ var module$test = {",
-            "  get b() { return 2; }",
-            "}",
-            "module$test.a = 1"));
+            "  /** @const */ default: {",
+            "    get b() { return 2; }",
+            "  }",
+            "};",
+            "module$test.default.a = 1"));
   }
 
   public void testIssue2450() {
@@ -802,9 +818,9 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  HASHSIZE: BCRYPT_HASHSIZE,",
             "};"),
         lines(
-            "/** @const */ var module$test={};",
-            "module$test.BLOCKS = 8;",
-            "module$test.HASHSIZE = 32;"));
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.BLOCKS = 8;",
+            "module$test.default.HASHSIZE = 32;"));
   }
 
   public void testWebpackAmdPattern() {
@@ -816,16 +832,15 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "      __WEBPACK_AMD_DEFINE_RESULT__ = function (b, c) {",
             "          console.log(b, c.exportA, c.exportB);",
             "      }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),",
-            "    __WEBPACK_AMD_DEFINE_RESULT__ !== undefined",
-            "    && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));"),
+            "    __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));"),
         lines(
-            "var module$test = {};",
+            "/** @const */ var module$test = {};",
             "var __WEBPACK_AMD_DEFINE_ARRAY__$$module$test;",
             "!(__WEBPACK_AMD_DEFINE_ARRAY__$$module$test = ",
             "    [__webpack_require__(1), __webpack_require__(2)],",
-            "    module$test = function(b,c){console.log(b,c.exportA,c.exportB)}",
-            "        .apply(module$test,__WEBPACK_AMD_DEFINE_ARRAY__$$module$test),",
-            "    module$test!==undefined && module$test)"));
+            "    module$test.default = function(b,c){console.log(b,c.exportA,c.exportB)}",
+            "        .apply(module$test.default,__WEBPACK_AMD_DEFINE_ARRAY__$$module$test),",
+            "    module$test.default!==undefined && module$test.default)"));
   }
 
   public void testIssue2593() {
@@ -840,7 +855,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "",
             "module.exports = {};"),
         lines(
-            "/** @const */ var module$test={};",
+            "/** @const */ var module$test = {/** @const */ default: {}};",
             "var first$$module$test=1;",
             "var second$$module$test=2;",
             "var third$$module$test=3;",
@@ -858,7 +873,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "   typeof define === 'function' && define.amd ?",
             "     define([], function() {return foobar;}) :",
             "     this.foobar = foobar;"),
-        "var module$test = {foo: 'bar'};");
+        "/** @const */ var module$test = {}; /** @const */ module$test.default = {foo: 'bar'};");
   }
 
   public void testLeafletUMDWrapper() {
@@ -880,18 +895,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  exports.webkit = webkit",
             "})));"),
         lines(
-            "/** @const */ var module$test={};",
-            "{",
-            "  var exports$jscomp$inline_4$$module$test=module$test;",
-            "  var userAgentContains$jscomp$inline_6$$module$test=",
-            "    function(str$jscomp$inline_7){",
-            "      return navigator.userAgent.toLowerCase().indexOf(",
-            "        str$jscomp$inline_7)>=0;",
-            "    };",
-            "  var webkit$jscomp$inline_5$$module$test=",
-            "    userAgentContains$jscomp$inline_6$$module$test('webkit');",
-            "  exports$jscomp$inline_4$$module$test.webkit=",
-            "    webkit$jscomp$inline_5$$module$test;",
+            "/** @const */ var module$test={/** @const */ default: {}};",
+            "module$test.default.webkit=userAgentContains$$module$test('webkit');",
+            "function userAgentContains$$module$test(str) {",
+            "  return navigator.userAgent.toLowerCase().indexOf(str) >= 0;",
             "}"));
   }
 
@@ -909,10 +916,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  return {foo: 'bar'};",
             "});"),
         lines(
-            "{",
-            "  var module$test;",
-            "  module$test = {foo: 'bar'};",
-            "}"));
+            "/** @const */ var module$test={};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
   }
 
   public void testDontSplitVarsInFor() {
@@ -920,6 +925,38 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "test.js",
         "for (var a, b, c; ;) {}",
         "for (var a, b, c; ;) {}");
+  }
+
+  public void testExportsDirectAssignment() {
+    testModules(
+        "test.js",
+        "exports = module.exports = {};",
+        "/** @const */ var module$test = {/** @const */ default: {}};");
+  }
+
+  public void testExportsPropertyHoisting() {
+    testModules(
+        "test.js",
+        lines(
+            "exports.Buffer = Buffer;", "Buffer.TYPED_ARRAY_SUPPORT = {};", "function Buffer() {}"),
+        lines(
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.Buffer = function() {};",
+            "module$test.default.Buffer.TYPED_ARRAY_SUPPORT = {};"));
+  }
+
+  public void testExportNameInParamList() {
+    testModules(
+        "test.js",
+        lines(
+            "var tinymce = { foo: 'bar' };",
+            "function register(cb) { cb(tinymce); }",
+            "register(function(tinymce) { module.exports = tinymce; });"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "var tinymce$$module$test = { foo: 'bar' };",
+            "function register$$module$test(cb) { cb(tinymce$$module$test); }",
+            "register$$module$test(function(tinymce) { /** @const */ module$test.default = tinymce; });"));
   }
 
   public void testIssue2616() {
@@ -933,10 +970,63 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  foo: foo,",
             "};"),
         lines(
-            "/** @const */ var module$test={};",
-            "module$test.foo = function foo() {",
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.foo = function foo() {",
             "  return 1;",
             "};"));
+  }
+
+  public void testFingerprintUmd() {
+    testModules(
+        "test.js",
+        lines(
+            "(function (name, context, definition) {",
+            "  'use strict';",
+            "  if (typeof define === 'function' && define.amd) { define(definition); }",
+            "  else if (typeof module !== 'undefined' && module.exports) { module.exports = definition(); }",
+            "  else if (context.exports) { context.exports = definition(); }",
+            "  else { context[name] = definition(); }",
+            "})('Fingerprint2', this, function() {",
+            "  var Fingerprint2 = function() {",
+            "    if (!(this instanceof Fingerprint2)) { return new Fingerprint2(); }",
+            "  };",
+            "  return Fingerprint2$$module$test;",
+            "})"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "var Fingerprint2$$module$test = function() {",
+            "  if (!(this instanceof Fingerprint2$$module$test)) {",
+            "    return new Fingerprint2$$module$test();",
+            "  }",
+            "};",
+            "module$test.default = Fingerprint2$$module$test;"));
+  }
+
+  public void testTypeofModuleReference() {
+    testModules(
+        "test.js",
+        lines(
+            "module.exports = 'foo';",
+            "console.log(typeof module);",
+            "console.log(typeof exports);"),
+        lines(
+            "/** @const */ var module$test={};",
+            "/** @const */ module$test.default = 'foo';",
+            "console.log('object');",
+            "console.log('object');"));
+  }
+
+  public void testUpdateGenericTypeReferences() {
+    testModules(
+        "test.js",
+        lines(
+            "const Foo = require('./other');",
+            "/** @type {!Array<!Foo>} */ const bar = [];",
+            "module.exports = bar;"),
+        lines(
+            "/** @const */ var module$test={};",
+            "const Foo$$module$test = module$other.default;",
+            "/** @const  @type {!Array<!module$other.default>} */ module$test.default = [];"));
   }
 
   public void testMissingRequire() {
@@ -955,6 +1045,35 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             " * @fileoverview",
             " * @suppress {moduleLoad}",
             " */",
-            "var foo = module$missing;"));
+            "var foo = module$missing.default;"));
+  }
+
+  /** The export reference in the if statement should not be recognized as a UMD pattern. */
+  public void testExportsUsageInIf() {
+    testModules(
+        "test.js",
+        lines(
+            "exports.merge = function(source) {",
+            "  return Object.keys(source).reduce(function (acc, key) {",
+            "    if (Object.prototype.hasOwnProperty.call(acc, key)) {",
+            "      acc[key] = exports.merge(acc[key], value, options);",
+            "    } else {",
+            "      acc[key] = value;",
+            "    }",
+            "    return acc;",
+            "  }, {});",
+            "};"),
+        lines(
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "module$test.default.merge = function(source) {",
+            "  return Object.keys(source).reduce(function(acc,key) {",
+            "    if (Object.prototype.hasOwnProperty.call(acc,key)) {",
+            "      acc[key] = module$test.default.merge(acc[key],value,options);",
+            "    } else {",
+            "      acc[key] = value;",
+            "    }",
+            "    return acc;",
+            "  }, {});",
+            "}"));
   }
 }


### PR DESCRIPTION
The interop for ES6 and CommonJS is defined here: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md

- When a `require('foo')` statement is importing an ES6 module, the import is the module object.
- When a `import bar from 'foo'` statement is importing a CommonJS module, the module export is treated as the default property.

This PR reworks CommonJS rewriting such that CommonJS modules are written to a `default` property on an export. A map of module names to module types is created by the compiler so that rewriting can vary based off what type of module is being imported. If an imported module cannot be located, it is assumed to be of the same type as the host.

Fixes #2634

Note this PR contains quite a few other CommonJS related fixes. It had become too difficult to separate them into standalone PRs.

cc @jplaisted 