### PR TITLE
Enable color for maven in travis build logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ install: true
 
 script:
   # Builds the compiler and runs tests
-  - mvn install --batch-mode
+  - mvn -Dstyle.color=always install
   - node test/gwt.js
   # Checks for JavaDoc errors
-  - mvn -pl com.google.javascript:closure-compiler javadoc:javadoc
+  - mvn -Dstyle.color=always -pl com.google.javascript:closure-compiler javadoc:javadoc
 
 # Causes the build to run on a VM instead of in a container, to avoid OOM errors.
 sudo: required
@@ -25,6 +25,8 @@ after_success:
 
 env:
   global:
+    # Force maven to use colorized output
+    - MAVEN_OPTS="-Djansi.force=true"
     # CI_DEPLOY_USERNAME
     - secure: "U2O3l6+TOz+3pxxsFdl/T+ktgGixfJO1Fc9pNC75v/N08lfNmyB+ee1wz0E8q7SZvnNR9D6KfLCFzjq0sS5F9FGrfKbFDTPxyaz/4EwTk0fdvPzaKhs8xl6LPVlLw6vLRIWc8PPCIVqqbYAbG6JA8liBPGbBXD/LXmCFbSr0rLg="
     # CI_DEPLOY_PASSWORD

--- a/travis_util/deploy_snapshot.sh
+++ b/travis_util/deploy_snapshot.sh
@@ -6,7 +6,7 @@ set -e -u
 
 function mvn_deploy() {
   mvn clean source:jar deploy \
-    --settings="$(dirname $0)/settings.xml" -DskipTests=true "$@"
+    --settings="$(dirname $0)/settings.xml" -DskipTests=true -Dstyle.color=always "$@"
 }
 
 # Restrict when snapshots are published


### PR DESCRIPTION
The travis logs are hard to read. I figured out how to enable colorized output from maven in Travis which greatly improves the situation.