### PR TITLE
Added support for new URLSearchParam({foo: 1})

### DIFF
--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -24,7 +24,7 @@
 
 /**
  * @constructor
- * @implements {Iterable<!Array<string>>}
+ * @implements {Iterable<!Array<string>>|Object<string, ?>}
  * @param {(string|!URLSearchParams)=} init
  */
 function URLSearchParams(init) {}

--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -23,7 +23,7 @@
  */
 
 /**
- * @typedef {Iterable<string>}
+ * @typedef {Array<string>}
  */
 var URLSearchParamsTupleType;
 
@@ -31,12 +31,14 @@ var URLSearchParamsTupleType;
  * @see https://url.spec.whatwg.org/#interface-urlsearchparams
  * @constructor
  * @implements {Iterable<!Array<string>>}
- * @param {(string|!Iterable<!URLSearchParamsTupleType>|!Object<string,string>)=} init
+ * @param {(string|!Array<!URLSearchParamsTupleType>|!Object<string,string>)=} init
  * when |init| is a string, it is basically parsed as a query string (a=b&b=c).
- * when |init| is an iterable of iterables of string ([["a", "b"], ["b", "c"]]),
+ * when |init| is an array of arrays of string ([["a", "b"], ["b", "c"]]),
  *  it must contain pairs of strings,
  *  where the first item in the pair will be interpreted as a key
  *  and the second as a value.
+ *  Note - the specification uses Iterable rather than Array,
+ *  but this is not supported in Edge 17 - 18.
  * when |init| is an object, keys and values will be interpreted as such
  *  ({a: "b", b: "c"}).
  */

--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -24,7 +24,7 @@
 
 /**
  * @constructor
- * @implements {Iterable<!Array<string>>|Object<string, ?>}
+ * @implements {Iterable<!Array<string>>|Object<*, *>}
  * @param {(string|!URLSearchParams)=} init
  */
 function URLSearchParams(init) {}

--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -23,19 +23,22 @@
  */
 
 /**
- * @typedef {IArrayLike<string>}
+ * @typedef {Iterable<string>}
  */
 var URLSearchParamsTupleType;
 
 /**
- * @typedef {IArrayLike<!URLSearchParamsTupleType>|Iterable<!URLSearchParamsTupleType>}
- */
-var URLSearchParamsTupleSequenceType;
-
-/**
+ * @see https://url.spec.whatwg.org/#interface-urlsearchparams
  * @constructor
  * @implements {Iterable<!Array<string>>}
- * @param {(string|!URLSearchParamsTupleSequenceType|!Object<string,string>)=} init
+ * @param {(string|!Iterable<!URLSearchParamsTupleType>|!Object<string,string>)=} init
+ * when |init| is a string, it is basically parsed as a query string (a=b&b=c).
+ * when |init| is an iterable of iterables of string ([["a", "b"], ["b", "c"]]),
+ *  it must contain pairs of strings,
+ *  where the first item in the pair will be interpreted as a key
+ *  and the second as a value.
+ * when |init| is an object, keys and values will be interpreted as such
+ *  ({a: "b", b: "c"}).
  */
 function URLSearchParams(init) {}
 

--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -24,8 +24,8 @@
 
 /**
  * @constructor
- * @implements {Iterable<!Array<string>>|Object<*, *>}
- * @param {(string|!URLSearchParams)=} init
+ * @implements {Iterable<!Array<string>>}
+ * @param {(string|!URLSearchParams|Object<*, *>)=} init
  */
 function URLSearchParams(init) {}
 

--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -23,9 +23,19 @@
  */
 
 /**
+ * @typedef {IArrayLike<string>}
+ */
+var URLSearchParamsTupleType;
+
+/**
+ * @typedef {IArrayLike<!URLSearchParamsTupleType>|Iterable<!URLSearchParamsTupleType>}
+ */
+var URLSearchParamsTupleSequenceType;
+
+/**
  * @constructor
  * @implements {Iterable<!Array<string>>}
- * @param {(string|!URLSearchParams|Object<*, *>)=} init
+ * @param {(string|!URLSearchParamsTupleSequenceType|!Object<string,string>)=} init
  */
 function URLSearchParams(init) {}
 


### PR DESCRIPTION
This is implemented everywhere (modern).