### PR TITLE
Default for empty-message replacement.

### DIFF
--- a/src/com/google/javascript/jscomp/ReplaceMessages.java
+++ b/src/com/google/javascript/jscomp/ReplaceMessages.java
@@ -298,8 +298,10 @@ final class ReplaceMessages extends JsMessageVisitor {
     Node objLitNode = stringExprNode.getNext();
 
     // Build the replacement tree.
-    return constructStringExprNode(
-        message.parts().iterator(), objLitNode, callNode);
+    Iterator<CharSequence> iterator = message.parts().iterator();
+    return iterator.hasNext()
+        ? constructStringExprNode(iterator, objLitNode, callNode)
+        : IR.string("");
   }
 
   /**

--- a/test/com/google/javascript/jscomp/ReplaceMessagesTest.java
+++ b/test/com/google/javascript/jscomp/ReplaceMessagesTest.java
@@ -105,6 +105,14 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         "/** @desc d */\n var MSG_E=obj.getAmt()");
   }
 
+  public void testMethodCallReplacementEmptyMessage() {
+    registerMessage(new JsMessage.Builder("MSG_M").build());
+
+    test(
+       "/** @desc d */\n var MSG_M = goog.getMsg('${$amount}', {amount: obj.getAmt()});",
+       "/** @desc d */\n var MSG_M=\"\"");
+  }
+
   public void testHookReplacement()  {
     registerMessage(new JsMessage.Builder("MSG_F")
         .appendStringPart("#")


### PR DESCRIPTION
Replacing a call node in an empty message leads to an NoSuchElementException. This fix adds a check and defaults to an empty string message in this case, since the same happens when replacing function nodes. Alternatively, an exception with a higher-level message should be thrown, to explain the problem.

This problem was identified by our automated detector [MUDetect](https://github.com/stg-tud/MUDetect/). We would very much appreciate your feedback on our patch. Thank you very much!