### PR TITLE
Let HTMLOptionsCollection extend HTMLCollection

### DIFF
--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -128,25 +128,32 @@ HTMLCollection.prototype.namedItem = function(name) {};
 
 /**
  * @constructor
- * @implements {IObject<(string|number),HTMLOptionElement>}
- * @implements {IArrayLike<!HTMLOptionElement>}
- * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection
+ * @extends {HTMLCollection<HTMLOptionElement>}
+ * @see https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmloptionscollection
  */
 function HTMLOptionsCollection() {}
 
 /**
  * @type {number}
- * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection-length
+ * @see https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-length
+ * @nosideeffects
  */
 HTMLOptionsCollection.prototype.length;
 
 /**
- * @param {number} index
- * @return {Node}
- * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection-item
- * @nosideeffects
+ * @param {HTMLOptionElement|HTMLOptGroupElement} element
+ * @param {HTMLElement|number=} before
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-add
  */
-HTMLOptionsCollection.prototype.item = function(index) {};
+HTMLOptionsCollection.prototype.add = function(element, before) {};
+
+/**
+ * @param {number} index
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-remove
+ */
+HTMLOptionsCollection.prototype.remove = function(index) {};
 
 /**
  * @constructor


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionsCollection the HTMLOptionsCollection is a subclass of HTMLCollection.

I discovered this issue when writing a `for-of`-loop which reported the following error:
```
src/patch-accessors.js:312: WARNING - actual parameter 1 of $jscomp.makeIterator does not match formal parameter
found   : HTMLOptionsCollection
required: (Arguments<?>|Iterable<?>|Iterator<?>|string)
          for (const option of select.options) {
                               ^^^^^^^^^^^^^^
```
By fixing this subclass definition I think this error should be resolved as well.