### PR TITLE
Add TexImageSource typedef for WebGL

### DIFF
--- a/externs/browser/webgl.js
+++ b/externs/browser/webgl.js
@@ -29,6 +29,9 @@
  */
 
 
+/** @typedef {ImageBitmap|ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|OffscreenCanvas} */
+var TexImageSource;
+
 /**
  * @constructor
  */
@@ -2595,8 +2598,7 @@ WebGLRenderingContext.prototype.stencilOpSeparate = function(
  * @param {number} internalformat
  * @param {number} format or width
  * @param {number} type or height
- * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|
- *     number} img or border
+ * @param {TexImageSource|number} img or border
  * @param {number=} opt_format
  * @param {number=} opt_type
  * @param {ArrayBufferView=} opt_pixels
@@ -2631,8 +2633,7 @@ WebGLRenderingContext.prototype.texParameteri = function(
  * @param {number} yoffset
  * @param {number} format or width
  * @param {number} type or height
- * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|
- *     number} data or format
+ * @param {TexImageSource|number} data or format
  * @param {number=} opt_type
  * @param {ArrayBufferView=} opt_pixels
  * @return {undefined}

--- a/externs/browser/webgl2.js
+++ b/externs/browser/webgl2.js
@@ -1778,10 +1778,10 @@ WebGL2RenderingContext.prototype.texStorage3D = function(
  * @param {number} internalformat
  * @param {number} formatOrWidth
  * @param {number} typeOrHeight
- * @param {?ImageData|?HTMLImageElement|?HTMLCanvasElement|?HTMLVideoElement|number} imgOrBorder
+ * @param {?TexImageSource|number} imgOrBorder
  * @param {number=} opt_format
  * @param {number=} opt_type
- * @param {?ArrayBufferView|?ImageData|?HTMLImageElement|?HTMLCanvasElement|?HTMLVideoElement|number=} opt_imgOrOffset
+ * @param {?ArrayBufferView|?TexImageSource|number=} opt_imgOrOffset
  * @param {number=} opt_srcOffset
  * @return {undefined}
  * @override
@@ -1797,9 +1797,9 @@ WebGL2RenderingContext.prototype.texImage2D = function(
  * @param {number} yoffset
  * @param {number} formatOrWidth
  * @param {number} typeOrHeight
- * @param {?ImageData|?HTMLImageElement|?HTMLCanvasElement|?HTMLVideoElement|number} dataOrFormat
+ * @param {?TexImageSource|number} dataOrFormat
  * @param {number=} opt_type
- * @param {?ArrayBufferView|?ImageData|?HTMLImageElement|?HTMLCanvasElement|?HTMLVideoElement|number=} opt_imgOrOffset
+ * @param {?ArrayBufferView|?TexImageSource|number=} opt_imgOrOffset
  * @param {number=} opt_srcOffset
  * @return {undefined}
  * @override
@@ -1818,7 +1818,7 @@ WebGL2RenderingContext.prototype.texSubImage2D = function(
  * @param {number} border
  * @param {number} format
  * @param {number} type
- * @param {?ArrayBufferView|?ImageData|?HTMLImageElement|?HTMLCanvasElement|?HTMLVideoElement|number} srcData
+ * @param {?ArrayBufferView|?TexImageSource|number} srcData
  * @param {number=} opt_srcOffset
  * @return {undefined}
  */
@@ -1837,7 +1837,7 @@ WebGL2RenderingContext.prototype.texImage3D = function(
  * @param {number} depth
  * @param {number} format
  * @param {number} type
- * @param {?ArrayBufferView|?ImageData|?HTMLImageElement|?HTMLCanvasElement|?HTMLVideoElement|number} srcData
+ * @param {?ArrayBufferView|?TexImageSource|number} srcData
  * @param {number=} opt_srcOffset
  * @return {undefined}
  */


### PR DESCRIPTION
This pulls the externs for WebGL closer to the spec by adding [`TexImageSource`](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14). Most notably adds `ImageBitmap` and `OffscreenCanvas` where they were missing before.