### PR TITLE
Replace CommonJS module.id references with the full module path

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -1072,6 +1072,15 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
             break;
           }
 
+        case GETPROP:
+          if (n.matchesQualifiedName(MODULE + ".id")) {
+            Var v = t.getScope().getVar(MODULE);
+            if (v == null || v.isExtern()) {
+              n.replaceWith(IR.string(t.getInput().getPath().toString()).useSourceInfoFrom(n));
+            }
+          }
+          break;
+
         case TYPEOF:
           if (allowFullRewrite
               && n.getFirstChild().isName()

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -1091,4 +1091,25 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "  }, {});",
             "}"));
   }
+
+  public void testModuleId() {
+    testModules(
+        "test.js",
+        "module.exports = module.id;",
+        LINE_JOINER.join(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = 'test.js';"));
+  }
+
+  public void testModuleIdAlias() {
+    testModules(
+        "test.js",
+        LINE_JOINER.join(
+            "module.exports = 'foo';",
+            "function foobar(module) { return module.id; }"),
+        LINE_JOINER.join(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = 'foo';",
+            "function foobar$$module$test(module) { return module.id; }"));
+  }
 }


### PR DESCRIPTION
In a CommonJS module, `module.id` is supposed to return a value that another module would be able to use to require it. In our case, simply replace references to module.id with the full module path.