### PR TITLE
Upstream Element.slot property from webcomponents polyfill

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -33,6 +33,11 @@
 Node.prototype.assignedSlot;
 
 /**
+ * @type {string}
+ */
+Element.prototype.slot;
+
+/**
  * Note: In IE, the contains() method only exists on Elements, not Nodes.
  * Therefore, it is recommended that you use the Conformance framework to
  * prevent calling this on Nodes which are not Elements.

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -34,6 +34,7 @@ Node.prototype.assignedSlot;
 
 /**
  * @type {string}
+ * @see https://dom.spec.whatwg.org/#dom-element-slot
  */
 Element.prototype.slot;
 


### PR DESCRIPTION
This upstreams the slot property declaration we had declared in the webcomponents polyfill: https://github.com/webcomponents/shadydom/blob/3b406bbcc10ea6d57ef9dd058710d2920b511d60/externs/shadydom.js#L6-L10

This property is specified in https://dom.spec.whatwg.org/#dom-element-slot see https://developer.mozilla.org/en-US/docs/Web/API/Element/slot