### PR TITLE
Add SourceMapObjectParserJs.getLineCount implementation

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapObjectParserJs.java
+++ b/src/com/google/debugging/sourcemap/SourceMapObjectParserJs.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
@@ -56,8 +57,11 @@ public class SourceMapObjectParserJs {
     Section[] sections;
     String[] sources;
     String[] names;
-    @JsMethod
-    native Object getLineCount();
+
+    @JsOverlay
+    public final Object getLineCount() {
+      return this.lineCount;
+    }
   }
 
   @JsType(isNative = true, name = "Object", namespace = JsPackage.GLOBAL)


### PR DESCRIPTION
The implementation was missing but used in the non-JVM version when building
  source maps.  The proposed implementation just returns the value of the
  lineCount property and fixes the problem.