### PR TITLE
deprecate HTMLElement.style.setAttribute

### DIFF
--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -519,6 +519,7 @@ CSSStyleDeclaration.prototype.removeAttribute =
 CSSStyleDeclaration.prototype.removeExpression = function(name) {};
 
 /**
+ * @deprecated
  * @param {string} name
  * @param {*} value
  * @param {number=} opt_flags


### PR DESCRIPTION
fix for https://github.com/google/elemental2/issues/39

According to this PR the method is deprecated instead of being removed.
https://github.com/google/closure-compiler/pull/2831