### PR TITLE
Add support for webpack4

### DIFF
--- a/src/com/google/javascript/jscomp/FindModuleDependencies.java
+++ b/src/com/google/javascript/jscomp/FindModuleDependencies.java
@@ -181,14 +181,8 @@ public class FindModuleDependencies implements NodeTraversal.ScopedCallback {
 
         if (modulePath != null) {
           if (dynamicImportScope != null
-              || (n.getParent().isCall()
-                  && n.getPrevious() != null
-                  && n.getPrevious().isGetProp()
-                  && n.getPrevious().getFirstChild().isCall()
-                  && n.getPrevious().getFirstFirstChild().isQualifiedName()
-                  && n.getPrevious()
-                      .getFirstFirstChild()
-                      .matchesQualifiedName("__webpack_require__.e"))) {
+              || ProcessCommonJSModules.isCommonJsDynamicImportCallback(
+                  NodeUtil.getEnclosingFunction(n), resolutionMode)) {
             t.getInput().addDynamicRequire(modulePath.toModuleName());
           } else {
             t.getInput().addOrderedRequire(Require.commonJs(modulePath.toModuleName(), path));

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -46,6 +46,9 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
   private static final String MODULE = "module";
   private static final String REQUIRE = "require";
   private static final String WEBPACK_REQUIRE = "__webpack_require__";
+  // Webpack transpiles import() statements to __webpack_require__.t(modulePath)
+  // Always imports the module namespace regardless of module type
+  private static final String WEBPACK_REQUIRE_NAMESPACE = "__webpack_require__.t";
   private static final String EXPORT_PROPERTY_NAME = "default";
 
   public static final DiagnosticType UNKNOWN_REQUIRE_ENSURE =
@@ -146,6 +149,16 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
     return input.toModuleName();
   }
 
+  public String getBasePropertyImport(String moduleName, Node requireCall) {
+    checkArgument(requireCall.isCall());
+    if (compiler.getOptions().getModuleResolutionMode() == ModuleLoader.ResolutionMode.WEBPACK
+        && requireCall.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE_NAMESPACE)) {
+      return moduleName;
+    }
+
+    return getBasePropertyImport(moduleName);
+  }
+
   public String getBasePropertyImport(String moduleName) {
     CompilerInput.ModuleType moduleType = compiler.getModuleTypeByName(moduleName);
     if (moduleType != null && moduleType != CompilerInput.ModuleType.COMMONJS) {
@@ -165,13 +178,15 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
    * <ul>
    *   <li>require("something");
    *   <li>__webpack_require__(4); // only when the module resolution is WEBPACK
+   *   <li>__webpack_require__.t(4); // only when the module resolution is WEBPACK
    * </ul>
    */
   public static boolean isCommonJsImport(
       Node requireCall, ModuleLoader.ResolutionMode resolutionMode) {
     if (requireCall.isCall() && requireCall.hasTwoChildren()) {
       if (resolutionMode == ModuleLoader.ResolutionMode.WEBPACK
-          && requireCall.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE)
+          && (requireCall.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE)
+              || requireCall.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE_NAMESPACE))
           && (requireCall.getSecondChild().isNumber() || requireCall.getSecondChild().isString())) {
         return true;
       } else if (requireCall.getFirstChild().matchesQualifiedName(REQUIRE)
@@ -268,12 +283,14 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
    * recognized:
    *
    * <ul>
-   *   <li>__webpack_require__.e(0).then(function() { return __webpack_require(4);})
+   *   <li>__webpack_require__.e(0).then(function() { return __webpack_require__(4);})
+   *   <li>Promise.all([__webpack_require__.e(0)]).then(function() { return
+   *       __webpack_require__(4);})
    * </ul>
    */
   public static boolean isCommonJsDynamicImportCallback(
       Node n, ModuleLoader.ResolutionMode resolutionMode) {
-    if (resolutionMode != ModuleLoader.ResolutionMode.WEBPACK) {
+    if (n == null || resolutionMode != ModuleLoader.ResolutionMode.WEBPACK) {
       return false;
     }
     if (n.isFunction() && isWebpackRequireEnsureCallback(n)) {
@@ -287,7 +304,11 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
    * Recognizes __webpack_require__ calls that are the .then callback of a __webpack_require__.e
    * call. Example:
    *
-   * <p>__webpack_require__.e(0).then(function() { return __webpack_require__(4); })
+   * <ul>
+   *   <li>__webpack_require__.e(0).then(function() { return __webpack_require__(4); })
+   *   <li>Promise.all([__webpack_require__.e(0)]).then(function() { return
+   *       __webpack_require__(4);})
+   * </ul>
    */
   private static boolean isWebpackRequireEnsureCallback(Node fnc) {
     checkArgument(fnc.isFunction());
@@ -300,16 +321,32 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       return false;
     }
 
-    if (callParent.hasChildren()
+    if (!(callParent.hasChildren()
         && callParent.getFirstChild().isGetProp()
-        && callParent.getFirstFirstChild().isCall()
-        && callParent
-            .getFirstFirstChild()
-            .getFirstChild()
-            .matchesQualifiedName(WEBPACK_REQUIRE + ".e")
+        && callParent.getFirstFirstChild().isCall())) {
+      return false;
+    }
+    Node callParentTarget = callParent.getFirstFirstChild().getFirstChild();
+
+    if (callParentTarget.matchesQualifiedName(WEBPACK_REQUIRE + ".e")
         && callParent.getFirstChild().getSecondChild().isString()
         && callParent.getFirstChild().getSecondChild().getString().equals("then")) {
       return true;
+    } else if (callParentTarget.matchesQualifiedName("Promise.all")
+        && callParentTarget.getNext() != null
+        && callParentTarget.getNext().isArrayLit()) {
+      boolean allElementsAreDynamicImports = false;
+      for (Node arrayItem = callParentTarget.getNext().getFirstChild();
+          arrayItem != null;
+          arrayItem = arrayItem.getNext()) {
+        if (!(arrayItem.isCall()
+            && arrayItem.hasTwoChildren()
+            && arrayItem.getFirstChild().matchesQualifiedName(WEBPACK_REQUIRE + ".e"))) {
+          return false;
+        }
+        allElementsAreDynamicImports = true;
+      }
+      return allElementsAreDynamicImports;
     }
     return false;
   }
@@ -1421,7 +1458,7 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
     private void visitRequireCall(NodeTraversal t, Node require, Node parent) {
       String moduleName = getImportedModuleName(t, require);
       Node moduleRef =
-          NodeUtil.newQName(compiler, getBasePropertyImport(moduleName))
+          NodeUtil.newQName(compiler, getBasePropertyImport(moduleName, require))
               .useSourceInfoFromForTree(require.getSecondChild());
       parent.replaceChild(require, moduleRef);
 
@@ -2061,10 +2098,12 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
       }
 
       if (rValue.isCall() && isCommonJsImport(rValue)) {
-        return getBasePropertyImport(getImportedModuleName(t, rValue)) + propSuffix;
+        return getBasePropertyImport(getImportedModuleName(t, rValue), rValue) + propSuffix;
       } else if (rValue.isGetProp() && isCommonJsImport(rValue.getFirstChild())) {
         // var foo = require('bar').foo;
-        String importName = getBasePropertyImport(getImportedModuleName(t, rValue.getFirstChild()));
+        String importName =
+            getBasePropertyImport(
+                getImportedModuleName(t, rValue.getFirstChild()), rValue.getFirstChild());
 
         String suffix =
             rValue.getSecondChild().isGetProp()

--- a/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
+++ b/test/com/google/javascript/jscomp/ProcessCommonJSModulesTest.java
@@ -1559,6 +1559,25 @@ public final class ProcessCommonJSModulesTest extends CompilerTestCase {
   }
 
   @Test
+  public void testWebpackRequireNamespace() {
+    Map<String, String> webpackModulesById =
+        ImmutableMap.of(
+            "1", "other.js",
+            "yet_another.js", "yet_another.js",
+            "3", "test.js");
+    setWebpackModulesById(webpackModulesById);
+    resolutionMode = ModuleLoader.ResolutionMode.WEBPACK;
+
+    testModules(
+        "test.js",
+        lines("var name = __webpack_require__.t('yet_another.js');", "exports.foo = 1;"),
+        lines(
+            "/** @const */ var module$test = {/** @const */ default: {}};",
+            "var name$$module$test = module$yet_another;",
+            "module$test.default.foo = 1;"));
+  }
+
+  @Test
   public void testGoogModuleUnaffected() {
     testModules(
         "test.js", "goog.module('foo'); exports.y = 123;", "goog.module('foo'); exports.y = 123;");


### PR DESCRIPTION
Recognize calls to __webpack_require__.t as namespace imports.
Recognize the Promise.all calls for the webpack4 require.ensure loading