### PR TITLE
Add more flags to the GWT version

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapObjectParserJs.java
+++ b/src/com/google/debugging/sourcemap/SourceMapObjectParserJs.java
@@ -51,17 +51,11 @@ public class SourceMapObjectParserJs {
   private static class JsonMap {
     int version;
     String file;
-    int lineCount;
     String mappings;
     String sourceRoot;
     Section[] sections;
     String[] sources;
     String[] names;
-
-    @JsOverlay
-    public final Object getLineCount() {
-      return this.lineCount;
-    }
   }
 
   @JsType(isNative = true, name = "Object", namespace = JsPackage.GLOBAL)
@@ -93,7 +87,8 @@ public class SourceMapObjectParserJs {
 
     builder.setVersion(sourceMap.version);
     builder.setFile(sourceMap.file);
-    builder.setLineCount(sourceMap.getLineCount() != null ? sourceMap.lineCount : -1);
+    // Line count is no longer part of the source map spec. -1 is the magic "not provided" value
+    builder.setLineCount(-1);
     builder.setMappings(sourceMap.mappings);
     builder.setSourceRoot(sourceMap.sourceRoot);
 

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -2647,6 +2647,10 @@ public class CompilerOptions implements Serializable {
     this.sourceMapIncludeSourcesContent = sourceMapIncludeSourcesContent;
   }
 
+  public void setParseInlineSourceMaps(boolean parseInlineSourceMaps) {
+    this.parseInlineSourceMaps = parseInlineSourceMaps;
+  }
+
   public void setSourceMapDetailLevel(SourceMap.DetailLevel sourceMapDetailLevel) {
     this.sourceMapDetailLevel = sourceMapDetailLevel;
   }


### PR DESCRIPTION
In order to move the GWT version of the compiler into the same distribution package as the java version, new flags needed added.

These changes should be still compatible with the https://github.com/google/closure-compiler-js repo as well as the https://github.com/google/closure-compiler-npm/tree/include-js-version.

There are no direct tests for GWT here, but the built jscomp.js file can be copied to each of the other repos and the tests there run.

Depends on #2921 to properly compose source maps.

cc @samthor 