### PR TITLE
Collapse module export properties in SIMPLE mode when an output wrapper is used

### DIFF
--- a/src/com/google/javascript/jscomp/CollapseProperties.java
+++ b/src/com/google/javascript/jscomp/CollapseProperties.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.GlobalNamespace.Name;
 import com.google.javascript.jscomp.GlobalNamespace.Ref;
 import com.google.javascript.jscomp.Normalize.PropagateConstantAnnotationsOverVars;
@@ -67,7 +68,6 @@ import java.util.Map;
  *
  */
 class CollapseProperties implements CompilerPass {
-
   // Warnings
   static final DiagnosticType UNSAFE_NAMESPACE_WARNING =
       DiagnosticType.warning(
@@ -84,6 +84,7 @@ class CollapseProperties implements CompilerPass {
       "dangerous use of ''this'' in static method {0}");
 
   private final AbstractCompiler compiler;
+  private final PropertyCollapseLevel propertyCollapseLevel;
 
   /** Global namespace tree */
   private List<Name> globalNames;
@@ -91,8 +92,9 @@ class CollapseProperties implements CompilerPass {
   /** Maps names (e.g. "a.b.c") to nodes in the global namespace tree */
   private Map<String, Name> nameMap;
 
-  CollapseProperties(AbstractCompiler compiler) {
+  CollapseProperties(AbstractCompiler compiler, PropertyCollapseLevel propertyCollapseLevel) {
     this.compiler = compiler;
+    this.propertyCollapseLevel = propertyCollapseLevel;
   }
 
   @Override
@@ -116,6 +118,32 @@ class CollapseProperties implements CompilerPass {
     // This shouldn't be necessary, this pass should already be setting new constants as constant.
     // TODO(b/64256754): Investigate.
     (new PropagateConstantAnnotationsOverVars(compiler, false)).process(externs, root);
+  }
+
+  private boolean canCollapse(Name n) {
+    if (!n.canCollapse()) {
+      return false;
+    }
+
+    if (propertyCollapseLevel == PropertyCollapseLevel.MODULE_EXPORT && !n.isModuleExport()) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean canEliminate(Name n) {
+    if (!n.canEliminate()) {
+      return false;
+    }
+
+    if (n.props == null
+        || n.props.size() == 0
+        || propertyCollapseLevel != PropertyCollapseLevel.MODULE_EXPORT) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -220,9 +248,14 @@ class CollapseProperties implements CompilerPass {
     for (Name p : n.props) {
       String propAlias = appendPropForAlias(alias, p.getBaseName());
 
-      if (p.canCollapse()) {
+      boolean isAllowedToCollapse =
+          propertyCollapseLevel != PropertyCollapseLevel.MODULE_EXPORT || p.isModuleExport();
+
+      if (isAllowedToCollapse && p.canCollapse()) {
         flattenReferencesTo(p, propAlias);
-      } else if (p.isSimpleStubDeclaration() && !p.isCollapsingExplicitlyDenied()) {
+      } else if (isAllowedToCollapse
+          && p.isSimpleStubDeclaration()
+          && !p.isCollapsingExplicitlyDenied()) {
         flattenSimpleStubDeclaration(p, propAlias);
       }
 
@@ -399,7 +432,7 @@ class CollapseProperties implements CompilerPass {
     boolean canCollapseChildNames = n.canCollapseUnannotatedChildNames();
 
     // Handle this name first so that nested object literals get unrolled.
-    if (n.canCollapse()) {
+    if (canCollapse(n)) {
       updateGlobalNameDeclaration(n, alias, canCollapseChildNames);
     }
 
@@ -540,7 +573,7 @@ class CollapseProperties implements CompilerPass {
     boolean isObjLit = rvalue.isObjectLit();
     boolean insertedVarNode = false;
 
-    if (isObjLit && n.canEliminate()) {
+    if (isObjLit && canEliminate(n)) {
       // Eliminate the object literal altogether.
       varParent.replaceChild(grandparent, varNode);
       ref.node = null;
@@ -645,7 +678,7 @@ class CollapseProperties implements CompilerPass {
 
     addStubsForUndeclaredProperties(n, name, grandparent, variableNode);
 
-    if (isObjLit && n.canEliminate()) {
+    if (isObjLit && canEliminate(n)) {
       variableNode.removeChild(ref.node);
       compiler.reportChangeToEnclosingScope(variableNode);
       if (!variableNode.hasChildren()) {
@@ -667,7 +700,7 @@ class CollapseProperties implements CompilerPass {
    */
   private void updateGlobalNameDeclarationAtFunctionNode(
       Name n, boolean canCollapseChildNames) {
-    if (!canCollapseChildNames || !n.canCollapse()) {
+    if (!canCollapseChildNames || !canCollapse(n)) {
       return;
     }
 
@@ -683,7 +716,7 @@ class CollapseProperties implements CompilerPass {
    * @param n An object representing a global name (e.g. "a")
    */
   private void updateGlobalNameDeclarationAtClassNode(Name n, boolean canCollapseChildNames) {
-    if (!canCollapseChildNames || !n.canCollapse()) {
+    if (!canCollapseChildNames || !canCollapse(n)) {
       return;
     }
 
@@ -735,7 +768,7 @@ class CollapseProperties implements CompilerPass {
       // If the name cannot be collapsed, skip it.
       String qName = objlitName.getFullName() + '.' + propName;
       Name p = nameMap.get(qName);
-      if (p != null && !p.canCollapse()) {
+      if (p != null && !canCollapse(p)) {
         continue;
       }
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1687,7 +1687,7 @@ public class CommandLineRunner extends
       level.setTypeBasedOptimizationOptions(options);
     }
 
-    if (flags.assumeFunctionWrapper) {
+    if (flags.assumeFunctionWrapper || flags.isolationMode == IsolationMode.IIFE) {
       level.setWrappedOutputOptimizations(options);
     }
 

--- a/src/com/google/javascript/jscomp/CompilationLevel.java
+++ b/src/com/google/javascript/jscomp/CompilationLevel.java
@@ -16,6 +16,7 @@
 
 package com.google.javascript.jscomp;
 
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.CompilerOptions.Reach;
 
 /**
@@ -180,7 +181,7 @@ public enum CompilationLevel {
     options.setRemoveUnusedPrototypePropertiesInExterns(false);
     options.setRemoveUnusedClassProperties(true);
     options.setCollapseAnonymousFunctions(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setCheckGlobalThisLevel(CheckLevel.WARNING);
     options.setRewriteFunctionExpressions(false);
     options.setSmartNameRemoval(true);
@@ -239,6 +240,7 @@ public enum CompilationLevel {
       case SIMPLE_OPTIMIZATIONS:
         // Enable global variable optimizations (but not property optimizations)
         options.setVariableRenaming(VariableRenamingPolicy.ALL);
+        options.setCollapsePropertiesLevel(PropertyCollapseLevel.MODULE_EXPORT);
         options.setCollapseAnonymousFunctions(true);
         options.setInlineConstantVars(true);
         options.setInlineFunctions(Reach.ALL);

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -75,6 +75,12 @@ public class CompilerOptions implements Serializable {
     NONE
   }
 
+  public enum PropertyCollapseLevel {
+    ALL,
+    NONE,
+    MODULE_EXPORT
+  }
+
   // TODO(nicksantos): All public properties of this class should be made
   // package-private, and have a public setter.
 
@@ -631,11 +637,15 @@ public class CompilerOptions implements Serializable {
     renamePrefixNamespaceAssumeCrossModuleNames = assume;
   }
 
-  private boolean collapseProperties;
+  private PropertyCollapseLevel collapsePropertiesLevel;
 
   /** Flattens multi-level property names (e.g. a$b = x) */
   public boolean shouldCollapseProperties() {
-    return collapseProperties;
+    return collapsePropertiesLevel != PropertyCollapseLevel.NONE;
+  }
+
+  public PropertyCollapseLevel getPropertyCollapseLevel() {
+    return collapsePropertiesLevel;
   }
 
   /** Split object literals into individual variables when possible. */
@@ -1291,7 +1301,7 @@ public class CompilerOptions implements Serializable {
     shadowVariables = false;
     preferStableNames = false;
     renamePrefix = null;
-    collapseProperties = false;
+    collapsePropertiesLevel = PropertyCollapseLevel.NONE;
     collapseObjectLiterals = false;
     devirtualizePrototypeMethods = false;
     disambiguateProperties = false;
@@ -2392,8 +2402,8 @@ public class CompilerOptions implements Serializable {
     this.renamePrefixNamespace = renamePrefixNamespace;
   }
 
-  public void setCollapseProperties(boolean collapseProperties) {
-    this.collapseProperties = collapseProperties;
+  public void setCollapsePropertiesLevel(PropertyCollapseLevel level) {
+    this.collapsePropertiesLevel = level;
   }
 
   public void setDevirtualizePrototypeMethods(boolean devirtualizePrototypeMethods) {
@@ -2868,7 +2878,7 @@ public class CompilerOptions implements Serializable {
             .add("codingConvention", getCodingConvention())
             .add("collapseAnonymousFunctions", collapseAnonymousFunctions)
             .add("collapseObjectLiterals", collapseObjectLiterals)
-            .add("collapseProperties", collapseProperties)
+            .add("collapseProperties", collapsePropertiesLevel)
             .add("collapseVariableDeclarations", collapseVariableDeclarations)
             .add("colorizeErrorOutput", shouldColorizeErrorOutput())
             .add("computeFunctionSideEffects", computeFunctionSideEffects)

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2430,7 +2430,7 @@ public final class DefaultPassConfig extends PassConfig {
       new PassFactory(PassNames.COLLAPSE_PROPERTIES, true) {
         @Override
         protected CompilerPass create(AbstractCompiler compiler) {
-          return new CollapseProperties(compiler);
+          return new CollapseProperties(compiler, options.getPropertyCollapseLevel());
         }
 
         @Override

--- a/src/com/google/javascript/jscomp/Es6RewriteModules.java
+++ b/src/com/google/javascript/jscomp/Es6RewriteModules.java
@@ -393,6 +393,7 @@ public final class Es6RewriteModules extends AbstractPostOrderCallback
       String withSuffix = entry.getValue().name;
       Node nodeForSourceInfo = entry.getValue().nodeForSourceInfo;
       Node getProp = IR.getprop(IR.name(moduleName), IR.string(exportedName));
+      getProp.putBooleanProp(Node.MODULE_EXPORT, true);
 
       if (typedefs.contains(exportedName)) {
         // /** @typedef {foo} */
@@ -429,6 +430,7 @@ public final class Es6RewriteModules extends AbstractPostOrderCallback
 
     if (!exportMap.isEmpty()) {
       Node moduleVar = IR.var(IR.name(moduleName), IR.objectlit());
+      moduleVar.getFirstChild().putBooleanProp(Node.MODULE_EXPORT, true);
       JSDocInfoBuilder infoBuilder = new JSDocInfoBuilder(false);
       infoBuilder.recordConstancy();
       moduleVar.setJSDocInfo(infoBuilder.build());

--- a/src/com/google/javascript/jscomp/GlobalNamespace.java
+++ b/src/com/google/javascript/jscomp/GlobalNamespace.java
@@ -607,6 +607,9 @@ class GlobalNamespace
 
       Name nameObj = getOrCreateName(name, shouldCreateProp);
       nameObj.type = type;
+      if (n.getBooleanProp(Node.MODULE_EXPORT)) {
+        nameObj.isModuleProp = true;
+      }
       maybeRecordEs6Subclass(n, parent, nameObj);
 
       Ref set = new Ref(module, scope, n, nameObj, Ref.Type.SET_FROM_GLOBAL,
@@ -704,6 +707,9 @@ class GlobalNamespace
       Ref set = new Ref(module, scope, n, nameObj,
           Ref.Type.SET_FROM_LOCAL, currentPreOrderIndex++);
       nameObj.addRef(set);
+      if (n.getBooleanProp(Node.MODULE_EXPORT)) {
+        nameObj.isModuleProp = true;
+      }
 
       if (isNestedAssign(parent)) {
         // This assignment is both a set and a get that creates an alias.
@@ -1013,6 +1019,7 @@ class GlobalNamespace
     Type type;
     private boolean declaredType = false;
     private boolean isDeclared = false;
+    private boolean isModuleProp = false;
     int globalSets = 0;
     int localSets = 0;
     int localSetsWithNoCollapse = 0;
@@ -1410,6 +1417,10 @@ class GlobalNamespace
       }
 
       return null;
+    }
+
+    boolean isModuleExport() {
+      return isModuleProp;
     }
   }
 

--- a/src/com/google/javascript/jscomp/debugger/common/CompilationParam.java
+++ b/src/com/google/javascript/jscomp/debugger/common/CompilationParam.java
@@ -19,6 +19,7 @@ package com.google.javascript.jscomp.debugger.common;
 import com.google.javascript.jscomp.AnonymousFunctionNamingPolicy;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.CompilerOptions.Reach;
 import com.google.javascript.jscomp.DiagnosticGroup;
 import com.google.javascript.jscomp.DiagnosticGroups;
@@ -682,7 +683,7 @@ public enum CompilationParam {
   COLLAPSE_PROPERTIES(ParamGroup.TYPE_CHECKING_OPTIMIZATION) {
     @Override
     public void apply(CompilerOptions options, boolean value) {
-      options.setCollapseProperties(value);
+      options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     }
 
     @Override

--- a/src/com/google/javascript/rhino/Node.java
+++ b/src/com/google/javascript/rhino/Node.java
@@ -161,8 +161,11 @@ public class Node implements Serializable {
       GOOG_MODULE_ALIAS = 95,     // Indicates that the node is an alias of goog.require'd module.
                                   // Aliases are desugared and inlined by compiler passes but we
                                   // need to preserve them for building index.
-      IS_UNUSED_PARAMETER = 96;   // Mark a parameter as unused. Used to defer work from
+      IS_UNUSED_PARAMETER = 96,   // Mark a parameter as unused. Used to defer work from
                                   // RemovedUnusedVars to OptimizeParameters.
+      MODULE_EXPORT = 97;         // Mark a property as a module export so that collase properties
+                                  // can act on it.
+
 
   private static final String propToString(byte propType) {
       switch (propType) {
@@ -225,6 +228,7 @@ public class Node implements Serializable {
         case DELETED:            return "DELETED";
         case GOOG_MODULE_ALIAS:  return "goog_module_alias";
         case IS_UNUSED_PARAMETER: return "is_unused_parameter";
+        case MODULE_EXPORT:      return "module_export";
         default:
           throw new IllegalStateException("unexpected prop id " + propType);
       }

--- a/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
@@ -20,6 +20,8 @@ import static com.google.javascript.jscomp.CollapseProperties.NAMESPACE_REDEFINE
 import static com.google.javascript.jscomp.CollapseProperties.UNSAFE_NAMESPACE_WARNING;
 
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
+import java.util.ArrayList;
 
 /**
  * Tests {@link CollapseProperties}.
@@ -35,13 +37,15 @@ public final class CollapsePropertiesTest extends CompilerTestCase {
       + "/** @constructor */ function String() {};\n"
       + "var arguments";
 
+  private PropertyCollapseLevel propertyCollapseLevel = PropertyCollapseLevel.ALL;
+
   public CollapsePropertiesTest() {
     super(EXTERNS);
   }
 
   @Override
   protected CompilerPass getProcessor(final Compiler compiler) {
-    return new CollapseProperties(compiler);
+    return new CollapseProperties(compiler, propertyCollapseLevel);
   }
 
   @Override
@@ -53,6 +57,14 @@ public final class CollapsePropertiesTest extends CompilerTestCase {
   @Override
   protected int getNumRepetitions() {
     return 1;
+  }
+
+  private void setupModuleExportsOnly() {
+    this.setAcceptedLanguage(LanguageMode.ECMASCRIPT_2015);
+    this.setLanguageOut(LanguageMode.ECMASCRIPT5);
+    enableProcessCommonJsModules();
+    enableTranspile();
+    propertyCollapseLevel = PropertyCollapseLevel.MODULE_EXPORT;
   }
 
   public void testMultiLevelCollapse() {
@@ -2102,5 +2114,130 @@ public final class CollapsePropertiesTest extends CompilerTestCase {
     test(
         "var a = {b: 5}; function f(x=a.b) { alert(x); }",
         "var a$b = 5; function f(x=a$b) { alert(x); }");
+  }
+
+  public void testModuleExportsBasicCommonJs() {
+    this.setupModuleExportsOnly();
+
+    ArrayList<SourceFile> inputs = new ArrayList();
+    inputs.add(SourceFile.fromCode("mod1.js", "module.exports = 123;"));
+    inputs.add(SourceFile.fromCode("entry.js", "var mod = require('./mod1.js'); alert(mod);"));
+
+    ArrayList<SourceFile> expected = new ArrayList();
+    expected.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            "/** @const */ var module$mod1={}; /** @const */ var module$mod1$default = 123;"));
+    expected.add(
+        SourceFile.fromCode(
+            "entry.js", "var mod = module$mod1$default; alert(module$mod1$default);"));
+
+    test(inputs, expected);
+  }
+
+  public void testModuleExportsBasicEsm() {
+    this.setupModuleExportsOnly();
+
+    ArrayList<SourceFile> inputs = new ArrayList();
+    inputs.add(SourceFile.fromCode("mod1.js", "export default 123; export var bar = 'bar'"));
+    inputs.add(
+        SourceFile.fromCode(
+            "entry.js", "import mod, {bar} from './mod1.js'; alert(mod); alert(bar)"));
+
+    ArrayList<SourceFile> expected = new ArrayList();
+    expected.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "/** @const */ var module$mod1={};",
+                "var $jscompDefaultExport$$module$mod1=123;",
+                "var bar$$module$mod1 = 'bar';",
+                "var module$mod1$default = $jscompDefaultExport$$module$mod1;",
+                "var module$mod1$bar = bar$$module$mod1")));
+    expected.add(
+        SourceFile.fromCode("entry.js", "alert(module$mod1$default); alert(module$mod1$bar);"));
+
+    test(inputs, expected);
+  }
+
+  public void testModuleExportsObjectCommonJs() {
+    this.setupModuleExportsOnly();
+
+    ArrayList<SourceFile> inputs = new ArrayList();
+    inputs.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "var foo ={};", "foo.bar = {};", "foo.bar.baz = 123;", "module.exports = foo;")));
+    inputs.add(
+        SourceFile.fromCode("entry.js", "var mod = require('./mod1.js'); alert(mod.bar.baz);"));
+
+    ArrayList<SourceFile> expected = new ArrayList();
+    expected.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "/** @const */ var module$mod1={};",
+                " /** @const */ var module$mod1$default = {};",
+                "module$mod1$default.bar = {};",
+                "module$mod1$default.bar.baz = 123;")));
+    expected.add(
+        SourceFile.fromCode(
+            "entry.js", "var mod = module$mod1$default; alert(module$mod1$default.bar.baz);"));
+
+    test(inputs, expected);
+  }
+
+  public void testModuleExportsObjectEsm() {
+    this.setupModuleExportsOnly();
+
+    ArrayList<SourceFile> inputs = new ArrayList();
+    inputs.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "var foo ={};", "foo.bar = {};", "foo.bar.baz = 123;", "export default foo;")));
+    inputs.add(SourceFile.fromCode("entry.js", "import mod from './mod1.js'; alert(mod.bar.baz);"));
+
+    ArrayList<SourceFile> expected = new ArrayList();
+    expected.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "/** @const */ var module$mod1={};",
+                "var foo$$module$mod1 = {};",
+                "foo$$module$mod1.bar = {};",
+                "foo$$module$mod1.bar.baz = 123;",
+                "var $jscompDefaultExport$$module$mod1 = foo$$module$mod1;",
+                "var module$mod1$default = $jscompDefaultExport$$module$mod1;")));
+    expected.add(SourceFile.fromCode("entry.js", "alert(module$mod1$default.bar.baz);"));
+
+    test(inputs, expected);
+  }
+
+  public void testModuleExportsObjectSubPropertyCommonJs() {
+    this.setupModuleExportsOnly();
+
+    ArrayList<SourceFile> inputs = new ArrayList();
+    inputs.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "var foo ={};", "module.exports = foo;", "module.exports.bar = 'bar';")));
+    inputs.add(SourceFile.fromCode("entry.js", "var mod = require('./mod1.js'); alert(mod.bar);"));
+
+    ArrayList<SourceFile> expected = new ArrayList();
+    expected.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            LINE_JOINER.join(
+                "/** @const */ var module$mod1={};",
+                " /** @const */ var module$mod1$default = {};",
+                "module$mod1$default.bar = 'bar';")));
+    expected.add(
+        SourceFile.fromCode(
+            "entry.js", "var mod = module$mod1$default; alert(module$mod1$default.bar);"));
+
+    test(inputs, expected);
   }
 }

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -83,6 +83,9 @@ public abstract class CompilerTestCase extends TestCase {
   /** Whether the closure pass is run on the expected JS. */
   private boolean closurePassEnabledForExpected;
 
+  /** Whether to rewrite commons js modules before the test is run. */
+  private boolean processCommonJsModules;
+
   /** Whether to rewrite Closure code before the test is run. */
   private boolean rewriteClosureCode;
 
@@ -574,6 +577,7 @@ public abstract class CompilerTestCase extends TestCase {
     this.normalizeEnabled = false;
     this.parseTypeInfo = false;
     this.polymerPass = false;
+    this.processCommonJsModules = false;
     this.rewriteClosureCode = false;
     this.runTypeCheckAfterProcessing = false;
     this.transpileEnabled = false;
@@ -821,6 +825,12 @@ public abstract class CompilerTestCase extends TestCase {
   protected final void enableClosurePassForExpected() {
     checkState(this.setUpRan, "Attempted to configure before running setUp().");
     closurePassEnabledForExpected = true;
+  }
+
+  /** Rewrite CommonJS modules before the test run. */
+  protected final void enableProcessCommonJsModules() {
+    checkState(this.setUpRan, "Attempted to configure before running setUp().");
+    processCommonJsModules = true;
   }
 
   /**
@@ -1495,6 +1505,13 @@ public abstract class CompilerTestCase extends TestCase {
           recentChange.reset();
           new ProcessClosurePrimitives(compiler, null, CheckLevel.ERROR, false)
               .process(externsRoot, mainRoot);
+          hasCodeChanged = hasCodeChanged || recentChange.hasCodeChanged();
+        }
+
+        // Only run process closure primitives once, if asked.
+        if (processCommonJsModules && i == 0) {
+          recentChange.reset();
+          new ProcessCommonJSModules(compiler).process(externsRoot, mainRoot);
           hasCodeChanged = hasCodeChanged || recentChange.hasCodeChanged();
         }
 

--- a/test/com/google/javascript/jscomp/InlineAndCollapsePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/InlineAndCollapsePropertiesTest.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 
 import static com.google.javascript.jscomp.CollapseProperties.UNSAFE_NAMESPACE_WARNING;
 
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.rhino.Node;
 
 /**
@@ -42,7 +43,8 @@ public final class InlineAndCollapsePropertiesTest extends CompilerTestCase {
   protected CompilerPass getProcessor(final Compiler compiler) {
     return new CompilerPass() {
       AggressiveInlineAliases aggressiveInlineAliases = new AggressiveInlineAliases(compiler);
-      CollapseProperties collapseProperties = new CollapseProperties(compiler);
+      CollapseProperties collapseProperties =
+          new CollapseProperties(compiler, PropertyCollapseLevel.ALL);
 
       @Override
       public void process(Node externs, Node root) {

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Chars;
 import com.google.javascript.jscomp.CompilerOptions.DevMode;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.CompilerOptions.Reach;
 import com.google.javascript.jscomp.CompilerTestCase.NoninjectingCompiler;
 import com.google.javascript.jscomp.testing.NodeSubject;
@@ -242,7 +243,7 @@ public final class IntegrationTest extends IntegrationTestCase {
 
   public void testMultipleAliasesInlined_bug31437418() {
     CompilerOptions options = createCompilerOptions();
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setLanguageIn(LanguageMode.ECMASCRIPT_2015);
     options.setLanguageOut(LanguageMode.ECMASCRIPT3);
     test(
@@ -268,7 +269,7 @@ public final class IntegrationTest extends IntegrationTestCase {
   @GwtIncompatible // b/63595345
   public void testBug1949424() {
     CompilerOptions options = createCompilerOptions();
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setClosurePass(true);
     test(options, CLOSURE_BOILERPLATE + "goog.provide('FOO'); FOO.bar = 3;",
         CLOSURE_COMPILED + "var FOO$bar = 3;");
@@ -277,7 +278,7 @@ public final class IntegrationTest extends IntegrationTestCase {
   @GwtIncompatible // b/63595345
   public void testBug1949424_v2() {
     CompilerOptions options = createCompilerOptions();
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setClosurePass(true);
     test(
         options,
@@ -309,7 +310,7 @@ public final class IntegrationTest extends IntegrationTestCase {
 
   public void testBug1956277() {
     CompilerOptions options = createCompilerOptions();
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setInlineVariables(true);
     test(
         options,
@@ -320,7 +321,7 @@ public final class IntegrationTest extends IntegrationTestCase {
 
   public void testBug1962380() {
     CompilerOptions options = createCompilerOptions();
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setInlineVariables(true);
     options.setGenerateExports(true);
     test(
@@ -349,7 +350,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     test(options, source, ConstParamCheck.CONST_NOT_STRING_LITERAL_ERROR);
 
     // With collapsed properties.
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(options, source, ConstParamCheck.CONST_NOT_STRING_LITERAL_ERROR);
   }
 
@@ -374,7 +375,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     test(options, source, ConstParamCheck.CONST_NOT_STRING_LITERAL_ERROR);
 
     // With collapsed properties.
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(options, source, ConstParamCheck.CONST_NOT_STRING_LITERAL_ERROR);
   }
 
@@ -673,7 +674,7 @@ public final class IntegrationTest extends IntegrationTestCase {
   public void testTypedefBeforeOwner2() {
     CompilerOptions options = createCompilerOptions();
     options.setClosurePass(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(
         options,
         LINE_JOINER.join(
@@ -758,7 +759,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     options.setRenamingPolicy(
         VariableRenamingPolicy.ALL, PropertyRenamingPolicy.ALL_UNQUOTED);
     options.setGeneratePseudoNames(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(options,
         new String[] {
             LINE_JOINER.join(
@@ -1339,7 +1340,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     testSame(options, code);
 
     options.setClosurePass(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setRemoveAbstractMethods(true);
     test(options, code, CLOSURE_COMPILED + " var x$bar = 3;");
   }
@@ -1351,7 +1352,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
 
     options.setClosurePass(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setDefineToBooleanLiteral("FLAG", false);
 
     test(options, code, CLOSURE_COMPILED + " var FLAG = false;");
@@ -1366,7 +1367,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
 
     options.setClosurePass(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setDefineToBooleanLiteral("ns.FLAG", false);
     test(options, code, CLOSURE_COMPILED + "var ns$FLAG = false;");
   }
@@ -1378,7 +1379,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     testSame(options, code);
 
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(options, code, "var x$FOO = 5; var x$bar = 3;");
   }
 
@@ -1389,7 +1390,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     testSame(options, code);
 
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.collapseObjectLiterals = true;
     test(options, code, "var x$FOO = 5; var x$bar = 3;");
   }
@@ -1722,7 +1723,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     options.syntheticBlockEndMarker = "synEnd";
     options.setCheckSymbols(true);
     options.processObjectPropertyString = true;
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(options, CLOSURE_BOILERPLATE, CLOSURE_COMPILED);
   }
 
@@ -1807,7 +1808,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setClosurePass(true);
     options.setInlineConstantVars(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(
         options,
         LINE_JOINER.join(
@@ -1825,7 +1826,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setClosurePass(true);
     options.setInlineConstantVars(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(
         options,
         "var goog = {}; "
@@ -1841,7 +1842,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setClosurePass(true);
     options.setInlineConstantVars(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(
         options,
         "var goog = {}; goog.provide('foo.Bar'); "
@@ -1854,7 +1855,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     options.setClosurePass(true);
     options.setInlineConstantVars(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     test(
         options,
         "var goog = {}; goog.provide('foo.Bar'); "
@@ -3749,7 +3750,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     CompilerOptions options = createCompilerOptions();
     testSame(options, code);
 
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setRenamePrefixNamespace("_");
     test(options, code, "_.x$FOO = 5; _.x$bar = 3;");
   }
@@ -3815,7 +3816,7 @@ public final class IntegrationTest extends IntegrationTestCase {
                   "i.am.on.a.Horse.prototype.x = function() {};" +
                   "i.am.on.a.Boat.prototype.y = function() {}";
     options.setClosurePass(true);
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setSmartNameRemoval(true);
     test(options, code, "");
   }
@@ -4906,7 +4907,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     // Currently the compiler unsafely collapses A.doSomething to A$doSomething, causing
     // JSCompiler_temp_const$jscomp$0.doSomething to be undefined and breaking at runtime.
     CompilerOptions options = createCompilerOptions();
-    options.setCollapseProperties(true);
+    options.setCollapsePropertiesLevel(PropertyCollapseLevel.ALL);
     options.setOptimizeCalls(false);
     options.setAllowMethodCallDecomposing(true);
     options.setLanguageIn(LanguageMode.ECMASCRIPT_2017);

--- a/test/com/google/javascript/jscomp/NormalizeTest.java
+++ b/test/com/google/javascript/jscomp/NormalizeTest.java
@@ -19,6 +19,7 @@ package com.google.javascript.jscomp;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.rhino.Node;
 import java.util.ArrayList;
@@ -878,18 +879,19 @@ public final class NormalizeTest extends CompilerTestCase {
     // we call enableNormalize to make the Normalize.VerifyConstants pass run.
 
     // TODO(johnlenz): fix this so it is just another test case.
-    CompilerTestCase tester = new CompilerTestCase() {
-      @Override
-      protected int getNumRepetitions() {
-        // The normalize pass is only run once.
-        return 1;
-      }
+    CompilerTestCase tester =
+        new CompilerTestCase() {
+          @Override
+          protected int getNumRepetitions() {
+            // The normalize pass is only run once.
+            return 1;
+          }
 
-      @Override
-      protected CompilerPass getProcessor(Compiler compiler) {
-        return new CollapseProperties(compiler);
-      }
-    };
+          @Override
+          protected CompilerPass getProcessor(Compiler compiler) {
+            return new CollapseProperties(compiler, PropertyCollapseLevel.ALL);
+          }
+        };
 
     tester.setUp();
     tester.enableNormalize();

--- a/test/com/google/javascript/jscomp/ReplaceStringsTest.java
+++ b/test/com/google/javascript/jscomp/ReplaceStringsTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.ReplaceStrings.Result;
 import com.google.javascript.rhino.Node;
@@ -137,7 +138,7 @@ public final class ReplaceStringsTest extends TypeICompilerTestCase {
         if (rename) {
           NodeTraversal.traverseEs6(compiler, js, new Renamer(compiler));
         }
-        new CollapseProperties(compiler).process(externs, js);
+        new CollapseProperties(compiler, PropertyCollapseLevel.ALL).process(externs, js);
         if (runDisambiguateProperties) {
           SourceInformationAnnotator sia =
               new SourceInformationAnnotator("test", false /* checkAnnotated */);


### PR DESCRIPTION
When a function wrapper is assumed, dead code elimination can be significantly improved by collapsing module export properties. This is particularly effective when utilizing ES modules with multiple exports as any unused exports can be dead-code eliminated.

Fixes #1954

cc @cramforce 