### PR TITLE
Add generics support to the reflectObject polyfill

### DIFF
--- a/src/com/google/javascript/jscomp/js/util/reflectobject.js
+++ b/src/com/google/javascript/jscomp/js/util/reflectobject.js
@@ -19,7 +19,7 @@
 /**
  * Definition for object reflection. See goog.reflect.object.
  *
- * @param {!Function} type Type to cast to.
+ * @param {?Object} type Type to cast to.
  * @param {T} object Object literal to cast.
  * @return {T} The object literal.
  * @template T

--- a/src/com/google/javascript/jscomp/js/util/reflectobject.js
+++ b/src/com/google/javascript/jscomp/js/util/reflectobject.js
@@ -20,8 +20,9 @@
  * Definition for object reflection. See goog.reflect.object.
  *
  * @param {!Function} type Type to cast to.
- * @param {Object} object Object literal to cast.
- * @return {Object} The object literal.
+ * @param {T} object Object literal to cast.
+ * @return {T} The object literal.
+ * @template T
  */
 $jscomp.reflectObject = function(type, object) {
   return object;

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -109,8 +109,9 @@ public class PolymerPassTest extends CompilerTestCase {
           "/** @const */ $jscomp.scope = {};",
           "/**",
           " * @param {!Function} type",
-          " * @param {Object} object",
-          " * @return {Object}",
+          " * @param {T} object",
+          " * @return {T}",
+          " * @template T",
           " */",
           "$jscomp.reflectObject = function (type, object) { return object; };");
 

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -108,7 +108,7 @@ public class PolymerPassTest extends CompilerTestCase {
           "/** @const */ var $jscomp = $jscomp || {};",
           "/** @const */ $jscomp.scope = {};",
           "/**",
-          " * @param {!Function} type",
+          " * @param {?Object} type",
           " * @param {T} object",
           " * @return {T}",
           " * @template T",


### PR DESCRIPTION
The polymer pass injects an object reflection polyfill. With NTI, the return type was coerced to match expectations. But with OTI, it causes warnings. By making the reflectObject polyfill use generics, the warning is removed.

The type of code this effects looks something like:

```js
class FooElement extends Polymer.Element {
  static get is() { return 'foo-element'; }
  /** @return {Object<string, (!Function|{type: !Function, value: *})>} */
  static get properties() {
    return $jscomp.reflectObject(FooElement, {
      myProp: {
        type: String,
        value: 'foo'
      }
    });
  }
}
```
