### PR TITLE
Fix inclusion of input source maps sourcesContent in JSModule compilations

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
@@ -137,7 +137,6 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
     mappings.clear();
     lastMapping = null;
     sourceFileMap.clear();
-    sourceFileContentMap.clear();
     originalNameMap.clear();
     lastSourceFile = null;
     lastSourceFileIndex = -1;


### PR DESCRIPTION
It looks like `sourceFileContentMap` was incorrectly being cleared. `sourceFileContentMap` is populated during the compile initialisation, not when the sourceMaps are generated. So clearing it was preventing `sourcesContent` from being included in the source map.

Our pattern for jsmodule compilations is:

```
compiler.compileModules(EXTERNS, modules, options); // sourceFileContentMap populated here
for (JSModule module : modules) {
   compiler.getSourceMap().reset(); // sourceFileContentMap dropped here
   String source = compiler.toSource(module);
   SourceMap = compiler.getSourceMap();
   writeOutput(source, sourceMap);
}
```