### PR TITLE
When resetting source maps, re-add input source maps.

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1470,7 +1470,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
         String moduleFilename = getModuleOutputFileName(m);
         try (Writer writer = fileNameToLegacyOutputWriter(moduleFilename)) {
           if (options.sourceMapOutputPath != null) {
-            compiler.getSourceMap().reset();
+            compiler.resetAndIntitializeSourceMap();
           }
           writeModuleOutput(writer, m);
           if (options.sourceMapOutputPath != null) {
@@ -1494,7 +1494,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   /** Given an output module, convert it to a JSONFileSpec with associated sourcemap */
   @GwtIncompatible("Unnecessary")
   private JsonFileSpec createJsonFileFromModule(JSModule module) throws IOException {
-    compiler.getSourceMap().reset();
+    compiler.resetAndIntitializeSourceMap();
 
     StringBuilder output = new StringBuilder();
     writeModuleOutput(output, module);

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1185,10 +1185,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   }
 
   final String getCurrentJsSource() {
-    SourceMap sourceMap = getSourceMap();
-    if (sourceMap != null) {
-      sourceMap.reset();
-    }
+    this.resetAndIntitializeSourceMap();
 
     List<String> fileNameRegexList = options.filesToPrintAfterEachPassRegexList;
     List<String> moduleNameRegexList = options.chunksToPrintAfterEachPassRegexList;
@@ -3718,5 +3715,17 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
 
     path1Parts.addAll(path2Parts);
     return String.join("/", path1Parts);
+  }
+
+  public void resetAndIntitializeSourceMap() {
+    if (sourceMap == null) {
+      return;
+    }
+    sourceMap.reset();
+    if (options.applyInputSourceMaps && options.sourceMapIncludeSourcesContent) {
+      for (SourceMapInput inputSourceMap : inputSourceMaps.values()) {
+        addSourceMapSourceFiles(inputSourceMap);
+      }
+    }
   }
 }

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -3722,9 +3722,24 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       return;
     }
     sourceMap.reset();
-    if (options.applyInputSourceMaps && options.sourceMapIncludeSourcesContent) {
-      for (SourceMapInput inputSourceMap : inputSourceMaps.values()) {
-        addSourceMapSourceFiles(inputSourceMap);
+    if (options.sourceMapIncludeSourcesContent) {
+      if (options.applyInputSourceMaps) {
+        // Add any input source map content files to the source map as potential sources
+        for (SourceMapInput inputSourceMap : inputSourceMaps.values()) {
+          addSourceMapSourceFiles(inputSourceMap);
+        }
+      }
+
+      // Add all the compilation sources to the source map as potential sources
+      Iterable<JSModule> allModules = getModules();
+      if (allModules != null) {
+        List<SourceFile> sourceFiles = new ArrayList<>();
+        for (JSModule module : allModules) {
+          for (CompilerInput input : module.getInputs()) {
+            sourceFiles.add(input.getSourceFile());
+          }
+        }
+        addFilesToSourceMap(sourceFiles);
       }
     }
   }

--- a/src/com/google/javascript/jscomp/gwt/client/GwtRunner.java
+++ b/src/com/google/javascript/jscomp/gwt/client/GwtRunner.java
@@ -340,7 +340,7 @@ public final class GwtRunner {
 
     for (JSModule c : chunks) {
       if (flags.createSourceMap != null && !flags.createSourceMap.equals(false)) {
-        compiler.getSourceMap().reset();
+        compiler.resetAndIntitializeSourceMap();
       }
 
       File file = new File();

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2460,6 +2460,33 @@ public final class CommandLineRunnerTest {
     testSame("alert('hello world')");
   }
 
+  @Test
+  public void testOutputSourceMapContainsSourcesContent() {
+    String inputString = "[{\"src\": \"\", \"path\": \"base.js\"},"
+        + "{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
+    args.add("--json_streams=BOTH");
+    args.add("--chunk=m1:1");
+    args.add("--chunk=m2:1:m1");
+    args.add("--source_map_include_content");
+
+    CommandLineRunner runner =
+        new CommandLineRunner(
+            args.toArray(new String[] {}),
+            new ByteArrayInputStream(inputString.getBytes(UTF_8)),
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    lastCompiler = runner.getCompiler();
+    try {
+      runner.doRun();
+    } catch (IOException e) {
+      e.printStackTrace();
+      assertWithMessage("Unexpected exception " + e).fail();
+    }
+    String output = new String(outReader.toByteArray(), UTF_8);
+    assertThat(output).contains("\\\"sourcesContent\\\":");
+  }
+
   /* Helper functions */
 
   private void testSame(String original) {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2484,7 +2484,18 @@ public final class CommandLineRunnerTest {
       assertWithMessage("Unexpected exception " + e).fail();
     }
     String output = new String(outReader.toByteArray(), UTF_8);
-    assertThat(output).contains("\\\"sourcesContent\\\":");
+    assertThat(output)
+        .isEqualTo(
+            "[{\"src\":\"\\n\",\"path\":\"./m1.js\",\"source_map\":\"{\\n\\\"version\\\":3,"
+                + "\\n\\\"file\\\":\\\"./m1.js\\\",\\n\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\";\\\""
+                + ",\\n\\\"sources\\\":[],\\n\\\"names\\\":[]\\n}\\n\"},{\"src\":\"alert(\\\"foo\\\");"
+                + "\\n\",\"path\":\"./m2.js\",\"source_map\":\"{\\n\\\"version\\\":3,\\n\\\"file\\\":"
+                + "\\\"./m2.js\\\",\\n\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\"AAAAA,KAAA,CAAM,KAAN;"
+                + "\\\",\\n\\\"sources\\\":[\\\"foo.js\\\"],\\n\\\"sourcesContent\\\":[\\\""
+                + "alert('foo');\\\"],\\n\\\"names\\\":[\\\"alert\\\"]\\n}\\n\"},"
+                + "{\"src\":\"\\n\",\"path\":\"./$weak$.js\",\"source_map\":\"{\\n\\\"version\\\":3,\\n"
+                + "\\\"file\\\":\\\"./$weak$.js\\\",\\n\\\"lineCount\\\":1,\\n\\\"mappings\\\":\\\";"
+                + "\\\",\\n\\\"sources\\\":[],\\n\\\"names\\\":[]\\n}\\n\"}]");
   }
 
   /* Helper functions */


### PR DESCRIPTION
When code splitting, the source map is reset between generation of every output file. However, input source maps were not re-applied. So the original source content from an input source map was not copied to the output source map.

Adds a helper method to the compiler to simply reapply those input source maps anytime the source map needs reset.

Alternative to #3166