### PR TITLE
update node definitions for os.tmpdir

### DIFF
--- a/contrib/nodejs/os.js
+++ b/contrib/nodejs/os.js
@@ -26,7 +26,7 @@ var os = {};
  * @return {string}
  * @nosideeffects
  */
-os.tmpDir;
+os.tmpdir;
 
 /**
  * @return {string}


### PR DESCRIPTION
`os.tmpDir` has been deprecated and `os.tmpdir` is available for at least way back to node 0.10.  
the definition managed to survive the update in the Closure compiler definitions until these day.