### PR TITLE
Check iterator immediately before access.

### DIFF
--- a/src/com/google/javascript/jscomp/ReplaceMessages.java
+++ b/src/com/google/javascript/jscomp/ReplaceMessages.java
@@ -180,9 +180,7 @@ final class ReplaceMessages extends JsMessageVisitor {
     checkNode(oldBlockNode, Token.BLOCK);
 
     Iterator<CharSequence> iterator = message.parts().iterator();
-    Node valueNode = iterator.hasNext()
-        ? constructAddOrStringNode(iterator, argListNode)
-        : IR.string("");
+    Node valueNode = constructAddOrStringNode(iterator, argListNode);
     Node newBlockNode = IR.block(IR.returnNode(valueNode));
 
     // TODO(user): checkTreeEqual is overkill. I am in process of rewriting
@@ -211,6 +209,10 @@ final class ReplaceMessages extends JsMessageVisitor {
   private static Node constructAddOrStringNode(Iterator<CharSequence> partsIterator,
                                                Node argListNode)
       throws MalformedException {
+    if (!partsIterator.hasNext()) {
+      return IR.string("");
+    }
+
     CharSequence part = partsIterator.next();
     Node partNode = null;
     if (part instanceof JsMessage.PlaceholderReference) {


### PR DESCRIPTION
It is not immediately obvious that the Iterator queried in `constructAddOrStringNode()` always has a next element to fetch, since the `hasNext()` check occurs outside the querying method. The refactoring pulls this check closer to the query, in order to clarify that the access is always safe.

This problem was identified by our automated detector [MUDetect](https://github.com/stg-tud/MUDetect/). We would very much appreciate your feedback on our patch. Thank you very much!