### PR TITLE
Add webkitRelativePath to the File interface

### DIFF
--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -336,6 +336,12 @@ File.prototype.lastModifiedDate;
 File.prototype.lastModified;
 
 /**
+ * @see https://wicg.github.io/entries-api/#dom-file-webkitrelativepath
+ * @type {string}
+ */
+File.prototype.webkitRelativePath;
+
+/**
  * @see http://www.w3.org/TR/file-system-api/#the-fileentry-interface
  * @constructor
  * @extends {Entry}


### PR DESCRIPTION
This property exists in the latest Chrome, Firefox and Edge. It is needed for directory upload.

See https://wicg.github.io/entries-api/#dom-file-webkitrelativepath