### PR TITLE
Adds support for webpack module resolution

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1085,6 +1085,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
 
       ImmutableMap.Builder<String, SourceMapInput> inputSourceMaps
           = new ImmutableMap.Builder<>();
+      ImmutableMap.Builder<String, String> inputPathByWebpackId = new ImmutableMap.Builder<>();
 
       boolean foundJsonInputSourceMap = false;
       for (JsonFileSpec jsonFile : jsonFiles) {
@@ -1095,12 +1096,20 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
           inputSourceMaps.put(jsonFile.getPath(), new SourceMapInput(sourceMap));
           foundJsonInputSourceMap = true;
         }
+        if (jsonFile.getWebpackId() != null) {
+          inputPathByWebpackId.put(jsonFile.getWebpackId(), jsonFile.getPath());
+        }
       }
 
       if (foundJsonInputSourceMap) {
         inputSourceMaps.putAll(options.inputSourceMaps);
         options.inputSourceMaps = inputSourceMaps.build();
       }
+
+      compiler.initWebpackMap(inputPathByWebpackId.build());
+    } else {
+      ImmutableMap<String, String> emptyMap = ImmutableMap.of();
+      compiler.initWebpackMap(emptyMap);
     }
 
     compiler.initWarningsGuard(options.getWarningsGuard());
@@ -2707,16 +2716,22 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   protected static class JsonFileSpec {
     private final String src;
     private final String path;
+    private final String webpackId;
     private String sourceMap;
 
     public JsonFileSpec(String src, String path) {
-      this(src, path, null);
+      this(src, path, null, null);
     }
 
     public JsonFileSpec(String src, String path, String sourceMap) {
+      this(src, path, sourceMap, null);
+    }
+
+    public JsonFileSpec(String src, String path, String sourceMap, String webpackId) {
       this.src = src;
       this.path = path;
       this.sourceMap = sourceMap;
+      this.webpackId = webpackId;
     }
 
     public String getSrc() {
@@ -2729,6 +2744,10 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
 
     public String getSourceMap() {
       return this.sourceMap;
+    }
+
+    public String getWebpackId() {
+      return this.webpackId;
     }
 
     public void setSourceMap(String map) {

--- a/src/com/google/javascript/jscomp/ClosureRewriteModule.java
+++ b/src/com/google/javascript/jscomp/ClosureRewriteModule.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.javascript.jscomp.NodeTraversal.Callback;
 import com.google.javascript.jscomp.NodeTraversal.ScopedCallback;
+import com.google.javascript.jscomp.deps.ModuleLoader.ResolutionMode;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.JSDocInfoBuilder;
@@ -981,7 +982,9 @@ final class ClosureRewriteModule implements HotSwapCompilerPass {
       t.report(legacyNamespaceNode, INVALID_GET_NAMESPACE);
       return;
     }
-    if (!currentScript.isModule && t.inGlobalScope()) {
+    if (!currentScript.isModule
+        && t.inGlobalScope()
+        && compiler.getOptions().moduleResolutionMode != ResolutionMode.WEBPACK) {
       t.report(legacyNamespaceNode, INVALID_GET_CALL_SCOPE);
       return;
     }

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -779,7 +779,7 @@ public class CommandLineRunner extends
       usage =
           "Specifies how the compiler locates modules. BROWSER requires all module imports "
               + "to begin with a '.' or '/' and have a file extension. NODE uses the node module "
-              + "rules."
+              + "rules. WEBPACK looks up modules from a special lookup map."
     )
     private ModuleLoader.ResolutionMode moduleResolutionMode = ModuleLoader.ResolutionMode.BROWSER;
 

--- a/src/com/google/javascript/jscomp/CompilerInput.java
+++ b/src/com/google/javascript/jscomp/CompilerInput.java
@@ -61,6 +61,7 @@ public class CompilerInput implements SourceAst, DependencyInfo {
   private final List<String> extraRequires = new ArrayList<>();
   private final List<String> extraProvides = new ArrayList<>();
   private final List<String> orderedRequires = new ArrayList<>();
+  private final List<String> dynamicRequires = new ArrayList<>();
   private boolean hasFullParseDependencyInfo = false;
   private ModuleType jsModuleType = ModuleType.NONE;
 
@@ -214,6 +215,28 @@ public class CompilerInput implements SourceAst, DependencyInfo {
   public boolean addOrderedRequire(String require) {
     if (!orderedRequires.contains(require)) {
       orderedRequires.add(require);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the types that this input dynamically depends on in the order seen in the file. The
+   * returned types were loaded dynamically so while they are part of the dependency graph, they do
+   * not need sorted before this input.
+   */
+  public List<String> getDynamicRequires() {
+    return ImmutableList.copyOf(dynamicRequires);
+  }
+
+  /**
+   * Registers a type that this input depends on in the order seen in the file. The type was loaded
+   * dynamically so while it is part of the dependency graph, it does not need sorted before this
+   * input.
+   */
+  public boolean addDynamicRequire(String require) {
+    if (!dynamicRequires.contains(require)) {
+      dynamicRequires.add(require);
       return true;
     }
     return false;

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -3618,7 +3618,7 @@ public final class DefaultPassConfig extends PassConfig {
 
         @Override
         public FeatureSet featureSet() {
-          return ES8_MODULES;
+          return ES_NEXT;
         }
       };
 

--- a/src/com/google/javascript/jscomp/JSModuleGraph.java
+++ b/src/com/google/javascript/jscomp/JSModuleGraph.java
@@ -412,8 +412,7 @@ public final class JSModuleGraph implements Serializable {
 
     SortedDependencies<CompilerInput> sorter = new Es6SortedDependencies<>(inputs);
 
-    Iterable<CompilerInput> entryPointInputs = createEntryPointInputs(
-        depOptions, inputs, sorter);
+    Set<CompilerInput> entryPointInputs = createEntryPointInputs(depOptions, inputs, sorter);
 
     HashMap<String, CompilerInput> inputsByProvide = new HashMap<>();
     for (CompilerInput input : inputs) {
@@ -423,6 +422,17 @@ public final class JSModuleGraph implements Serializable {
       String moduleName = input.getPath().toModuleName();
       if (!inputsByProvide.containsKey(moduleName)) {
         inputsByProvide.put(moduleName, input);
+      }
+    }
+
+    // Dynamically imported files must be added to the module graph, but
+    // they should not be ordered ahead of the files that import them.
+    // We add them as entry points to ensure they get included.
+    for (CompilerInput input : inputs) {
+      for (String require : input.getDynamicRequires()) {
+        if (inputsByProvide.containsKey(require)) {
+          entryPointInputs.add(inputsByProvide.get(require));
+        }
       }
     }
 
@@ -539,7 +549,7 @@ public final class JSModuleGraph implements Serializable {
     return orderedInputs;
   }
 
-  private Collection<CompilerInput> createEntryPointInputs(
+  private Set<CompilerInput> createEntryPointInputs(
       DependencyOptions depOptions,
       List<CompilerInput> inputs,
       SortedDependencies<CompilerInput> sorter)

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -15,6 +15,7 @@
  */
 package com.google.javascript.jscomp;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -44,6 +45,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
   private static final String EXPORTS = "exports";
   private static final String MODULE = "module";
   private static final String REQUIRE = "require";
+  private static final String WEBPACK_REQUIRE = "__webpack_require__";
   private static final String EXPORT_PROPERTY_NAME = "default";
 
   public static final DiagnosticType UNKNOWN_REQUIRE_ENSURE =
@@ -78,6 +80,10 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
     if (n.isRoot()) {
       return true;
     } else if (n.isScript()) {
+      if (compiler.getOptions().getModuleResolutionMode() == ModuleLoader.ResolutionMode.WEBPACK) {
+        removeWebpackModuleShim(n);
+      }
+
       FindImportsAndExports finder = new FindImportsAndExports();
       NodeTraversal.traverseEs6(compiler, n, finder);
 
@@ -157,24 +163,60 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
     return moduleName + "." + EXPORT_PROPERTY_NAME;
   }
 
+  public boolean isCommonJsImport(Node requireCall) {
+    return isCommonJsImport(requireCall, compiler.getOptions().getModuleResolutionMode());
+  }
+
   /**
-   * Recognize if a node is a module import. We recognize the form:
+   * Recognize if a node is a module import. We recognize two forms:
    *
    * <ul>
    *   <li>require("something");
+   *   <li>__webpack_require__(4); // only when the module resolution is WEBPACK
    * </ul>
    */
-  public static boolean isCommonJsImport(Node requireCall) {
+  public static boolean isCommonJsImport(
+      Node requireCall, ModuleLoader.ResolutionMode resolutionMode) {
     if (requireCall.isCall() && requireCall.hasTwoChildren()) {
-      if (requireCall.getFirstChild().matchesQualifiedName(REQUIRE)
+      if (resolutionMode == ModuleLoader.ResolutionMode.WEBPACK
+          && requireCall.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE)
+          && (requireCall.getSecondChild().isNumber() || requireCall.getSecondChild().isString())) {
+        return true;
+      } else if (requireCall.getFirstChild().matchesQualifiedName(REQUIRE)
           && requireCall.getSecondChild().isString()) {
         return true;
       }
+    } else if (requireCall.isCall()
+        && requireCall.getChildCount() == 3
+        && resolutionMode == ModuleLoader.ResolutionMode.WEBPACK
+        && requireCall.getFirstChild().isQualifiedName()
+        && requireCall.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE + ".bind")
+        && requireCall.getSecondChild().isNull()
+        && (requireCall.getChildAtIndex(2).isNumber()
+            || requireCall.getChildAtIndex(2).isString())) {
+      return true;
     }
     return false;
   }
 
-  public static String getCommonJsImportPath(Node requireCall) {
+  public String getCommonJsImportPath(Node requireCall) {
+    return getCommonJsImportPath(requireCall, compiler.getOptions().getModuleResolutionMode());
+  }
+
+  public static String getCommonJsImportPath(
+      Node requireCall, ModuleLoader.ResolutionMode resolutionMode) {
+    if (resolutionMode == ModuleLoader.ResolutionMode.WEBPACK) {
+      Node pathArgument =
+          requireCall.getChildCount() >= 3
+              ? requireCall.getChildAtIndex(2)
+              : requireCall.getSecondChild();
+      if (pathArgument.isNumber()) {
+        return String.valueOf((int) pathArgument.getDouble());
+      } else {
+        return pathArgument.getString();
+      }
+    }
+
     return requireCall.getSecondChild().getString();
   }
 
@@ -198,15 +240,16 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
    * Recognize if a node is a module export. We recognize several forms:
    *
    * <ul>
-   *   <li> module.exports = something;
-   *   <li> module.exports.something = something;
-   *   <li> exports.something = something;
+   *   <li>module.exports = something;
+   *   <li>module.exports.something = something;
+   *   <li>exports.something = something;
    * </ul>
    *
    * <p>In addition, we only recognize an export if the base export object is not defined or is
    * defined in externs.
    */
-  public static boolean isCommonJsExport(NodeTraversal t, Node export) {
+  public static boolean isCommonJsExport(
+      NodeTraversal t, Node export, ModuleLoader.ResolutionMode resolutionMode) {
     if (export.matchesQualifiedName(MODULE + "." + EXPORTS)) {
       Var v = t.getScope().getVar(MODULE);
       if (v == null || v.isExtern()) {
@@ -217,6 +260,62 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       if (v == null || v.isGlobal()) {
         return true;
       }
+    }
+    return false;
+  }
+
+  private boolean isCommonJsExport(NodeTraversal t, Node export) {
+    return ProcessCommonJSModules.isCommonJsExport(
+        t, export, compiler.getOptions().getModuleResolutionMode());
+  }
+
+  /**
+   * Recognize if a node is a dynamic module import. Currently only the webpack dynamic import is
+   * recognized:
+   *
+   * <ul>
+   *   <li>__webpack_require__.e(0).then(function() { return __webpack_require(4);})
+   * </ul>
+   */
+  public static boolean isCommonJsDynamicImportCallback(
+      Node n, ModuleLoader.ResolutionMode resolutionMode) {
+    if (resolutionMode != ModuleLoader.ResolutionMode.WEBPACK) {
+      return false;
+    }
+    if (n.isFunction() && isWebpackRequireEnsureCallback(n)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Recognizes __webpack_require__ calls that are the .then callback of a __webpack_require__.e
+   * call. Example:
+   *
+   * <p>__webpack_require__.e(0).then(function() { return __webpack_require__(4); })
+   */
+  private static boolean isWebpackRequireEnsureCallback(Node fnc) {
+    checkArgument(fnc.isFunction());
+    if (fnc.getParent() == null) {
+      return false;
+    }
+
+    Node callParent = fnc.getParent();
+    if (!callParent.isCall()) {
+      return false;
+    }
+
+    if (callParent.hasChildren()
+        && callParent.getFirstChild().isGetProp()
+        && callParent.getFirstFirstChild().isCall()
+        && callParent
+            .getFirstFirstChild()
+            .getFirstChild()
+            .matchesQualifiedName(WEBPACK_REQUIRE + ".e")
+        && callParent.getFirstChild().getSecondChild().isString()
+        && callParent.getFirstChild().getSecondChild().getString().equals("then")) {
+      return true;
     }
     return false;
   }
@@ -329,6 +428,93 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
     compiler.reportChangeToEnclosingScope(root);
 
     return true;
+  }
+
+  /**
+   * For AMD wrappers, webpack adds a shim for the "module" variable. We need that to be a free var
+   * so we remove the shim.
+   */
+  private void removeWebpackModuleShim(Node root) {
+    checkState(root.isScript());
+    Node n = root.getFirstChild();
+
+    // Sometimes scripts start with a semicolon for easy concatenation.
+    // Skip any empty statements from those
+    while (n != null && n.isEmpty()) {
+      n = n.getNext();
+    }
+
+    // An IIFE wrapper must be the only non-empty statement in the script,
+    // and it must be an expression statement.
+    if (n == null || !n.isExprResult() || n.getNext() != null) {
+      return;
+    }
+
+    Node call = n.getFirstChild();
+    if (call == null || !call.isCall()) {
+      return;
+    }
+
+    // Find the IIFE call and function nodes
+    Node fnc;
+    if (call.getFirstChild().isFunction()) {
+      fnc = n.getFirstFirstChild();
+    } else if (call.getFirstChild().isGetProp()
+        && call.getFirstFirstChild().isFunction()
+        && call.getFirstFirstChild().getNext().isString()
+        && call.getFirstFirstChild().getNext().getString().equals("call")) {
+      fnc = call.getFirstFirstChild();
+    } else {
+      return;
+    }
+
+    Node params = NodeUtil.getFunctionParameters(fnc);
+    Node moduleParam = null;
+    Node param = params.getFirstChild();
+    int paramNumber = 0;
+    while (param != null) {
+      paramNumber++;
+      if (param.isName() && param.getString().equals(MODULE)) {
+        moduleParam = param;
+        break;
+      }
+      param = param.getNext();
+    }
+    if (moduleParam == null) {
+      return;
+    }
+
+    boolean isFreeCall = call.getBooleanProp(Node.FREE_CALL);
+    Node arg = call.getChildAtIndex(isFreeCall ? paramNumber : paramNumber + 1);
+    if (arg == null) {
+      return;
+    }
+
+    if (arg.isCall()
+        && arg.getFirstChild().isCall()
+        && isCommonJsImport(arg.getFirstChild())
+        && arg.getSecondChild().isName()
+        && arg.getSecondChild().getString().equals(MODULE)) {
+      String importPath = getCommonJsImportPath(arg.getFirstChild());
+
+      ModulePath modulePath =
+          compiler
+              .getInput(root.getInputId())
+              .getPath()
+              .resolveJsModule(
+                  importPath, arg.getSourceFileName(), arg.getLineno(), arg.getCharno());
+      if (modulePath == null) {
+        // The module loader will issue an error
+        return;
+      }
+
+      if (modulePath.toString().contains("/buildin/module.js")) {
+        arg.detachFromParent();
+        param.detachFromParent();
+        compiler.reportChangeToChangeScope(fnc);
+        compiler.reportChangeToEnclosingScope(fnc);
+      }
+    }
   }
 
   /**
@@ -468,7 +654,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
         exports.add(new ExportInfo(n, t.getScope()));
       }
 
-      if (ProcessCommonJSModules.isCommonJsImport(n)) {
+      if (isCommonJsImport(n)) {
         visitRequireCall(t, n, parent);
       }
     }
@@ -1028,27 +1214,49 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
               break;
             }
             final Var nameDeclaration = t.getScope().getVar(qName);
-            if (nameDeclaration != null
-                && nameDeclaration.getNode() != null
-                && Objects.equals(nameDeclaration.getNode().getInputId(), n.getInputId())) {
-              // Avoid renaming a shadowed global
-              //
-              // var angular = angular;  // value is global ref
-              Node enclosingDeclaration =
-                  NodeUtil.getEnclosingNode(
-                      n,
-                      new Predicate<Node>() {
-                        @Override
-                        public boolean apply(Node node) {
-                          return node == nameDeclaration.getNameNode();
-                        }
-                      });
-
-              if (enclosingDeclaration == null
-                  || enclosingDeclaration == n
-                  || nameDeclaration.getScope() != t.getScope()) {
+            if (nameDeclaration != null) {
+              if (NodeUtil.isLhsByDestructuring(n)) {
                 maybeUpdateName(t, n, nameDeclaration);
+              } else if (nameDeclaration.getNode() != null
+                  && Objects.equals(nameDeclaration.getNode().getInputId(), n.getInputId())) {
+                // Avoid renaming a shadowed global
+                //
+                // var angular = angular;  // value is global ref
+                Node enclosingDeclaration =
+                    NodeUtil.getEnclosingNode(
+                        n,
+                        new Predicate<Node>() {
+                          @Override
+                          public boolean apply(Node node) {
+                            return node == nameDeclaration.getNameNode();
+                          }
+                        });
+
+                if (enclosingDeclaration == null
+                    || enclosingDeclaration == n
+                    || nameDeclaration.getScope() != t.getScope()) {
+                  maybeUpdateName(t, n, nameDeclaration);
+                }
               }
+            }
+            break;
+          }
+
+          // ES6 object literal shorthand notation can refer to renamed variables
+        case STRING_KEY:
+          {
+            if (n.hasChildren() || n.isQuotedString() || NodeUtil.isLhsByDestructuring(n)) {
+              break;
+            }
+            Var nameDeclaration = t.getScope().getVar(n.getString());
+            if (nameDeclaration == null) {
+              break;
+            }
+            String importedName = getModuleImportName(t, nameDeclaration.getNode());
+            if (nameDeclaration.isGlobal() || importedName != null) {
+              Node value = IR.name(n.getString()).useSourceInfoFrom(n);
+              n.addChildToBack(value);
+              maybeUpdateName(t, value, nameDeclaration);
             }
             break;
           }

--- a/src/com/google/javascript/jscomp/deps/WebpackModuleResolver.java
+++ b/src/com/google/javascript/jscomp/deps/WebpackModuleResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.deps;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.ErrorHandler;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Resolution algorithm for Webpack. Modules are located by a map of numeric ids to module paths.
+ *
+ * <p>As the compiler normally locates modules by path string, webpack numeric ids are converted to
+ * strings.
+ */
+public class WebpackModuleResolver extends NodeModuleResolver {
+  private final ImmutableMap<String, String> modulesById;
+
+  public WebpackModuleResolver(
+      ImmutableSet<String> modulePaths,
+      ImmutableList<String> moduleRootPaths,
+      Map<String, String> modulesById,
+      ErrorHandler errorHandler) {
+    super(modulePaths, moduleRootPaths, null, errorHandler);
+
+    this.modulesById = ImmutableMap.copyOf(modulesById);
+  }
+
+  @Override
+  @Nullable
+  public String resolveJsModule(
+      String scriptAddress, String moduleAddress, String sourcename, int lineno, int colno) {
+    String loadAddress = modulesById.get(moduleAddress);
+    if (loadAddress == null) {
+      // Module paths may still be used in type nodes so we need to fall back
+      // to node module resolution for those.
+      return super.resolveJsModule(scriptAddress, moduleAddress, sourcename, lineno, colno);
+    }
+    return loadAddress;
+  }
+}

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.javascript.jscomp.AbstractCompiler.MostRecentTypechecker;
@@ -43,8 +44,10 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import junit.framework.TestCase;
@@ -178,6 +181,8 @@ public abstract class CompilerTestCase extends TestCase {
   private boolean astValidationEnabled;
 
   private final Set<DiagnosticType> ignoredWarnings = new HashSet<>();
+
+  private final Map<String, String> webpackModulesById = new HashMap<>();
 
   /** Whether {@link #setUp} has run. */
   private boolean setUpRan = false;
@@ -935,6 +940,11 @@ public abstract class CompilerTestCase extends TestCase {
   protected final void setExpectParseWarningsThisTest() {
     checkState(this.setUpRan, "Attempted to configure before running setUp().");
     expectParseWarningsThisTest = true;
+  }
+
+  protected final void setWebpackModulesById(Map<String, String> webpackModulesById) {
+    this.webpackModulesById.clear();
+    this.webpackModulesById.putAll(webpackModulesById);
   }
 
   /** Returns a newly created TypeCheck. */
@@ -2021,6 +2031,9 @@ public abstract class CompilerTestCase extends TestCase {
   protected Compiler createCompiler() {
     Compiler compiler = new Compiler();
     compiler.setFeatureSet(acceptedLanguage.toFeatureSet());
+    if (!webpackModulesById.isEmpty()) {
+      compiler.initWebpackMap(ImmutableMap.copyOf(webpackModulesById));
+    }
     return compiler;
   }
 

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.deps.ModuleLoader;
+import java.util.HashMap;
 
 /**
  * Unit tests for {@link ProcessCommonJSModules}
@@ -26,12 +27,13 @@ import com.google.javascript.jscomp.deps.ModuleLoader;
 public final class ProcessCommonJSModulesTest extends CompilerTestCase {
 
   private ImmutableList<String> moduleRoots = null;
+  private ModuleLoader.ResolutionMode resolutionMode = ModuleLoader.ResolutionMode.NODE;
 
   @Override
   protected CompilerOptions getOptions() {
     CompilerOptions options = super.getOptions();
     options.setProcessCommonJSModules(true);
-    options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
+    options.setModuleResolutionMode(resolutionMode);
 
     if (moduleRoots != null) {
       options.setModuleRoots(moduleRoots);
@@ -529,6 +531,18 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         lines(
             "const {foo, bar} = module$other.default;",
             "var baz = module$other.default.foo + module$other.default.bar;"));
+  }
+
+  public void testDestructuringImports2() {
+    setLanguage(
+        CompilerOptions.LanguageMode.ECMASCRIPT_2015, CompilerOptions.LanguageMode.ECMASCRIPT5);
+    testModules(
+        "test.js",
+        lines("const {foo, bar: {baz}} = require('./other');", "module.exports = true;"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "const {foo: foo$$module$test, bar: {baz: baz$$module$test}} = module$other.default;",
+            "/** @const */ module$test.default = true;"));
   }
 
   public void testAnnotationsCopied() {
@@ -1111,5 +1125,70 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "/** @const */ var module$test = {};",
             "/** @const */ module$test.default = 'foo';",
             "function foobar$$module$test(module) { return module.id; }"));
+  }
+
+  public void testWebpackRequire() {
+    HashMap<String, String> webpackModulesById = new HashMap<>();
+    webpackModulesById.put("1", "other.js");
+    webpackModulesById.put("2", "yet_another.js");
+    webpackModulesById.put("3", "test.js");
+    setWebpackModulesById(webpackModulesById);
+    resolutionMode = ModuleLoader.ResolutionMode.WEBPACK;
+
+    testModules(
+        "test.js",
+        lines("var name = __webpack_require__(1);", "exports.foo = 1;"),
+        lines(
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "var name$$module$test = module$other.default;",
+            "module$test.default.foo = 1;"));
+  }
+
+  public void testWebpackRequireString() {
+    HashMap<String, String> webpackModulesById = new HashMap<>();
+    webpackModulesById.put("1", "other.js");
+    webpackModulesById.put("yet_another.js", "yet_another.js");
+    webpackModulesById.put("3", "test.js");
+    setWebpackModulesById(webpackModulesById);
+    resolutionMode = ModuleLoader.ResolutionMode.WEBPACK;
+
+    testModules(
+        "test.js",
+        lines("var name = __webpack_require__('yet_another.js');", "exports.foo = 1;"),
+        lines(
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "var name$$module$test = module$yet_another.default;",
+            "module$test.default.foo = 1;"));
+  }
+
+  public void testWebpackAMDModuleShim() {
+    HashMap<String, String> webpackModulesById = new HashMap<>();
+    webpackModulesById.put("1", "test.js");
+    webpackModulesById.put("2", "/webpack/buildin/module.js");
+    setWebpackModulesById(webpackModulesById);
+    resolutionMode = ModuleLoader.ResolutionMode.WEBPACK;
+
+    // Shared with ProcessCommonJSModulesTest.
+    ImmutableList<SourceFile> inputs =
+        ImmutableList.of(
+            SourceFile.fromCode(
+                "test.js",
+                lines(
+                    "(function(module) {",
+                    "  console.log(module.id);",
+                    "})(__webpack_require__(2)(module))")),
+            SourceFile.fromCode(
+                "/webpack/buildin/module.js",
+                "module.exports = function(module) { return module; };"));
+    ImmutableList<SourceFile> expecteds =
+        ImmutableList.of(
+            SourceFile.fromCode("test.js", "(function(){console.log('test.js')})()"),
+            SourceFile.fromCode(
+                "/webpack/buildin/module.js",
+                lines(
+                    "/** @const */ var module$webpack$buildin$module = {};",
+                    "/** @const */ module$webpack$buildin$module.default = ",
+                    "    function(module) { return module; };")));
+    test(inputs, expecteds);
   }
 }


### PR DESCRIPTION
* Adds a webpack specific module resolution mode to lookup modules by their webpack id. Requires passing in webpack module ids with the associated source.
* Adds support for dynamically loaded modules by treating them as entry points in the module graph. Late loaded webpack modules are the only recognized form so far, but the dynamic `import()` statement can use the same mechanism when supported.
* ProcessCommonJSModules is updated to recognize and rewrite webpack specific require calls.

This is the last PR in a long chain to get full webpack support.