### PR TITLE
Fix charset in inline data url sourcemaps

### DIFF
--- a/src/com/google/javascript/jscomp/SourceMapResolver.java
+++ b/src/com/google/javascript/jscomp/SourceMapResolver.java
@@ -20,14 +20,21 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import javax.annotation.Nullable;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Utility class for resolving source maps and files referenced in source maps. */
 @GwtIncompatible("Accesses the file system")
 public class SourceMapResolver {
-  private static final String BASE64_URL_PREFIX = "data:application/json;base64,";
+  private static final String BASE64_URL_PREFIX = "data:";
+  private static final String BASE64_START = "base64,";
+  // For now only accept utf-8. We could use the actual charset information in the future.
+  private static final String[] acceptedMetadata = {
+          "application/json;charset=utf-8;",
+          "application/json;" // default is utf-8 if unspecified.
+  };
 
   /**
    * For a given //# sourceMappingUrl, this locates the appropriate sourcemap on disk. This is use
@@ -38,10 +45,11 @@ public class SourceMapResolver {
   static SourceFile extractSourceMap(
       SourceFile jsFile, String sourceMapURL, boolean parseInlineSourceMaps) {
     if (parseInlineSourceMaps && sourceMapURL.startsWith(BASE64_URL_PREFIX)) {
-      byte[] data =
-          BaseEncoding.base64().decode(sourceMapURL.substring(BASE64_URL_PREFIX.length()));
-      String source = new String(data, StandardCharsets.UTF_8);
-      return SourceFile.fromCode(jsFile.getName() + ".inline.map", source);
+      String extractedString = extractBase64String(sourceMapURL);
+      if (extractedString != null) {
+        return SourceFile.fromCode(jsFile.getName() + ".inline.map", extractedString);
+      }
+      return null;
     }
     // TODO(tdeegan): Handle absolute urls here.  The compiler needs to come up with a scheme for
     // properly resolving absolute urls from http:// or the root /some/abs/path/... See b/62544959.
@@ -51,6 +59,29 @@ public class SourceMapResolver {
     // If not absolute, its relative.
     // TODO(tdeegan): Handle urls relative to //# sourceURL. See the sourcemap spec.
     return getRelativePath(jsFile.getName(), sourceMapURL);
+  }
+
+  /**
+   * Based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+   * @param url
+   * @return String or null.
+   */
+  @Nullable
+  private static String extractBase64String(String url) {
+    if (url.startsWith(BASE64_URL_PREFIX)) {
+      if (url.contains(BASE64_START)) {
+        int base64StartIndex = url.indexOf(BASE64_START);
+        String metadata = url.substring(BASE64_URL_PREFIX.length(), base64StartIndex);
+        for (String md : acceptedMetadata) {
+          if (md.equals(metadata)) {
+            byte[] data = BaseEncoding.base64().decode(
+                    url.substring(base64StartIndex + BASE64_START.length()));
+            return new String(data, UTF_8);
+          }
+        }
+      }
+    }
+    return null;
   }
 
   @VisibleForTesting
@@ -71,6 +102,6 @@ public class SourceMapResolver {
   static SourceFile getRelativePath(String baseFilePath, String relativePath) {
     return SourceFile.fromPath(
         FileSystems.getDefault().getPath(baseFilePath).resolveSibling(relativePath).normalize(),
-        StandardCharsets.UTF_8);
+        UTF_8);
   }
 }

--- a/test/com/google/javascript/jscomp/SourceMapResolverTest.java
+++ b/test/com/google/javascript/jscomp/SourceMapResolverTest.java
@@ -41,6 +41,26 @@ public final class SourceMapResolverTest extends TestCase {
     assertNull(noInline);
   }
 
+  public void testResolveBase64WithCharsetInline() throws Exception {
+    String sourceMap = "{map: 'asdfasdf'}";
+    String encoded = BaseEncoding.base64().encode(sourceMap.getBytes("UTF-8"));
+    String url = "data:application/json;charset=utf-8;base64," + encoded;
+    String code = "console.log('asdf')\n//# sourceMappingURL=" + url;
+    SourceFile s =
+            SourceMapResolver.extractSourceMap(
+                    SourceFile.fromCode("somePath/hello.js", code), url, true);
+    assertEquals(sourceMap, s.getCode());
+    assertEquals("somePath/hello.js.inline.map", s.getName());
+
+    // Try non supported charset.
+    String dataURLWithBadCharset = "data:application/json;charset=asdf;base64," + encoded;
+    String charsetCode = "console.log('asdf')\n//# sourceMappingURL=" + dataURLWithBadCharset;
+    SourceFile result =
+            SourceMapResolver.extractSourceMap(
+                    SourceFile.fromCode("somePath/hello.js", charsetCode), dataURLWithBadCharset, true);
+    assertNull(result);
+  }
+
   public void testAbsolute() {
     SourceFile jsFile = SourceFile.fromCode("somePath/hello.js", "console.log(1)");
     // We cannot reslove absolute urls.


### PR DESCRIPTION
I noticed that babel produces inline source maps of the form:

`//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZyb250ZW5kL2FwcC9yZWFjdC1jb21wb25lbnRzL2FwcC5qc3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7Ozs7QUFJQSxTQUFTLE9BQVQsUUFBd0IsWUFBeEI7QUFDQSxPQUFPLEdBQVAsTUFBZ0IsVUFBaEI7QUFDQSxPQUFPLFlBQVAsTUFBeUIsbUJBQXpCO0FBQ0EsU0FBUyxTQUFULFFBQTBCLGFBQTFCO0FBQ0EsT0FBTyxNQUFQLE1BQW1CLFdBQW5COztBQUVBO0FBQ0EsTUFBTSxlQUFOLFNBQThCLE1BQU0sU0FBcEMsQ0FBOEM7QUFDMUM7QUFDQSxnQkFBWSxLQUFaLEVBQW1CLE9BQW5CLEVBQTRCO0FBQ3hCLGNBQU0sS0FBTixFQUFhLE9BQWI7QUFDQSxhQUFLLEtBQUwsR0FBYTtBQUNULDJCQUFlLGVBRE4sRUFDdUI7QUFDaEMsNkJBQWlCO0FBQ2IsMEJBQVU7QUFERyxhQUZSO0FBS1QsMkJBQWU7QUFDWCwwQkFBVTtBQURDLGFBTE47QUFRVCw0Q0FBaUMsSUFBSSxJQUFKLEVBQUQsQ0FBVyxPQUFYLEVBUnZCLENBUTZDO0FBUj......`

This is not recognized by the SourceMapResolver because of the 'charset=utf-8'

See acceptable data url format: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs