### PR TITLE
jQuery.prototype.attr

### DIFF
--- a/contrib/externs/jquery-3.3.js
+++ b/contrib/externs/jquery-3.3.js
@@ -305,8 +305,8 @@ jQuery.prototype.append = function(arg1, content) {};
 jQuery.prototype.appendTo = function(target) {};
 
 /**
- * @param {(string|Object<string,*>)} arg1
- * @param {(string|number|boolean|function(number,string))=} arg2
+ * @param {(string|Object<string,(string|number)>)} arg1
+ * @param {(string|number|function(this:Element,number,string):(string|number))=} arg2
  * @return {(string|!jQuery)}
  */
 jQuery.prototype.attr = function(arg1, arg2) {};


### PR DESCRIPTION
According to the documentation ( https://api.jquery.com/attr/#attr2 )
Since at least jQuery 1.6:
If arg1 is a string, arg2 is "String or Number or Null"
If arg1 is an object, arg2 is "Function( Integer index, String attr ) => String or Number" and "this is the current element"

In this PR:
- Improved first parameter object definition
- Second parameter can't be a boolean
- Improved second parameters function prototype