### PR TITLE
CompilerInput.generateDependencyInfo needs to use compiler's ModuleLoader

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -584,7 +584,7 @@ public abstract class AbstractCompiler implements SourceExcerptProvider {
   /**
    * Gets the module loader.
    */
-  abstract ModuleLoader getModuleLoader();
+  public abstract ModuleLoader getModuleLoader();
 
   /** Lookup the type of a module from its name. */
   abstract CompilerInput.ModuleType getModuleTypeByName(String moduleName);

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -3471,7 +3471,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   }
 
   @Override
-  ModuleLoader getModuleLoader() {
+  public ModuleLoader getModuleLoader() {
     return moduleLoader;
   }
 

--- a/src/com/google/javascript/jscomp/CompilerInput.java
+++ b/src/com/google/javascript/jscomp/CompilerInput.java
@@ -304,6 +304,7 @@ public class CompilerInput extends DependencyInfo.Base implements SourceAst {
         DependencyInfo info =
             (new JsFileParser(compiler.getErrorManager()))
             .setIncludeGoogBase(true)
+            .setModuleLoader(compiler.getModuleLoader())
             .parseFile(getName(), getName(), getCode());
         return new LazyParsedDependencyInfo(info, (JsAst) ast, compiler);
       } catch (IOException e) {

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/JsFileParser.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/deps/JsFileParser.java
@@ -27,6 +27,10 @@ public final class JsFileParser {
     throw new UnsupportedOperationException("JsFileParser.setIncludeGoogBase not implemented");
   }
 
+  public JsFileParser setModuleLoader(ModuleLoader loader) {
+    throw new UnsupportedOperationException("JsFileParser.setModuleLoader not implemented");
+  }
+
   public DependencyInfo parseFile(String filePath, String closureRelativePath,
       String fileContents) {
     throw new UnsupportedOperationException("JsFileParser.parseFile not implemented");


### PR DESCRIPTION
See #2846. This addresses the issue by making `Compiler.getModuleLoader` public and using this in `CompilerInput.getDependencyInfo` to guarantee we get the correct information.