### PR TITLE
Add --help_markdown flag to generate documentation for the flags

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.33</version>
+      <version>2.0.26</version>
     </dependency>
 
     <dependency>

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -962,7 +962,7 @@ public class CommandLineRunner extends
           // For markdown docs we don't want any line wrapping so we just set a very
           // large line length.
           maxLineLength = 5000;
-          parser.getProperties().withUsageWidth(maxLineLength);
+          parser.setUsageWidth(maxLineLength);
         }
 
         printCategoryUsage(entry.getKey(), entry.getValue(), outputStream, prefix, suffix);

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -959,6 +959,8 @@ public class CommandLineRunner extends
         }
 
         if (this.helpMarkdown) {
+          // For markdown docs we don't want any line wrapping so we just set a very
+          // large line length.
           maxLineLength = 5000;
           parser.getProperties().withUsageWidth(maxLineLength);
         }


### PR DESCRIPTION
I wanted a page to document the flags. I added a `--help_markdown` flag to generate the flag usage in a format for the wiki. The output of that flag can be directly pasted into https://github.com/google/closure-compiler/wiki/Flags-and-Options