### PR TITLE
Remove the deprecated replaceWholeText api

### DIFF
--- a/externs/browser/w3c_dom3.js
+++ b/externs/browser/w3c_dom3.js
@@ -559,13 +559,6 @@ Element.prototype.setIdAttributeNS = function(namespaceURI, localName, isId) {};
 Text.prototype.wholeText;
 
 /**
- * @param {string} newText
- * @return {Text}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Text3-replaceWholeText
- */
-Text.prototype.replaceWholeText = function(newText) {};
-
-/**
  * @constructor
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo
  */


### PR DESCRIPTION
this PR Removes the Text.replaceWholeText which is according to MDN is obsolete
https://developer.mozilla.org/en-US/docs/Web/API/Text/replaceWholeText