### PR TITLE
Added missing space.

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -146,7 +146,7 @@ public class DiagnosticGroups {
           + "newCheckTypes, "
           + "nonStandardJsDocs, "
           + "missingSourcesWarnings, "
-          + "polymer,"
+          + "polymer, "
           + "reportUnknownTypes, "
           + "suspiciousCode, "
           + "strictCheckTypes, "


### PR DESCRIPTION
There should be a space after each diagnostic group. This was missing for the recently added "polymer" group.