### PR TITLE
Implement string literal trim() folding

### DIFF
--- a/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java
+++ b/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java
@@ -218,6 +218,8 @@ class PeepholeReplaceKnownMethods extends AbstractPeepholeOptimization {
             return tryFoldStringToLowerCase(subtree, stringNode);
           case "toUpperCase":
             return tryFoldStringToUpperCase(subtree, stringNode);
+          case "trim":
+            return tryFoldStringTrim(subtree, stringNode);
           default: // fall out
         }
       } else {
@@ -314,6 +316,20 @@ class PeepholeReplaceKnownMethods extends AbstractPeepholeOptimization {
     // From Rhino, NativeString.java. See ECMA 15.5.4.12
     String upped = stringNode.getString().toUpperCase(Locale.ROOT);
     Node replacement = IR.string(upped);
+    subtree.replaceWith(replacement);
+    compiler.reportChangeToEnclosingScope(replacement);
+    return replacement;
+  }
+
+  /**
+   * @return The trimmed string Node.
+   */
+  private Node tryFoldStringTrim(Node subtree, Node stringNode) {
+    // See ECMA 15.5.4.20, 7.2, and 7.3
+    // All Unicode 10.0 whitespace + BOM
+    String whitespace = "[ \t\n-\r\\u0085\\u00A0\\u1680\\u2000-\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000\\FEFF]+";
+    String trimmed = stringNode.getString().replaceAll("^" + whitespace + "|" + whitespace + "$", "");
+    Node replacement = IR.string(trimmed);
     subtree.replaceWith(replacement);
     compiler.reportChangeToEnclosingScope(replacement);
     return replacement;

--- a/test/com/google/javascript/jscomp/PeepholeIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeIntegrationTest.java
@@ -377,6 +377,7 @@ public class PeepholeIntegrationTest extends CompilerTestCase {
     test("x = `abcdef`.charCodeAt(0)", "x = 97");
     test("x = `abc`.toUpperCase()", "x = 'ABC'");
     test("x = `ABC`.toLowerCase()", "x = 'abc'");
+    test("x = `\t\n\uFEFF\t asd foo bar \r\n`.trim()", "x = 'asd foo bar'");
     test("x = parseInt(`123`)", "x = 123");
     test("x = parseFloat(`1.23`)", "x = 1.23");
   }


### PR DESCRIPTION
The ECMAScript spec requires implementations at least trim off Unicode 3.0 whitespace characters plus the BOM. I've included all of code points with the [`White_Space` property](https://www.unicode.org/Public/UNIDATA/PropList.txt) from Unicode 10.0.0.