### PR TITLE
Ignore cases where destructuring patterns are empty.

### DIFF
--- a/src/com/google/javascript/jscomp/RescopeGlobalSymbols.java
+++ b/src/com/google/javascript/jscomp/RescopeGlobalSymbols.java
@@ -375,6 +375,9 @@ final class RescopeGlobalSymbols implements CompilerPass {
 
     private void visitNameDeclaration(NodeTraversal t, Node declaration) {
       List<Node> allLhsNodes = NodeUtil.findLhsNodesInNode(declaration);
+      if (allLhsNodes.size() == 0) {
+        return;
+      }
       boolean hasImportantName = false;
       boolean isGlobalDeclaration = t.getScope().getVar(allLhsNodes.get(0).getString()).isGlobal();
 

--- a/test/com/google/javascript/jscomp/RescopeGlobalSymbolsTest.java
+++ b/test/com/google/javascript/jscomp/RescopeGlobalSymbolsTest.java
@@ -812,4 +812,9 @@ public final class RescopeGlobalSymbolsTest extends CompilerTestCase {
     testSame(
         createModules("var a = 3; export {a};", "import {a} from './input0';"));
   }
+
+  @Test
+  public void testEmptyDestructuring() {
+    testSame("var {} = {};");
+  }
 }


### PR DESCRIPTION
With ES2015 out, the compiler misses a lot of optimization opportunities. With destructuring, the compiler doesn't clean up empty patterns such as `const {} = {};`.

This fixes a crash caused by empty destructuring patterns.

Closes #3106