### PR TITLE
Recognize UMD patterns when define is referenced as a property of window

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -601,7 +601,8 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
             umdPatterns.add(new UmdPattern(ifAncestor, enclosingIf.getSecondChild()));
           }
         }
-      } else if (n.matchesQualifiedName("define.amd")) {
+      } else if (n.matchesQualifiedName("define.amd")
+          || n.matchesQualifiedName("window.define.amd")) {
         // If a define.amd statement is nested in the then branch of an if statement,
         // and the test of the if checks for "module" or "define,
         // assume the if statement is an UMD pattern with a common js export
@@ -885,8 +886,9 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
             new NodeUtil.Visitor() {
               @Override
               public void visit(Node node) {
-                if (node.isName()
-                    && (node.getString().equals(MODULE) || node.getString().equals("define"))) {
+                if ((node.isName()
+                        && (node.getString().equals(MODULE) || node.getString().equals("define")))
+                    || (node.isGetProp() && node.matchesQualifiedName("window.define"))) {
                   umdTests.add(node);
                 }
               }

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -293,8 +293,38 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
         "test.js",
         lines(
             "var foobar = {foo: 'bar'};",
+            "if (typeof module === 'object' && module.exports) {",
+            "  module.exports = foobar;",
+            "} else if (typeof window.define === 'function' && window.define.amd) {",
+            "  window.define([], function() {return foobar;});",
+            "} else {",
+            "  this.foobar = foobar;",
+            "}"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
+
+    testModules(
+        "test.js",
+        lines(
+            "var foobar = {foo: 'bar'};",
             "if (typeof define === 'function' && define.amd) {",
             "  define([], function() {return foobar;});",
+            "} else if (typeof module === 'object' && module.exports) {",
+            "  module.exports = foobar;",
+            "} else {",
+            "  this.foobar = foobar;",
+            "}"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
+
+    testModules(
+        "test.js",
+        lines(
+            "var foobar = {foo: 'bar'};",
+            "if (typeof window.define === 'function' && window.define.amd) {",
+            "  window.define([], function() {return foobar;});",
             "} else if (typeof module === 'object' && module.exports) {",
             "  module.exports = foobar;",
             "} else {",
@@ -321,12 +351,48 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
     testModules(
         "test.js",
         lines(
+            "var foobar = {foo: 'bar'};",
+            "if (typeof module === 'object' && module.exports) {",
+            "  module.exports = foobar;",
+            "}",
+            "if (typeof window.define === 'function' && window.define.amd) {",
+            "  window.define([], function () {return foobar;});",
+            "}"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "/** @const */ module$test.default = {foo: 'bar'};"));
+
+    testModules(
+        "test.js",
+        lines(
             "(function(global, factory) {",
             "  true ? module.exports = factory(",
             "             typeof angular === 'undefined' ? require('./other') :",
             "                                              angular) :",
             "         typeof define === 'function' && define.amd ?",
             "         define('angular-cache', ['angular'], factory) :",
+            "         (global.angularCacheModuleName = factory(global.angular));",
+            "}(this, function(angular) {",
+            "  'use strict';",
+            "  console.log(angular);",
+            "  return angular;",
+            "}));"),
+        lines(
+            "/** @const */ var module$test = {};",
+            "var angular$$module$test = ",
+            "    typeof angular === 'undefined' ? module$other.default : angular;",
+            "console.log(angular$$module$test);",
+            "module$test.default = angular$$module$test;"));
+
+    testModules(
+        "test.js",
+        lines(
+            "(function(global, factory) {",
+            "  true ? module.exports = factory(",
+            "             typeof angular === 'undefined' ? require('./other') :",
+            "                                              angular) :",
+            "         typeof window.define === 'function' && window.define.amd ?",
+            "         window.define('angular-cache', ['angular'], factory) :",
             "         (global.angularCacheModuleName = factory(global.angular));",
             "}(this, function(angular) {",
             "  'use strict';",


### PR DESCRIPTION
The fingerprint2 library references `define` as `window.define` in the UMD pattern. Update the common js module processing to recognize this variant.