### PR TITLE
Fix a NPE crash in the gwt compiler introduced by #3100

### DIFF
--- a/src/com/google/javascript/jscomp/SourceMap.java
+++ b/src/com/google/javascript/jscomp/SourceMap.java
@@ -180,7 +180,7 @@ public final class SourceMap {
         lineNo = sourceMapping.getLineNumber();
         charNo = sourceMapping.getColumnPosition();
         String identifier = sourceMapping.getIdentifier();
-        if (sourceMapping != null && !identifier.isEmpty()) {
+        if (sourceMapping != null && identifier != null && !identifier.isEmpty()) {
           originalName = identifier;
         }
       }


### PR DESCRIPTION
c143b8c7f50b6ce86e6e1944eae50d6f664019e2 introduced a NPE in the GWT runner. Nightly builds started failing: https://travis-ci.org/google/closure-compiler-npm/jobs/456772868

Add a null guard to prevent the crash