### PR TITLE
Fix types of Document.prototype.importNode

### DIFF
--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -87,9 +87,9 @@ Document.prototype.createTreeWalker = function(
 Document.prototype.getElementsByTagNameNS = function(namespace, name) {};
 
 /**
- * @param {Node} externalNode
- * @param {boolean} deep
- * @return {Node}
+ * @param {!Node} externalNode
+ * @param {boolean=} deep
+ * @return {!Node}
  * @see https://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/core.html#Core-Document-importNode
  */
 Document.prototype.importNode = function(externalNode, deep) {};


### PR DESCRIPTION
Per https://dom.spec.whatwg.org/#ref-for-dom-document-importnode the first argument must always be a Node and the return type is always a Node. Morever, `deep` is optional.

Found together with #3073 while working on some polyfills.