### PR TITLE
Externs createNodeIterator and createTreeWalker exists on Document

### DIFF
--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -52,6 +52,32 @@ Document.prototype.createAttributeNS =
     function(namespaceURI, qualifiedName) {};
 
 /**
+ * @param {Node} root
+ * @param {number=} whatToShow
+ * @param {NodeFilter=} filter
+ * @param {boolean=} entityReferenceExpansion
+ * @return {!NodeIterator}
+ * @see https://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/traversal.html#Traversal-Document
+ * @see https://dom.spec.whatwg.org/#interface-document
+ * @nosideeffects
+ */
+Document.prototype.createNodeIterator = function(
+    root, whatToShow, filter, entityReferenceExpansion) {};
+
+/**
+ * @param {Node} root
+ * @param {number=} whatToShow
+ * @param {NodeFilter=} filter
+ * @param {boolean=} entityReferenceExpansion
+ * @return {!TreeWalker}
+ * @see https://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/traversal.html#Traversal-Document
+ * @see https://dom.spec.whatwg.org/#interface-document
+ * @nosideeffects
+ */
+Document.prototype.createTreeWalker = function(
+    root, whatToShow, filter, entityReferenceExpansion) {};
+
+/**
  * @param {string} namespace
  * @param {string} name
  * @return {!NodeList<!Element>}
@@ -236,30 +262,6 @@ HTMLDocument.prototype.writeln = function(text) {};
  * @nosideeffects
  */
 HTMLDocument.prototype.getElementsByName = function(elementName) {};
-
-/**
- * @param {Node} root
- * @param {number=} whatToShow
- * @param {NodeFilter=} filter
- * @param {boolean=} entityReferenceExpansion
- * @return {!NodeIterator}
- * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-Document
- * @nosideeffects
- */
-HTMLDocument.prototype.createNodeIterator = function(
-    root, whatToShow, filter, entityReferenceExpansion) {};
-
-/**
- * @param {Node} root
- * @param {number=} whatToShow
- * @param {NodeFilter=} filter
- * @param {boolean=} entityReferenceExpansion
- * @return {!TreeWalker}
- * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-Document
- * @nosideeffects
- */
-HTMLDocument.prototype.createTreeWalker = function(
-    root, whatToShow, filter, entityReferenceExpansion) {};
 
 
 /** @typedef {{


### PR DESCRIPTION
For #2793

`createNodeIterator` and `createTreeWalker` are defined on `Document` according to https://dom.spec.whatwg.org/#interface-document, not on `HTMLDocument` as it is currently in your externs file.

https://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/traversal.html#Traversal-Document defines them to exists on `DocumentTraversal` which I'm not sure what that means in practice, but somewhere in the documentation it was mentioned that a `Document` can simply be cast to `DocumentTraversal` to access them. Anyway, this spec just confuses me, it doesn't seem to relate to JS specifically.

I've left both URLs in as comments to both reflect the DOM level 2 status and as a source for them existing on `Document`.

cc @MatrixFrog 