### PR TITLE
 Keep original identifier when its missing in input source maps

### DIFF
--- a/src/com/google/javascript/jscomp/SourceMap.java
+++ b/src/com/google/javascript/jscomp/SourceMap.java
@@ -180,7 +180,10 @@ public final class SourceMap {
         sourceFile = sourceMapping.getOriginalFile();
         lineNo = sourceMapping.getLineNumber();
         charNo = sourceMapping.getColumnPosition();
-        originalName = sourceMapping.getIdentifier();
+        String identifier = sourceMapping.getIdentifier();
+        if (identifier != null && !identifier.isEmpty()) {
+          originalName = identifier;
+        }
       }
     }
 

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2289,10 +2289,10 @@ public final class CommandLineRunnerTest extends TestCase {
                 + "\"src\":\"function log(a){console.log(a)}log(\\\"one.js\\\");\\n\","
                 + "\"path\":\"bar.js\","
                 + "\"source_map\":\"{\\n\\\"version\\\":3,\\n\\\"file\\\":\\\"bar.js\\\",\\n"
-                + "\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\"AAAAA,QAASA,IAAGC,CAACC,CAADD,CAAIA,"
-                + "CACdE,OAAAA,IAAAA,CAAYD,CAAZC,CADcF,CAGhBD,GAAAA,CAAIC,QAAJD;\\\",\\n"
-                + "\\\"sources\\\":[\\\"one.js\\\"],\\n\\\"names\\\":[\\\"log\\\",\\\"\\\","
-                + "\\\"a\\\",\\\"console\\\"]\\n}\\n\"}]");
+                + "\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+                + "OAAAA,IAAAA,CAAYD,CAAZC,CADc,CAGhBF,GAAAA,CAAI,QAAJA;\\\",\\n"
+                + "\\\"sources\\\":[\\\"one.js\\\"],\\n"
+                + "\\\"names\\\":[\\\"log\\\",\\\"a\\\",\\\"console\\\"]\\n}\\n\"}]");
   }
 
   @Test


### PR DESCRIPTION
The TypeScript compiler does not rename any symbols, so does not include any `names` in its output sourcemaps.

The closure compiler when reading mappings from an input sourcemap, applies name from the input sourcemap mapping without checking it is defined.

This results in the closure compiler sourcemap output missing many mapping names.

This fix checks if the input mapping name is defined before applying it.