### PR TITLE
Update w3c_eventsource.js

### DIFF
--- a/externs/browser/w3c_eventsource.js
+++ b/externs/browser/w3c_eventsource.js
@@ -95,6 +95,6 @@ EventSource.prototype.onmessage = function(e) {};
 EventSource.prototype.onerror = function(e) {};
 
 /**
- * @type {function()}
+ * @return {undefined}
  */
 EventSource.prototype.close = function() {};


### PR DESCRIPTION
EventSource.prototype.close should be a method.

https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events