### PR TITLE
Fix a NPE in CommonJS modules.

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -2014,7 +2014,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
             Var typeDeclaration = t.getScope().getVar(baseName);
 
             // Make sure we can find a variable declaration (and it's in this file)
-            if (typeDeclaration != null
+            if (typeDeclaration != null && typeDeclaration.getNode() != null
                 && Objects.equals(typeDeclaration.getNode().getInputId(), typeNode.getInputId())) {
               String importedModuleName = getModuleImportName(t, typeDeclaration.getNode());
 


### PR DESCRIPTION
Only occurs when the typeDeclaration doesn't have a node.

This seems to occur with Polymer code that is rewritten to CommonJS modules, but I'm unsure of exactly how this scenario is created.