### PR TITLE
Adds assert typings to Sinon externs

### DIFF
--- a/contrib/externs/sinon-1.17.js
+++ b/contrib/externs/sinon-1.17.js
@@ -854,3 +854,124 @@ SinonFakeXmlHttpRequest.prototype.respond = function(status, headers, body) {};
  * @return {SinonClock}
  */
 sinon.useFakeTimers = function(params) {};
+
+sinon.assert = {};
+
+/** @type {string} */
+sinon.assert.failException;
+
+/** @param {string} message */
+sinon.assert.fail = function(message) {};
+
+/** @param {*} assertion */
+sinon.assert.pass = function(assertion) {};
+
+/** @param {!SinonSpy} spy */
+sinon.assert.notCalled = function(spy) {};
+
+/** @param {!SinonSpy} spy */
+sinon.assert.called = function(spy) {};
+
+/** @param {!SinonSpy} spy */
+sinon.assert.calledOnce = function(spy) {};
+
+/** @param {!SinonSpy} spy */
+sinon.assert.calledTwice = function(spy) {};
+
+/** @param {!SinonSpy} spy */
+sinon.assert.calledThrice = function(spy) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {number} count
+ */
+sinon.assert.callCount = function(spy, count) {};
+
+/** @param {...SinonSpy} spies */
+sinon.assert.callOrder = function(...spies) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {*} obj
+ */
+sinon.assert.calledOn = function(spy, obj) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {*} obj
+ */
+sinon.assert.alwaysCalledOn = function(spy, obj) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.calledWith = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.alwaysCalledWith = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.neverCalledWith = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.calledWithExactly = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.alwaysCalledWithExactly = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.calledWithMatch = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.alwaysCalledWithMatch = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {...*} args
+ */
+sinon.assert.neverCalledWithMatch = function(spy, args) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {*=} exception
+ */
+sinon.assert.threw = function(spy, exception) {};
+
+/**
+ * @param {!SinonSpy} spy
+ * @param {*=} exception
+ *
+ * */
+sinon.assert.alwaysThrew = function(spy, exception) {};
+
+/**
+ * @typedef {Object} SinonExposeOptions
+ * @property {string=} prefix
+ * @property {boolean=} includeFail
+ */
+var SinonExposeOptions = {};
+
+/**
+ * @param {*} obj
+ * @param {SinonExposeOptions=} options
+ **/
+sinon.assert.expose = function(obj, options) {};

--- a/contrib/externs/sinon-1.17.js
+++ b/contrib/externs/sinon-1.17.js
@@ -891,7 +891,7 @@ sinon.assert.calledThrice = function(spy) {};
  */
 sinon.assert.callCount = function(spy, count) {};
 
-/** @param {...SinonSpy} spies */
+/** @param {...!SinonSpy} spies */
 sinon.assert.callOrder = function(...spies) {};
 
 /**
@@ -968,14 +968,15 @@ sinon.assert.threw = function(spy, exception) {};
 sinon.assert.alwaysThrew = function(spy, exception) {};
 
 /**
- * @typedef {Object} SinonExposeOptions
- * @property {string=} prefix
- * @property {boolean=} includeFail
+ * @typedef {{
+ *     prefix: string|undefined,
+ *     includeFail: boolean|undefined
+ * }}
  */
 var SinonExposeOptions = {};
 
 /**
  * @param {*} obj
- * @param {SinonExposeOptions=} options
+ * @param {!SinonExposeOptions=} options
  **/
 sinon.assert.expose = function(obj, options) {};

--- a/contrib/externs/sinon-1.17.js
+++ b/contrib/externs/sinon-1.17.js
@@ -855,6 +855,10 @@ SinonFakeXmlHttpRequest.prototype.respond = function(status, headers, body) {};
  */
 sinon.useFakeTimers = function(params) {};
 
+/**
+ * Assertions
+ * @see http:/sinonjs.org/releases/1.17.7/assertions
+ */
 sinon.assert = {};
 
 /** @type {string} */


### PR DESCRIPTION
[These assertions](http://sinonjs.org/releases/v1.17.6/assertions/) are more useful to use than asserting truth on other sinon spy methods.

For example, assertTrue(spy.calledOnce) may give you the failure message "Expected false to be true"
Whereas using sinon.assert.calledOnce(spy) will provide the message "Spy was not called once".