### PR TITLE
Document the rename_variable_prefix and rename_prefix_namespace command line options

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -855,6 +855,8 @@ public class CommandLineRunner extends
                     "export_local_property_definitions",
                     "formatting",
                     "generate_exports",
+                    "rename_variable_prefix",
+                    "rename_prefix_namespace",
                     "isolation_mode",
                     "output_wrapper",
                     "output_wrapper_file"))


### PR DESCRIPTION
I just spent an hour trying to replicate this functionality using `--module_output_wrapper` and the like because I assumed these options were only available in Java. Then when I went to expose them myself, lo and behold, they already existed but were undocumented!

So after this, nobody else should share my fate. :)