### PR TITLE
Update ProcessCommonJSModules to handle object spread operators

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -827,6 +827,13 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
           Node rValue = NodeUtil.getRValueOfLValue(export.node);
           if (rValue == null || !rValue.isObjectLit()) {
             directAssignments++;
+          } else if (rValue.isObjectLit()) {
+            for (Node key = rValue.getFirstChild(); key != null; key = key.getNext()) {
+              if (!((key.isStringKey() && !key.isQuotedString()) || key.isMemberFunctionDef())) {
+                directAssignments++;
+                break;
+              }
+            }
           }
         }
       }
@@ -1358,8 +1365,9 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
             && rValue.isObjectLit()
             && root.getParent().isAssign()
             && root.getParent().getParent().isExprResult()) {
-          expandObjectLitAssignment(t, root, export.scope);
-          return;
+          if (expandObjectLitAssignment(t, root, export.scope)) {
+            return;
+          }
         }
       }
 
@@ -1465,7 +1473,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
      *
      * <p>module.exports.foo = bar; // removed later module.exports.baz = function() {};
      */
-    private void expandObjectLitAssignment(NodeTraversal t, Node export, Scope scope) {
+    private boolean expandObjectLitAssignment(NodeTraversal t, Node export, Scope scope) {
       checkState(export.getParent().isAssign());
       Node insertionRef = export.getParent().getParent();
       checkState(insertionRef.isExprResult());
@@ -1475,14 +1483,15 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       Node rValue = NodeUtil.getRValueOfLValue(export);
       Node key = rValue.getFirstChild();
 
+      boolean removedNodes = false;
       while (key != null) {
         Node lhs;
-        if (key.isQuotedString()) {
-          lhs = IR.getelem(export.cloneTree(), IR.string(key.getString()));
-        } else {
-          lhs = IR.getprop(export.cloneTree(), IR.string(key.getString()));
+        if (!((key.isStringKey() && !key.isQuotedString()) || key.isMemberFunctionDef())) {
+          key = key.getNext();
+          continue;
         }
 
+        lhs = IR.getprop(export.cloneTree(), IR.string(key.getString()));
         Node value = null;
         if (key.isStringKey()) {
           if (key.hasChildren()) {
@@ -1495,44 +1504,31 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
         }
 
         Node expr = null;
-        if (!key.isGetterDef()) {
-          expr = IR.exprResult(IR.assign(lhs, value)).useSourceInfoIfMissingFromForTree(key);
-          insertionParent.addChildAfter(expr, insertionRef);
-          ExportInfo newExport = new ExportInfo(lhs.getFirstChild(), scope);
-          visitExport(t, newExport);
-        } else {
-          String moduleName = getModuleName(t.getInput());
-          Var moduleVar = t.getScope().getVar(moduleName + "." + EXPORT_PROPERTY_NAME);
-          Node defaultProp = null;
-          if (moduleVar == null) {
-            moduleVar = t.getScope().getVar(moduleName);
-            if (moduleVar != null
-                && moduleVar.getNode().getFirstChild() != null
-                && moduleVar.getNode().getFirstChild().isObjectLit()) {
-              defaultProp =
-                  NodeUtil.getFirstPropMatchingKey(
-                      moduleVar.getNode().getFirstChild(), EXPORT_PROPERTY_NAME);
-            }
-          } else if (moduleVar.getNode().getFirstChild() != null
-              && moduleVar.getNode().getFirstChild().isObjectLit()) {
-            defaultProp = moduleVar.getNode().getFirstChild();
-          }
-
-          if (defaultProp != null) {
-            Node getter = key.detach();
-            defaultProp.addChildToBack(getter);
-          }
-        }
+        expr = IR.exprResult(IR.assign(lhs, value)).useSourceInfoIfMissingFromForTree(key);
+        insertionParent.addChildAfter(expr, insertionRef);
+        ExportInfo newExport = new ExportInfo(lhs.getFirstChild(), scope);
+        visitExport(t, newExport);
 
         // Export statements can be removed in visitExport
         if (expr != null && expr.getParent() != null) {
           insertionRef = expr;
         }
 
+        Node currentKey = key;
         key = key.getNext();
+        currentKey.detach();
+        removedNodes = true;
       }
 
-      export.getParent().getParent().detach();
+      if (!rValue.hasChildren()) {
+        export.getParent().getParent().detach();
+        return true;
+      }
+
+      if (removedNodes) {
+        t.reportCodeChange(rValue);
+      }
+      return false;
     }
 
     /**

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.deps.ModuleLoader;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
   @Override
   protected CompilerOptions getOptions() {
     CompilerOptions options = super.getOptions();
+    options.setLanguageIn(LanguageMode.ECMASCRIPT_2018);
     options.setProcessCommonJSModules(true);
     options.setModuleResolutionMode(resolutionMode);
 
@@ -820,14 +822,13 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
   public void testIssue2510() {
     testModules(
         "test.js",
-        lines("module.exports = {", "  a: 1,", "  get b() { return 2; }", "};"),
+        lines("module.exports = {a: 1, get b() { return 2; }};"),
         lines(
-            "/** @const */ var module$test = {",
-            "  /** @const */ default: {",
-            "    get b() { return 2; }",
-            "  }",
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {",
+            "  get b() { return 2; }",
             "};",
-            "module$test.default.a = 1"));
+            "module$test.default.a = 1;"));
   }
 
   public void testIssue2450() {
@@ -1222,5 +1223,17 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "if(foobar$$module$test) {",
             "  /** @const */ module$test.default = foobar$$module$test;",
             "}"));
+  }
+
+  public void testObjectSpreadExport() {
+    testModules(
+        "test.js",
+        "var g = {}; module.exports = { ...g };",
+        lines(
+            "/** @const */ var module$test = {};",
+            "var g$$module$test = {};",
+            "/** @const */ module$test.default = {",
+            "  ...g$$module$test",
+            "};"));
   }
 }


### PR DESCRIPTION
Restricts the rewriting of object literals on CommonJS exports to simple keys. Getters, Setters, spread operators and computed properties are now left alone.

Fixes #2926