### PR TITLE
If the compiler output is a JSON stream, don't restrict chunk naming

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1162,8 +1162,11 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
       if (isInTestMode()) {
         modules = modulesSupplierForTesting.get();
       } else {
-        for (JsModuleSpec m : jsModuleSpecs) {
-          checkModuleName(m.getName());
+        if (JsonStreamMode.IN.equals(config.jsonStreamMode)
+            || JsonStreamMode.NONE.equals(config.jsonStreamMode)) {
+          for (JsModuleSpec m : jsModuleSpecs) {
+            checkModuleName(m.getName());
+          }
         }
         modules = createJsModules(jsModuleSpecs, inputs);
       }

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2093,6 +2093,34 @@ public final class CommandLineRunnerTest extends TestCase {
                 + "\\\"a\\\",\\\"console\\\"]\\n}\\n\"}]");
   }
 
+  public void testJsonStreamAllowsAnyChunkName() {
+    String inputString = "[{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
+    args.add("--json_streams=BOTH");
+    args.add("--chunk=foo/bar/baz:1");
+
+    CommandLineRunner runner =
+        new CommandLineRunner(
+            args.toArray(new String[] {}),
+            new ByteArrayInputStream(inputString.getBytes(UTF_8)),
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    lastCompiler = runner.getCompiler();
+    try {
+      runner.doRun();
+    } catch (IOException e) {
+      e.printStackTrace();
+      fail("Unexpected exception " + e);
+    }
+    String output = new String(outReader.toByteArray(), UTF_8);
+    assertThat(output).isEqualTo("[{\"src\":\"alert(\\\"foo\\\");\\n\","
+        + "\"path\":\"./foo/bar/baz.js\",\"source_map\":\"{\\n\\\"version\\\":3,"
+        + "\\n\\\"file\\\":\\\"./foo/bar/baz.js\\\",\\n\\\"lineCount\\\":1,"
+        + "\\n\\\"mappings\\\":\\\"AAAAA,KAAA,CAAM,KAAN;\\\","
+        + "\\n\\\"sources\\\":[\\\"foo.js\\\"],"
+        + "\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"}]");
+  }
+
   public void testOutputModuleNaming() {
     String inputString = "[{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
     args.add("--json_streams=BOTH");


### PR DESCRIPTION
With JSON streams, it's the responsibility of the caller to create the file structure.

Allows chunk names to contain path segments and other non-identifier characters.