### PR TITLE
Add sourcesContent support to 'applyInputSourceMaps' option

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,6 +44,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer,
   static final int UNMAPPED = -1;
 
   private String[] sources;
+  private String[] sourcesContent;
   private String[] names;
   private int lineCount;
   // Slots in the lines list will be null if the line does not have any entries.
@@ -92,6 +94,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer,
     lineCount = sourceMapObject.getLineCount();
     sourceRoot = sourceMapObject.getSourceRoot();
     sources = sourceMapObject.getSources();
+    sourcesContent = sourceMapObject.getSourcesContent();
     names = sourceMapObject.getNames();
 
     if (lineCount >= 0) {
@@ -182,8 +185,13 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer,
   }
 
   @Override
-  public Collection<String> getOriginalSources() {
+  public List<String> getOriginalSources() {
     return Arrays.asList(sources);
+  }
+
+  @Override
+  public List<String> getOriginalSourcesContent() {
+    return sourcesContent == null ? Collections.emptyList() : Arrays.asList(sourcesContent);
   }
 
   @Override

--- a/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
@@ -506,7 +506,13 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
       if (i != 0) {
         out.append(",");
       }
-      out.append(escapeString(contents.get(i)));
+      String content = contents.get(i);
+      if (content != null) {
+        out.append(escapeString(content));
+      }
+      else {
+        out.append("null");
+      }
     }
     out.append("]");
     appendFieldEnd(out);

--- a/src/com/google/debugging/sourcemap/SourceMapObject.java
+++ b/src/com/google/debugging/sourcemap/SourceMapObject.java
@@ -27,6 +27,7 @@ public class SourceMapObject {
   private final String file;
   private final String mappings;
   private final String[] sources;
+  private final String[] sourcesContent;
   private final String[] names;
   private final List<SourceMapSection> sections;
   private final Map<String, Object> extensions;
@@ -38,6 +39,7 @@ public class SourceMapObject {
       String file,
       String mappings,
       String[] sources,
+      String[] sourcesContent,
       String[] names,
       List<SourceMapSection> sections,
       Map<String, Object> extensions) {
@@ -47,6 +49,7 @@ public class SourceMapObject {
     this.file = file;
     this.mappings = mappings;
     this.sources = sources;
+    this.sourcesContent = sourcesContent;
     this.names = names;
     this.sections = sections;
     this.extensions = extensions;
@@ -76,6 +79,10 @@ public class SourceMapObject {
     return sources;
   }
 
+  public String[] getSourcesContent() {
+    return sourcesContent;
+  }
+
   public String[] getNames() {
     return names;
   }
@@ -99,6 +106,7 @@ public class SourceMapObject {
     private String file;
     private String mappings;
     private String[] sources;
+    private String[] sourcesContent;
     private String[] names;
     private List<SourceMapSection> sections;
     private Map<String, Object> extensions;
@@ -133,6 +141,11 @@ public class SourceMapObject {
       return this;
     }
 
+    public Builder setSourcesContent(String[] sourcesContent) {
+      this.sourcesContent = sourcesContent;
+      return this;
+    }
+
     public Builder setNames(String[] names) {
       this.names = names;
       return this;
@@ -150,7 +163,7 @@ public class SourceMapObject {
 
     public SourceMapObject build() {
       return new SourceMapObject(
-          version, lineCount, sourceRoot, file, mappings, sources, names, sections, extensions);
+          version, lineCount, sourceRoot, file, mappings, sources, sourcesContent, names, sections, extensions);
     }
   }
 }

--- a/src/com/google/debugging/sourcemap/SourceMapObjectParser.java
+++ b/src/com/google/debugging/sourcemap/SourceMapObjectParser.java
@@ -52,6 +52,9 @@ public class SourceMapObjectParser {
       }
 
       builder.setSources(getJavaStringArray(sourceMapRoot.get("sources")));
+      if (sourceMapRoot.has("sourcesContent")) {
+        builder.setSourcesContent(getJavaStringArray(sourceMapRoot.get("sourcesContent")));
+      }
       builder.setNames(getJavaStringArray(sourceMapRoot.get("names")));
 
       Map<String, Object> extensions = new LinkedHashMap<>();
@@ -99,7 +102,9 @@ public class SourceMapObjectParser {
     int len = array.size();
     String[] result = new String[len];
     for (int i = 0; i < len; i++) {
-      result[i] = array.get(i).getAsString();
+      JsonElement arrayElement = array.get(i);
+      boolean elementIsNull = arrayElement == null || arrayElement.isJsonNull();
+      result[i] = elementIsNull ? null : arrayElement.getAsString();
     }
     return result;
   }

--- a/src/com/google/debugging/sourcemap/SourceMappingReversable.java
+++ b/src/com/google/debugging/sourcemap/SourceMappingReversable.java
@@ -19,6 +19,7 @@ package com.google.debugging.sourcemap;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * A SourceMappingReversable is a SourceMapping that can provide the reverse
@@ -29,7 +30,12 @@ public interface SourceMappingReversable extends SourceMapping {
   /**
    * @return the collection of original sources in this source mapping
    */
-  public Collection<String> getOriginalSources();
+  public List<String> getOriginalSources();
+
+  /**
+   * @return the collection of original sources content in this source mapping
+   */
+  public List<String> getOriginalSourcesContent();
 
   /**
    * Given a source file, line, and column, return the reverse mapping (source → target).

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -3478,8 +3478,21 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   private void addFilesToSourceMap(Iterable<? extends SourceFile> files) {
     if (getOptions().sourceMapIncludeSourcesContent && getSourceMap() != null) {
       for (SourceFile file : files) {
-        getSourceMap().addSourceFile(file);
+        if (getOptions().applyInputSourceMaps) {
+            addOriginalFilesToSourceMap(file);
+        }
+        else {
+          getSourceMap().addSourceFile(file);
+        }
       }
+    }
+  }
+
+  private void addOriginalFilesToSourceMap(SourceFile file) {
+    List<String> originalSources = inputSourceMaps.get(file.getName()).getSourceMap(errorManager).getOriginalSources();
+    List<String> originalSourcesContent = inputSourceMaps.get(file.getName()).getSourceMap(errorManager).getOriginalSourcesContent();
+    for (int i = 0; i < originalSources.size() && i < originalSourcesContent.size(); i++) {
+      getSourceMap().addSourceFileContents(originalSources.get(i), originalSourcesContent.get(i));
     }
   }
 

--- a/src/com/google/javascript/jscomp/SourceMap.java
+++ b/src/com/google/javascript/jscomp/SourceMap.java
@@ -184,10 +184,14 @@ public final class SourceMap {
 
   public void addSourceFile(SourceFile sourceFile) {
     try {
-      generator.addSourcesContent(fixupSourceLocation(sourceFile.getName()), sourceFile.getCode());
+      addSourceFileContents(sourceFile.getName(), sourceFile.getCode());
     } catch (IOException e) {
       logger.log(Level.WARNING, "Exception while adding source content to source map.", e);
     }
+  }
+
+  public void addSourceFileContents(String sourceFileName, String content) {
+    generator.addSourcesContent(fixupSourceLocation(sourceFileName), content);
   }
 
   /**


### PR DESCRIPTION
The 'applyInputSourceMaps' option did not pipe the content sources
through to the new source map file. Now, if the option is set, the input
source map contents should appear in the output source map file.