### PR TITLE
Disable collapse properties for module exports in simple mode

### DIFF
--- a/src/com/google/javascript/jscomp/CompilationLevel.java
+++ b/src/com/google/javascript/jscomp/CompilationLevel.java
@@ -241,7 +241,7 @@ public enum CompilationLevel {
       case SIMPLE_OPTIMIZATIONS:
         // Enable global variable optimizations (but not property optimizations)
         options.setVariableRenaming(VariableRenamingPolicy.ALL);
-        options.setCollapsePropertiesLevel(PropertyCollapseLevel.MODULE_EXPORT);
+        options.setCollapsePropertiesLevel(PropertyCollapseLevel.NONE);
         options.setCollapseAnonymousFunctions(true);
         options.setInlineConstantVars(true);
         options.setInlineFunctions(Reach.ALL);


### PR DESCRIPTION
With dynamic import statements, this optimization is not safe. Property collapsing will leave the following with an undefined reference.

```js
import('./path/to/module.js').then(moduleNamespace => console.log(moduleNamespace.default));
```

Fixes #3182.