### PR TITLE
Remove the js version repo from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ The [Closure Compiler](https://developers.google.com/closure/compiler/) is a too
  * [Download the latest version](https://dl.google.com/closure-compiler/compiler-latest.zip) ([Release details here](https://github.com/google/closure-compiler/wiki/Releases))
  * [Download a specific version](https://github.com/google/closure-compiler/wiki/Binary-Downloads). Also available via:
    - [Maven](https://github.com/google/closure-compiler/wiki/Maven)
-   - [NPM](https://www.npmjs.com/package/google-closure-compiler)
- * [Use the JavaScript version](https://github.com/google/closure-compiler-js), with no Java dependency
+   - [NPM](https://www.npmjs.com/package/google-closure-compiler) - includes java, native and javascript versions.
  * See the [Google Developers Site](https://developers.google.com/closure/compiler/docs/gettingstarted_app) for documentation including instructions for running the compiler from the command line.
 
 ## Options for Getting Help


### PR DESCRIPTION
Update the readme to remove references to the closure-compiler-js repo as development has now moved to the main npm version.