### PR TITLE
Remove the extra quotes on command line arguments

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1340,8 +1340,16 @@ public class CommandLineRunner extends
       }
 
       @Override public void addValue(String value) throws CmdLineException {
-        proxy.addValue(value);
-        entries.add(new FlagEntry<>(flag, value));
+        // On windows, some quoted values seem to preserve the quotes as part of the value.
+        String normalizedValue = value;
+        if (value != null
+            && value.length() > 0
+            && (value.substring(0, 1).equals("'") || value.substring(0, 1).equals("\""))
+            && value.substring(value.length() - 1).equals(value.substring(0, 1))) {
+          normalizedValue = value.substring(1, value.length() - 1);
+        }
+        proxy.addValue(normalizedValue);
+        entries.add(new FlagEntry<>(flag, normalizedValue));
       }
 
       @Override public FieldSetter asFieldSetter() {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2431,6 +2431,14 @@ public final class CommandLineRunnerTest extends TestCase {
         "var Foo, x = '\\${Foo}'+Foo;");
   }
 
+  /** windows shells can add extra quotes to an argument */
+  @Test
+  public void testWarningGuardQuotedValue() {
+    args.add("--jscomp_error='\"*\"'");
+    args.add("--jscomp_warning=\"'*'\"");
+    args.add("--jscomp_off='\"*\"'");
+    testSame("alert('hello world')");
+  }
 
   /* Helper functions */
 


### PR DESCRIPTION
The windows shell can apparently preserve the quotes as part of an argument value in some cases. Remove those extra quotes.

Closes #3081