### PR TITLE
Add a no-arg constructor for the JsonFileSpec class to support Graal

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2767,6 +2767,12 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
     @Nullable
     private final String webpackId;
 
+    // Graal requires a non-arg constructor for use with GSON
+    // See https://github.com/oracle/graal/issues/680
+    private JsonFileSpec() {
+      this(null, null, null, null);
+    }
+
     public JsonFileSpec(String src, String path) {
       this(src, path, null, null);
     }


### PR DESCRIPTION
For reflection support, Graal requires classes to which GSON de-serializes have a no-args constructor. Add a private no-args constructor to the `JsonFileSpec` class.

Fixes https://github.com/oracle/graal/issues/680