### PR TITLE
When adding interfaces to Polymer classes, use any existing JSDoc.

### DIFF
--- a/src/com/google/javascript/jscomp/PolymerClassRewriter.java
+++ b/src/com/google/javascript/jscomp/PolymerClassRewriter.java
@@ -214,12 +214,13 @@ final class PolymerClassRewriter {
 
     // If an external interface is required, mark the class as implementing it
     if (!readOnlyProps.isEmpty() || !attributeReflectedProps.isEmpty()) {
-      JSDocInfoBuilder classInfo = JSDocInfoBuilder.maybeCopyFrom(clazz.getJSDocInfo());
+      Node jsDocInfoNode = NodeUtil.getBestJSDocInfoNode(clazz);
+      JSDocInfoBuilder classInfo = JSDocInfoBuilder.maybeCopyFrom(jsDocInfoNode.getJSDocInfo());
       String interfaceName = getInterfaceName(cls);
       JSTypeExpression interfaceType =
           new JSTypeExpression(new Node(Token.BANG, IR.string(interfaceName)), VIRTUAL_FILE);
       classInfo.recordImplementedInterface(interfaceType);
-      clazz.setJSDocInfo(classInfo.build());
+      jsDocInfoNode.setJSDocInfo(classInfo.build());
     }
 
     if (block.hasChildren()) {

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -3086,6 +3086,61 @@ public class PolymerPassTest extends CompilerTestCase {
             "a.B.prototype.thingToDo;"));
   }
 
+  public void testPolymerElementAnnotation3() {
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        lines(
+            "/** @interface */",
+            "function User() {};",
+            "/** @type {boolean} */ User.prototype.id;",
+            "var a = {};",
+            "/**",
+            " * @polymer",
+            " * @implements {User}",
+            " */",
+            "a.B = class extends Foo {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      id: Boolean,",
+            "      other: {",
+            "        type: String,",
+            "        reflectToAttribute: true",
+            "      }",
+            "    };",
+            "  }",
+            "};"),
+        lines(
+            "/** @interface */",
+            "function User() {};",
+            "/** @type {boolean} */ User.prototype.id;",
+            "var a = {};",
+            "/**",
+            " * @polymer",
+            " * @implements {User}",
+            " * @implements {Polymera_BInterface}",
+            " */",
+            "a.B = class extends Foo {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return {",
+            "      id: Boolean,",
+            "      other: {",
+            "        type: String,",
+            "        reflectToAttribute: true",
+            "      }",
+            "    };",
+            "  }",
+            "};",
+            "/** @type {boolean} */",
+            "a.B.prototype.id;",
+            "/** @type {string} */",
+            "a.B.prototype.other;"));
+  }
+
   public void testObjectReflectionAddedToConfigProperties1() {
     propertyRenamingEnabled = true;
     test(


### PR DESCRIPTION
Fixes renaming bugs where the synthetic interface was attached at a closer node and hiding the interface attached to a getprop assignment.