### PR TITLE
Fix an exception caused by attempting to load an empty filename

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -17,6 +17,7 @@ package com.google.javascript.jscomp;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.javascript.jscomp.parsing.parser.FeatureSet.ES8_MODULES;
 
 import com.google.common.annotations.GwtIncompatible;
@@ -2938,7 +2939,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     String relativePath = resolveSibling(sourceMapOriginalPath, resultOriginalPath);
 
     SourceFile source = getSourceFileByName(relativePath);
-    if (source == null) {
+    if (source == null && !isNullOrEmpty(resultOriginalPath)) {
       source =
           SourceMapResolver.getRelativePath(sourceMap.getOriginalPath(), result.getOriginalFile());
       if (source != null) {


### PR DESCRIPTION
Fixes #2976

Input source maps can have empty file name references. In this case, don't attempt to load the source of the file as that will cause an exception.