### PR TITLE
Fix IE Symbol errors when used with output wrapper

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/array/from.js
+++ b/src/com/google/javascript/jscomp/js/es6/array/from.js
@@ -43,7 +43,8 @@ $jscomp.polyfill('Array.from', function(orig) {
     opt_mapFn = opt_mapFn != null ? opt_mapFn : function(x) { return x; };
     var result = [];
     // NOTE: this is cast to ? because [] on @struct is an error
-    var iteratorFunction = /** @type {?} */ (arrayLike)[Symbol.iterator];
+    var iteratorFunction =
+        /** @type {?} */ (arrayLike)[$jscomp.global.Symbol.iterator];
     if (typeof iteratorFunction == 'function') {
       arrayLike = iteratorFunction.call(arrayLike);
       var next;

--- a/src/com/google/javascript/jscomp/js/es6/generator_engine.js
+++ b/src/com/google/javascript/jscomp/js/es6/generator_engine.js
@@ -847,12 +847,12 @@ $jscomp.generator.Generator_ = function(engine) {
   $jscomp.initSymbolIterator();
 
   /** @this {$jscomp.generator.Generator_<VALUE>} */
-  this[Symbol.iterator] = function() {
+  this[$jscomp.global.Symbol.iterator] = function() {
     return this;
   };
 
   // TODO(skill): uncomment once Symbol.toStringTag is polyfilled:
-  // this[Symbol.toStringTag] = 'Generator';
+  // this[$jscomp.global.Symbol.toStringTag] = 'Generator';
 };
 
 /**

--- a/src/com/google/javascript/jscomp/js/es6/map.js
+++ b/src/com/google/javascript/jscomp/js/es6/map.js
@@ -248,7 +248,7 @@ $jscomp.polyfill('Map',
   };
 
 
-  /** @type {?} */ (PolyfillMap.prototype)[Symbol.iterator] =
+  /** @type {?} */ (PolyfillMap.prototype)[$jscomp.global.Symbol.iterator] =
       PolyfillMap.prototype.entries;
 
 

--- a/src/com/google/javascript/jscomp/js/es6/set.js
+++ b/src/com/google/javascript/jscomp/js/es6/set.js
@@ -154,7 +154,7 @@ $jscomp.polyfill('Set',
   PolyfillSet.prototype.keys = PolyfillSet.prototype.values;
 
 
-  /** @type {?} */ (PolyfillSet.prototype)[Symbol.iterator] =
+  /** @type {?} */ (PolyfillSet.prototype)[$jscomp.global.Symbol.iterator] =
       PolyfillSet.prototype.values;
 
 

--- a/src/com/google/javascript/jscomp/js/es6/util/iteratorfromarray.js
+++ b/src/com/google/javascript/jscomp/js/es6/util/iteratorfromarray.js
@@ -43,6 +43,6 @@ $jscomp.iteratorFromArray = function(array, transform) {
       return iter.next();
     }
   };
-  iter[Symbol.iterator] = function() { return iter; };
+  iter[$jscomp.global.Symbol.iterator] = function() { return iter; };
   return iter;
 };

--- a/src/com/google/javascript/jscomp/js/es6/util/makeiterator.js
+++ b/src/com/google/javascript/jscomp/js/es6/util/makeiterator.js
@@ -32,7 +32,8 @@ $jscomp.makeIterator = function(iterable) {
   $jscomp.initSymbolIterator();
 
   // NOTE: Disabling typechecking because [] not allowed on @struct.
-  var iteratorFunction = /** @type {?} */ (iterable)[Symbol.iterator];
+  var iteratorFunction =
+      /** @type {?} */ (iterable)[$jscomp.global.Symbol.iterator];
   return iteratorFunction ? iteratorFunction.call(iterable) :
       $jscomp.arrayIterator(/** @type {!Array} */ (iterable));
 };


### PR DESCRIPTION
When using an output wrapper, the polyfill for "Symbol" does not
necessarily appear in "window".  So all internal references to
"Symbol" need to go through "$jscomp.global".

Closes #2957