### PR TITLE
Add IRegExpResult

### DIFF
--- a/externs/es3.js
+++ b/externs/es3.js
@@ -142,6 +142,18 @@ function IArrayLike() {}
 IArrayLike.prototype.length;
 
 /**
+ * @record
+ * @extends {IArrayLike.<string>}
+ */
+function IRegExpResult() {};
+
+/** @type {number} */
+IRegExpResult.prototype.index;
+
+/** @type {string} */
+IRegExpResult.prototype.input;
+
+/**
  * @constructor
  * @implements {IArrayLike<T>}
  * @template T
@@ -1873,9 +1885,7 @@ String.prototype.localeCompare = function(compareString, locales, options) {};
  *
  * @this {String|string}
  * @param {*} regexp
- * @return {Array<string>} This should really return an Array with a few
- *     special properties, but we do not have a good way to model this in
- *     our type system. Also see Regexp.prototype.exec.
+ * @return {IRegExpResult}
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
  */
 String.prototype.match = function(regexp) {};
@@ -2068,9 +2078,7 @@ RegExp.prototype.compile = function(pattern, opt_flags) {};
 
 /**
  * @param {*} str The string to search.
- * @return {Array<string>} This should really return an Array with a few
- *     special properties, but we do not have a good way to model this in
- *     our type system. Also see String.prototype.match.
+ * @return {IRegExpResult}
  * @see http://msdn.microsoft.com/en-us/library/z908hy33(VS.85).aspx
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
  */


### PR DESCRIPTION
Interface that matches the return value of String.prototype.match and RegExp.prototype.exec
Currently we need to use a cast to access the "index" and "input" properties.