### PR TITLE
Improve CommonJS UMD pattern detection

### DIFF
--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -694,7 +694,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         lines(
             "/** @const */ var module$test = {};",
             "(function(){",
-            "  /** @const */ module$test.default={foo:'bar'};",
+            "  var foobar = {foo: 'bar'};",
+            "  /** @const */ module$test.default=foobar;",
             "}).call(window);"));
 
     // Can't remove IIFEs when there are sibling statements
@@ -714,7 +715,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         lines(
             "/** @const */ var module$test = {};",
             "(function(){",
-            "  /** @const */ module$test.default={foo:\"bar\"};",
+            "  var foobar = {foo: 'bar'};",
+            "  /** @const */ module$test.default = foobar;",
             "})();",
             "alert('foo');"));
 
@@ -736,7 +738,8 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "/** @const */ var module$test = {};",
             "alert('foo');",
             "(function(){",
-            "  /** @const */ module$test.default={foo:\"bar\"};",
+            "  var foobar={foo:\"bar\"};",
+            "  /** @const */ module$test.default=foobar;",
             "})();"));
 
     // Annotations for local names should be preserved
@@ -1207,5 +1210,17 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
                     "/** @const */ module$webpack$buildin$module.default = ",
                     "    function(module) { return module; };")));
     test(inputs, expecteds);
+  }
+
+  public void testUMDRequiresIfTest() {
+    testModules(
+        "test.js",
+        lines("var foobar = {foo: 'bar'};", "if (foobar) {", "  module.exports = foobar;", "}"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "var foobar$$module$test={foo:\"bar\"};",
+            "if(foobar$$module$test) {",
+            "  /** @const */ module$test.default = foobar$$module$test;",
+            "}"));
   }
 }


### PR DESCRIPTION
We have historically detected the Universal Module Definition pattern by looking for an export nested inside any `if` statement. However, this is far from correct. In CommonJS, exports can be conditionally created.

Improves the UMD pattern detection by requiring the `if` statement to reference the `module` or `define` names.

In addition, the pass now creates export aliases for any export nested inside an `if` or `function`. Rewriting such exports to avoid aliases potentially produced incorrect code.

Fixes #2841