### PR TITLE
Handle cases where a class extends clause is also a CommonJS export

### DIFF
--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -2004,7 +2004,11 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
         return null;
       }
 
-      if (NodeUtil.isFunctionExpression(rValue) || NodeUtil.isClassExpression(rValue)) {
+      if (NodeUtil.isFunctionExpression(rValue)) {
+        return rValue.getFirstChild();
+      }
+
+      if (NodeUtil.isClassExpression(rValue) && rValue.getFirstChild() == qNameBase) {
         return rValue.getFirstChild();
       }
 

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -601,15 +601,10 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
 
     testModules(
         "test.js",
-        lines(
-            "module.exports = class Foo {",
-            "  /** @this {Foo} */",
-            "  bar() { return 'bar'; }",
-            "};"),
+        "module.exports = class { bar() { return 'bar'; }};",
         lines(
             "/** @const */ var module$test = {};",
             "/** @const */ module$test.default = class {",
-            "  /** @this {module$test.default} */",
             "  bar() { return 'bar'; }",
             "};"));
   }
@@ -1510,5 +1505,37 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
             "    && {} !== null && !{}.nodeType && {};",
             "console.log(freeExports$$module$test, freeModule$$module$test);",
             "module$test.default = true;"));
+  }
+
+  /** @see https://github.com/google/closure-compiler/issues/3051 */
+  @Test
+  public void testIssue3051() {
+    testModules(
+        "test.js",
+        lines(
+            "class Base {}",
+            "exports.Base = Base;",
+            "",
+            "class Impl extends exports.Base {",
+            "    getString() {",
+            "        return \"test\";",
+            "    }",
+            "}",
+            "exports.Impl = Impl;",
+            "",
+            "const w = new exports.Impl(\"a\")",
+            "console.log(w.getString());"),
+        lines(
+            "/** @const */ var module$test = {",
+            "    /** @const */ default: {}",
+            "};",
+            "module$test.default.Base = class {};",
+            "module$test.default.Impl = class extends module$test.default.Base {",
+            "    getString() {",
+            "        return \"test\"",
+            "    }",
+            "};",
+            "const w$$module$test = new module$test.default.Impl(\"a\");",
+            "console.log(w$$module$test.getString());"));
   }
 }


### PR DESCRIPTION
When a class is exported in a CommonJS module with the form:

```js
class Foo {}
exports.Foo = Foo;

class Bar extends Foo {}
exports.Bar = Bar;
```

The pass failed to recognize the export correctly. Adjust the logic so when looking up an export name, exclude classes where the referenced node is not the class name.

Closes #3051