### PR TITLE
Add configuration options for RescopeGlobalSymbols

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -47,6 +47,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -617,6 +618,18 @@ public class CompilerOptions implements Serializable {
   @Deprecated
   void setRenamePrefixNamespaceAssumeCrossModuleNames(boolean assume) {
     setRenamePrefixNamespaceAssumeCrossChunkNames(assume);
+  }
+  
+  public String rescopeRuntimeGlobal = "window";
+
+  public Set<String> rescopeRuntimeGlobalNames = new HashSet<>();
+
+  public void setRescopeRuntimeGlobal(String rescopeRuntimeGlobal) {
+    this.rescopeRuntimeGlobal = rescopeRuntimeGlobal;
+  }
+
+  public Set<String> getRescopeRuntimeGlobalNames() {
+    return rescopeRuntimeGlobalNames;
   }
 
   private PropertyCollapseLevel collapsePropertiesLevel;
@@ -1314,6 +1327,8 @@ public class CompilerOptions implements Serializable {
     exportTestFunctions = false;
     declaredGlobalExternsOnWindow = true;
     nameGenerator = new DefaultNameGenerator();
+    rescopeRuntimeGlobal = RescopeGlobalSymbols.WINDOW;
+    rescopeRuntimeGlobalNames.addAll(RescopeGlobalSymbols.SPECIAL_EXTERNS);
 
     // Alterations
     runtimeTypeCheck = false;

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2353,7 +2353,11 @@ public final class DefaultPassConfig extends PassConfig {
       return new RescopeGlobalSymbols(
           compiler,
           options.renamePrefixNamespace,
-          options.renamePrefixNamespaceAssumeCrossChunkNames);
+          true,
+          options.renamePrefixNamespaceAssumeCrossChunkNames,
+          options.rescopeRuntimeGlobal,
+          options.rescopeRuntimeGlobalNames
+          );
     }
 
     @Override


### PR DESCRIPTION
Making it usable in a node.js environment that does not use "window". The original behavior is preserved and can now be overridden selectively.

I struggled coming up with reasonable names for the new configuration options. It might also be useful to adjust some other option names.

