### PR TITLE
Better handling of CommonJS exports in complex expressions

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -1374,6 +1374,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       }
 
       if (root.getParent().isAssign()
+          && root.getGrandparent().isExprResult()
           && (root.getNext() != null && (root.getNext().isName() || root.getNext().isGetProp()))
           && root.getParent().getParent().isExprResult()
           && rValueVar != null
@@ -1402,39 +1403,35 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       if (root.matchesQualifiedName("module.exports")
           && rValue != null
           && export.scope.getVar("module.exports") == null
-          && root.getParent().isAssign()) {
-        if (root.getGrandparent().isExprResult() && moduleInitialization == null) {
-          // Rewrite "module.exports = foo;" to "var moduleName = {default: foo};"
-          Node parent = root.getParent();
-          Node exportName = IR.exprResult(IR.assign(updatedExport, rValue.detach()));
-          if (exportIsConst) {
-            JSDocInfoBuilder info = new JSDocInfoBuilder(false);
-            info.recordConstancy();
-            exportName.getFirstChild().setJSDocInfo(info.build());
-          }
-          parent.getParent().replaceWith(exportName.useSourceInfoFromForTree(root.getParent()));
-          changeScope = NodeUtil.getEnclosingChangeScopeRoot(parent);
-        } else if (root.getNext() != null
-            && root.getNext().isName()
-            && rValueVar != null
-            && rValueVar.isGlobal()
-            && export.isInSupportedScope) {
-          // This is a where a module export assignment is used in a complex expression.
-          // Before: `SOME_VALUE !== undefined && module.exports = SOME_VALUE`
-          // After: `SOME_VALUE !== undefined && module$name`
-          root.getParent().replaceWith(updatedExport);
-          changeScope = NodeUtil.getEnclosingChangeScopeRoot(root);
-        } else {
-          // Other references to "module.exports" are just replaced with the module name.
-          export.node.replaceWith(updatedExport);
-          if (updatedExport.getParent().isAssign() && exportIsConst) {
-            JSDocInfoBuilder infoBuilder =
-                JSDocInfoBuilder.maybeCopyFrom(updatedExport.getParent().getJSDocInfo());
-            infoBuilder.recordConstancy();
-            updatedExport.getParent().setJSDocInfo(infoBuilder.build());
-          }
-          changeScope = NodeUtil.getEnclosingChangeScopeRoot(updatedExport);
+          && root.getParent().isAssign()
+          && root.getGrandparent().isExprResult()
+          && moduleInitialization == null) {
+        // Rewrite "module.exports = foo;" to "var moduleName = {default: foo};"
+        Node parent = root.getParent();
+        Node exportName = IR.exprResult(IR.assign(updatedExport, rValue.detach()));
+        if (exportIsConst) {
+          JSDocInfoBuilder info = new JSDocInfoBuilder(false);
+          info.recordConstancy();
+          exportName.getFirstChild().setJSDocInfo(info.build());
         }
+        parent.getParent().replaceWith(exportName.useSourceInfoFromForTree(root.getParent()));
+        changeScope = NodeUtil.getEnclosingChangeScopeRoot(parent);
+      } else if (root.getNext() != null
+          && root.getNext().isName()
+          && rValueVar != null
+          && rValueVar.isGlobal()
+          && export.isInSupportedScope) {
+        // This is a where a module export assignment is used in a complex expression.
+        // Before: `SOME_VALUE !== undefined && module.exports = SOME_VALUE`
+        // After: `SOME_VALUE !== undefined && module$name`
+        Node parent = root.getParent();
+        root.detach();
+        parent.replaceWith(root);
+        if (root == export.node) {
+          root = updatedExport;
+        }
+        export.node.replaceWith(updatedExport);
+        changeScope = NodeUtil.getEnclosingChangeScopeRoot(root);
       } else {
         // Other references to "module.exports" are just replaced with the module name.
         export.node.replaceWith(updatedExport);
@@ -1447,6 +1444,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
 
         changeScope = NodeUtil.getEnclosingChangeScopeRoot(updatedExport);
       }
+
       if (changeScope != null) {
         compiler.reportChangeToChangeScope(changeScope);
       }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -1212,6 +1212,16 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     test(inputs, expecteds);
   }
 
+  public void testIssue2932() {
+    testModules(
+        "test.js",
+        "const width = 800; const vwidth = exports.vwidth = width;",
+        lines(
+            "/** @const */ var module$test = { /** @const */ default: {}};",
+            "module$test.default.vwidth = 800;",
+            "const vwidth$$module$test = module$test.default.vwidth;"));
+  }
+
   public void testUMDRequiresIfTest() {
     testModules(
         "test.js",


### PR DESCRIPTION
Update handling of cases where a CommonJS export assignment is used in a larger expression. Replaces the export assignment with just a reference to the export itself.

Fixes #2932