### PR TITLE
Disable the PhaseOptimizer log messages in open source runners

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -67,6 +67,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.kohsuke.args4j.Argument;
@@ -2042,10 +2044,16 @@ public class CommandLineRunner extends
     return this.errors;
   }
 
+  private static Logger phaseLogger = Logger.getLogger(PhaseOptimizer.class.getName());
+
   /**
    * Runs the Compiler. Exits cleanly in the event of an error.
    */
   public static void main(String[] args) {
+    // disable any logging messages that can interfere with standard error reporting
+    if (phaseLogger != null) {
+      phaseLogger.setLevel(Level.OFF);
+    }
     CommandLineRunner runner = new CommandLineRunner(args);
     if (runner.shouldRunCompiler()) {
       runner.run();

--- a/src/com/google/javascript/jscomp/gwt/client/GwtRunner.java
+++ b/src/com/google/javascript/jscomp/gwt/client/GwtRunner.java
@@ -64,6 +64,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
@@ -73,6 +75,9 @@ import jsinterop.annotations.JsType;
  * Runner for the GWT-compiled JSCompiler.
  */
 public final class GwtRunner {
+  private static Logger phaseLogger
+      = Logger.getLogger("com.google.javascript.jscomp.PhaseOptimizer");
+
   private static final CompilationLevel DEFAULT_COMPILATION_LEVEL =
       CompilationLevel.SIMPLE_OPTIMIZATIONS;
 
@@ -697,6 +702,10 @@ public final class GwtRunner {
   /** Public compiler call. Exposed in {@link #exportCompile}. */
   @JsMethod(namespace = "jscomp")
   public static ChunkOutput compile(Flags flags, File[] inputs) throws IOException {
+    // The PhaseOptimizer logs skipped pass warnings that interfere with capturing
+    // output and errors in the open source runners.
+    phaseLogger.setLevel(Level.OFF);
+
     String[] unhandled = updateFlags(flags, getDefaultFlags());
     if (unhandled.length > 0) {
       throw new RuntimeException("Unhandled flag: " + unhandled[0]);


### PR DESCRIPTION
The skipped pass warnings use the standard Java logger and interfere with parsing of structured errors. Disable these messages for open source runners.

Closes #2984.