### PR TITLE
Allow typed ES6 keywords in import and export statements

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
  * <p>7 Lexical Conventions
  */
 public class Scanner {
+  private final boolean parseTypeSyntax;
   private final ErrorReporter errorReporter;
   private final SourceFile source;
   private final ArrayList<Token> currentTokens = new ArrayList<>();
@@ -39,13 +40,14 @@ public class Scanner {
   private final CommentRecorder commentRecorder;
   private int typeParameterLevel;
 
-  public Scanner(ErrorReporter errorReporter, CommentRecorder commentRecorder,
+  public Scanner(boolean parseTypeSyntax, ErrorReporter errorReporter, CommentRecorder commentRecorder,
       SourceFile source) {
-    this(errorReporter, commentRecorder, source, 0);
+    this(parseTypeSyntax, errorReporter, commentRecorder, source, 0);
   }
 
-  public Scanner(ErrorReporter errorReporter, CommentRecorder commentRecorder,
+  public Scanner(boolean parseTypeSyntax, ErrorReporter errorReporter, CommentRecorder commentRecorder,
       SourceFile file, int offset) {
+    this.parseTypeSyntax = parseTypeSyntax;
     this.errorReporter = errorReporter;
     this.commentRecorder = commentRecorder;
     this.source = file;
@@ -725,7 +727,7 @@ public class Scanner {
     }
 
     Keywords k = Keywords.get(value);
-    if (k != null) {
+    if (k != null && (!Keywords.isTypeScriptSpecificKeyword(value) || parseTypeSyntax)) {
       return new Token(k.type, getTokenRange(beginToken));
     }
 

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -3657,6 +3657,15 @@ public final class ParserTest extends BaseJSTypeTestCase {
     parseError("export * as s from './someModule';", "'from' expected");
   }
 
+  public void testImportExportTypescriptKeyword() {
+    mode = LanguageMode.TYPESCRIPT;
+    parseError("export { namespace };", "cannot use keyword 'namespace' here.");
+
+    mode = LanguageMode.ECMASCRIPT6;
+    parse("export { namespace };");
+    parse("import { namespace } from './input0.js';");
+  }
+
   public void testGoogModule() {
     Node tree = parse("goog.module('example');");
     assertNode(tree).hasType(Token.SCRIPT);

--- a/test/com/google/javascript/jscomp/parsing/TypeSyntaxTest.java
+++ b/test/com/google/javascript/jscomp/parsing/TypeSyntaxTest.java
@@ -537,7 +537,7 @@ public final class TypeSyntaxTest extends TestCase {
     expectErrors("Parse error. Semi-colon expected");
     parse("if (true) { type Foo = number; }");
 
-    testNotEs6Typed("type Foo = number;", "type alias");
+    testNotEs6TypedFullError("type Foo = number;", "Parse error. Semi-colon expected");
   }
 
   public void testAmbientDeclaration() {
@@ -566,7 +566,8 @@ public final class TypeSyntaxTest extends TestCase {
     expectErrors("Parse error. Semi-colon expected");
     parse("declare class Foo {\n  constructor() {}\n};");
 
-    testNotEs6Typed("declare var x;", "ambient declaration");
+    testNotEs6TypedFullError("declare var x;", "Parse error. Semi-colon expected");
+
   }
 
   public void testExportDeclaration() {
@@ -728,7 +729,7 @@ public final class TypeSyntaxTest extends TestCase {
     expectErrors("Parse error. Semi-colon expected");
     parse("namespace 'foo' {}"); // External modules are not supported
 
-    testNotEs6Typed("namespace foo {}", "namespace declaration");
+    testNotEs6TypedFullError("namespace foo {}", "Parse error. Semi-colon expected");
   }
 
   public void testAmbientNameSpace() {
@@ -765,7 +766,7 @@ public final class TypeSyntaxTest extends TestCase {
     expectErrors("Parse error. '}' expected");
     parse("declare namespace foo { type Foo = number; }");
 
-    testNotEs6Typed("declare namespace foo {}", "ambient declaration", "namespace declaration");
+    testNotEs6TypedFullError("declare namespace foo {}", "Parse error. Semi-colon expected");
   }
 
   private void assertVarType(String message, TypeDeclarationNode expectedType, String source) {


### PR DESCRIPTION
Default behavior forbids the use of TypeScript keywords in import and export statements when ES6 typed features are inactive: modify scanner to emit IdentifierTokens when parseTypeSyntax is false.

Export decl parser coerces identifiers in exports to keywords: check there also.

Addresses #2005