### PR TITLE
Fix Array.prototype.copyWithin polyfill

### DIFF
--- a/src/com/google/javascript/jscomp/js/util/tointeger.js
+++ b/src/com/google/javascript/jscomp/js/util/tointeger.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Converts argument to an integral numeric value.
+ *
+ * @see https://www.ecma-international.org/ecma-262/8.0/#sec-tointeger
+ *
+ * @param {*} arg
+ * @return {number}
+ */
+$jscomp.toInteger = function(arg) {
+  var n = Number(arg);
+  if (isNaN(n)) {
+    return 0;
+  }
+  return n > 0 ? Math.floor(n) : Math.ceil(n);
+};

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/array_copywithin_test.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/array_copywithin_test.js
@@ -64,5 +64,55 @@ testSuite({
     arr = {length: 3, 1: 4, 3: 'unused'};
     assertEquals(arr, Array.prototype.copyWithin.call(noCheck(arr), 0, 1));
     assertObjectEquals({length: 3, 0: 4, 3: 'unused'}, arr);
+
+    arr = {length: 3, 1: 4, 3: 'unused'};
+    assertEquals(arr, Array.prototype.copyWithin.call(noCheck(arr), 1, 0));
+    assertObjectEquals({length: 3, 2: 4, 3: 'unused'}, arr);
+  },
+
+  testCopyWithin_coercingArgs() {
+    assertObjectEquals([1, 2, 3, 3], [0, 1, 2, 3].copyWithin(NaN, 1));
+    assertObjectEquals([1, 2, 3, 3], [0, 1, 2, 3].copyWithin(0.5, 1));
+    assertObjectEquals([0, 0, 1, 2], [0, 1, 2, 3].copyWithin(1.5, 0));
+
+    assertObjectEquals([0, 0, 1, 2], [0, 1, 2, 3].copyWithin(1, NaN));
+    assertObjectEquals([0, 0, 1, 2], [0, 1, 2, 3].copyWithin(1, 0.5));
+    assertObjectEquals([1, 2, 3, 3], [0, 1, 2, 3].copyWithin(0, 1.5));
+
+    assertObjectEquals([0, 1, 2, 3], [0, 1, 2, 3].copyWithin(1, 0, NaN));
+    assertObjectEquals([0, 0, 2, 3], [0, 1, 2, 3].copyWithin(1, 0, 1.5));
+    assertObjectEquals([0, 0, 1, 3], [0, 1, 2, 3].copyWithin(1, 0, -2.5));
+    assertObjectEquals([0, 0, 1, 2], [0, 1, 2, 3].copyWithin(1, 0, undefined));
+  },
+
+  testCopyWithin_negativeArgs() {
+    assertObjectEquals([1, 2, 3, 1, 2], [1, 2, 3, 4, 5].copyWithin(-2, 0));
+    assertObjectEquals([1, 3, 4, 5, 5], [1, 2, 3, 4, 5].copyWithin(1, -3));
+    assertObjectEquals([1, 3, 4, 4, 5], [1, 2, 3, 4, 5].copyWithin(1, 2, -1));
+  },
+
+  testCopyWithin_throwsIfNullish() {
+    assertThrows(function() {
+      Array.prototype.copyWithin.call(null);
+    });
+    assertThrows(function() {
+      Array.prototype.copyWithin.call(undefined);
+    });
+  },
+
+  testCopyWithin_throwIfFailToDeleteProperty() {
+    var obj = {
+      length: 5
+    };
+
+    Object.defineProperty(obj, 4, {
+      value: 'a',
+      configurable: false,
+      writable: true
+    });
+
+    assertThrows(function() {
+      Array.prototype.copyWithin.call(noCheck(obj), 4, 0);
+    });
   },
 });


### PR DESCRIPTION
Improvement:
- should handle negative params
- should coerce params to integer
- fix bug in deleting props of ArrayLike
- should throw if `this` is null or undefined
- should throw if impossible to delete props

Also this fixes `.name` and `.length` with `defineProperty`.
But if the policy of Closure Compiler for them is "won't fix", I will revert them.

I don't know how to run polyfill tests (https://github.com/google/closure-compiler/issues/1504), but I confirmed this passed [all Test262 tests for copyWithin](https://github.com/tc39/test262/tree/c55d2ab7c344e35a3ceb93cf1d4d30019584db82/test/built-ins/Array/prototype/copyWithin). (https://gist.github.com/teppeis/c8a88f653cdd70ed3e3d6597ec1ee30c)

Ref:
- https://www.ecma-international.org/ecma-262/8.0/#sec-array.prototype.copywithin
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin