### PR TITLE
Fix: Map/Set polyfill should store -0 in keys as +0

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/map.js
+++ b/src/com/google/javascript/jscomp/js/es6/map.js
@@ -142,6 +142,8 @@ $jscomp.polyfill('Map',
 
   /** @override */
   PolyfillMap.prototype.set = function(key, value) {
+    // normalize -0/+0 to +0
+    key = key === 0 ? 0 : key;
     var r = maybeGetEntry(this, key);
     if (!r.list) {
       r.list = (this.data_[r.id] = []);

--- a/src/com/google/javascript/jscomp/js/es6/set.js
+++ b/src/com/google/javascript/jscomp/js/es6/set.js
@@ -109,6 +109,8 @@ $jscomp.polyfill('Set',
 
   /** @override */
   PolyfillSet.prototype.add = function(value) {
+    // normalize -0/+0 to +0
+    value = value === 0 ? 0 : value;
     this.map_.set(value, value);
     this.size = this.map_.size;
     return this;

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/map_test.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/map_test.js
@@ -63,10 +63,18 @@ testSuite({
       checkSetGet(map, keys[i], {});
     }
     assertEquals(37, map.size);
+  },
 
-    // Note: +0 and -0 are the same key
+  testKeysNormalizeZero() {
+    const map = new Map().set(-0, 'foo');
     assertTrue(map.has(-0));
-    assertEquals(map.get(0), map.get(-0));
+    assertEquals('foo', map.get(0));
+    assertEquals('foo', map.get(-0));
+    // stored value should be +0
+    assertEquals(Infinity, 1 / map.keys().next().value);
+    assertTrue(map.delete(-0));
+    assertFalse(map.has(0));
+    assertFalse(map.has(-0));
   },
 
   testNanKeys() {
@@ -157,6 +165,13 @@ testSuite({
     assertEquals(2, map.size);
     assertTrue(map.has('b'));
     assertEquals(3, map.get('a'));
+  },
+
+  testConstructor_normalizeZero() {
+    const map = new Map([[-0, 'foo']]);
+    assertEquals(Infinity, 1 / map.keys().next().value);
+    assertEquals('foo', map.get(0));
+    assertEquals('foo', map.get(-0));
   },
 
   testForEach() {

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/set_test.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/set_test.js
@@ -60,11 +60,18 @@ testSuite({
       checkAddHas(set, keys[i]);
     }
     assertEquals(37, set.size);
+  },
 
+  testAdd_normalizeZero() {
     // Note: +0 and -0 are the same
+    const set = new Set().add(-0);
+    assertTrue(set.has(0));
     assertTrue(set.has(-0));
+    // stored value should be +0
+    assertEquals(Infinity, 1 / set.keys().next().value);
     assertTrue(set.delete(-0));
     assertFalse(set.has(0));
+    assertFalse(set.has(-0));
   },
 
   testAdd_nans() {
@@ -149,6 +156,13 @@ testSuite({
     assertEquals(2, set.size);
     assertTrue(set.has('a'));
     assertTrue(set.has('b'));
+  },
+
+  testConstructor_normalizeZero() {
+    const set = new Set([-0]);
+    assertEquals(Infinity, 1 / set.keys().next().value);
+    assertTrue(set.has(0));
+    assertTrue(set.has(-0));
   },
 
   testForEach() {


### PR DESCRIPTION
- https://www.ecma-international.org/ecma-262/8.0/#sec-map.prototype.set
- https://www.ecma-international.org/ecma-262/8.0/#sec-set.prototype.add
- https://kangax.github.io/compat-table/es6/#test-Map_-0_key_converts_to_+0
- https://kangax.github.io/compat-table/es6/#test-Set_-0_key_converts_to_+0