### PR TITLE
Add property reflection for Polymer computed properties and observers

### DIFF
--- a/src/com/google/javascript/jscomp/CheckSideEffects.java
+++ b/src/com/google/javascript/jscomp/CheckSideEffects.java
@@ -56,6 +56,8 @@ final class CheckSideEffects extends AbstractPostOrderCallback
 
   private final boolean protectSideEffectFreeCode;
 
+  private boolean preserveFunctionInjected = false;
+
   CheckSideEffects(AbstractCompiler compiler, boolean report,
       boolean protectSideEffectFreeCode) {
     this.compiler = compiler;
@@ -170,7 +172,9 @@ final class CheckSideEffects extends AbstractPostOrderCallback
    */
   private void protectSideEffects() {
     if (!problemNodes.isEmpty()) {
-      addExtern();
+      if (!preserveFunctionInjected) {
+        addExtern(compiler);
+      }
       for (Node n : problemNodes) {
         Node name = IR.name(PROTECTOR_FN).srcref(n);
         name.putBooleanProp(Node.IS_CONSTANT_NAME, true);
@@ -183,7 +187,7 @@ final class CheckSideEffects extends AbstractPostOrderCallback
     }
   }
 
-  private void addExtern() {
+  static void addExtern(AbstractCompiler compiler) {
     Node name = IR.name(PROTECTOR_FN);
     name.putBooleanProp(Node.IS_CONSTANT_NAME, true);
     Node var = IR.var(name);
@@ -244,6 +248,10 @@ final class CheckSideEffects extends AbstractPostOrderCallback
           String name = NodeUtil.getName(n);
           noSideEffectExterns.add(name);
         }
+      }
+
+      if (n.isName() && PROTECTOR_FN.equals(n.getString())) {
+        preserveFunctionInjected = true;
       }
     }
   }

--- a/src/com/google/javascript/jscomp/ClosureCodingConvention.java
+++ b/src/com/google/javascript/jscomp/ClosureCodingConvention.java
@@ -340,7 +340,9 @@ public final class ClosureCodingConvention extends CodingConventions.Proxy {
 
   @Override
   public boolean isPropertyRenameFunction(String name) {
-    return super.isPropertyRenameFunction(name) || "goog.reflect.objectProperty".equals(name);
+    return super.isPropertyRenameFunction(name)
+        || "goog.reflect.objectProperty".equals(name)
+        || "$jscomp.reflectProperty".equals(name);
   }
 
   @Override

--- a/src/com/google/javascript/jscomp/PolymerClassRewriter.java
+++ b/src/com/google/javascript/jscomp/PolymerClassRewriter.java
@@ -288,7 +288,8 @@ final class PolymerClassRewriter {
         sinkFunction.putBooleanProp(Node.FREE_CALL, true);
 
         Node stmt = NodeUtil.getEnclosingStatement(clazz);
-        stmt.getParent().addChildToBack(IR.exprResult(sinkFunction).useSourceInfoFromForTree(stmt));
+        stmt.getParent().addChildAfter(
+            IR.exprResult(sinkFunction).useSourceInfoFromForTree(stmt), stmt);
         compiler.reportChangeToChangeScope(sinkFunction.getFirstChild());
         compiler.reportChangeToEnclosingScope(stmt);
       }

--- a/src/com/google/javascript/jscomp/PolymerClassRewriter.java
+++ b/src/com/google/javascript/jscomp/PolymerClassRewriter.java
@@ -15,11 +15,13 @@
  */
 package com.google.javascript.jscomp;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.PolymerBehaviorExtractor.BehaviorDefinition;
 import com.google.javascript.jscomp.PolymerPass.MemberDefinition;
 import com.google.javascript.jscomp.parsing.parser.FeatureSet;
@@ -178,7 +180,7 @@ final class PolymerClassRewriter {
     if (polymerVersion > 1 && propertyRenamingEnabled && cls.descriptor != null) {
       Node props = NodeUtil.getFirstPropMatchingKey(cls.descriptor, "properties");
       if (props != null && props.isObjectLit()) {
-        addObjectReflectionCall(cls, props);
+        addPropertiesConfigObjectReflection(cls, props);
       }
     }
   }
@@ -254,8 +256,29 @@ final class PolymerClassRewriter {
     // If property renaming is enabled, wrap the properties object literal
     // in a reflection call so that the properties are renamed consistently
     // with the class members.
+    //
+    // Also add reflection and sinks for computed properties and complex observers
+    // and switch simple observers to direct function references.
     if (propertyRenamingEnabled && cls.descriptor != null) {
-      addObjectReflectionCall(cls, cls.descriptor);
+      convertObserverStringsToReferences(cls);
+      List<Node> propertySinks = addComputedPropertiesReflectionCalls(cls);
+      propertySinks.addAll(addComplexObserverReflectionCalls(cls));
+      if (propertySinks.size() > 0) {
+        Node sinkFunction = IR.function(IR.name(""), IR.paramList(), IR.block(propertySinks));
+        JSDocInfoBuilder sinkFunctionDoc = new JSDocInfoBuilder(false);
+        sinkFunctionDoc.recordSuppressions(ImmutableSet.of("uselessCode"));
+        sinkFunction.setJSDocInfo(sinkFunctionDoc.build());
+
+        sinkFunction = IR.call(sinkFunction);
+        sinkFunction.putBooleanProp(Node.FREE_CALL, true);
+
+        Node stmt = NodeUtil.getEnclosingStatement(clazz);
+        stmt.getParent().addChildToBack(IR.exprResult(sinkFunction).useSourceInfoFromForTree(stmt));
+        compiler.reportChangeToChangeScope(sinkFunction.getFirstChild());
+        compiler.reportChangeToEnclosingScope(stmt);
+      }
+
+      addPropertiesConfigObjectReflection(cls, cls.descriptor);
     }
   }
 
@@ -275,7 +298,8 @@ final class PolymerClassRewriter {
   }
 
   /** Wrap the properties config object in an objectReflect call */
-  private void addObjectReflectionCall(PolymerClassDefinition cls, Node propertiesLiteral) {
+  private void addPropertiesConfigObjectReflection(
+      PolymerClassDefinition cls, Node propertiesLiteral) {
     checkNotNull(propertiesLiteral);
     checkState(propertiesLiteral.isObjectLit());
 
@@ -695,5 +719,259 @@ final class PolymerClassRewriter {
     Node assign =
         IR.assign(var.getFirstChild().cloneNode(), var.getFirstChild().removeFirstChild());
     return IR.exprResult(assign).useSourceInfoIfMissingFromForTree(var);
+  }
+
+  /**
+   * Converts property observer strings to direct function references.
+   *
+   * <p>From: <code>observer: '_observerName'</code> To: <code>
+   * observer: ClassName.prototype._observerName</code>
+   */
+  private void convertObserverStringsToReferences(final PolymerClassDefinition cls) {
+    for (MemberDefinition prop : cls.props) {
+      if (prop.value.isObjectLit()) {
+        Node observer = NodeUtil.getFirstPropMatchingKey(prop.value, "observer");
+        if (observer != null && observer.isString()) {
+          Node observerDirectReference =
+              IR.getprop(cls.target.cloneTree(), "prototype", observer.getString())
+                  .useSourceInfoFrom(observer);
+
+          observer.replaceWith(observerDirectReference);
+          compiler.reportChangeToEnclosingScope(observerDirectReference);
+        }
+      }
+    }
+  }
+
+  /**
+   * For any property in the Polymer property configuration object with a `computed` key, parse the
+   * method call and path arguments and replace them with property reflection calls.
+   *
+   * <p>Returns a list of property sink statements to guard against dead code elimination since the
+   * compiler may not see these methods as being used.
+   */
+  private List<Node> addComputedPropertiesReflectionCalls(final PolymerClassDefinition cls) {
+    List<Node> propertySinkStatements = new ArrayList<>();
+    for (MemberDefinition prop : cls.props) {
+      if (prop.value.isObjectLit()) {
+        Node computed = NodeUtil.getFirstPropMatchingKey(prop.value, "computed");
+        if (computed != null && computed.isString()) {
+          propertySinkStatements.addAll(
+              replaceMethodStringWithReflectedCalls(cls.target, computed));
+        }
+      }
+    }
+    return propertySinkStatements;
+  }
+
+  /**
+   * For any strings returned in the array from the Polymer static observers property, parse the
+   * method call and path arguments and replace them with property reflection calls.
+   *
+   * <p>Returns a list of property sink statements to guard against dead code elimination since the
+   * compiler may not see these methods as being used.
+   */
+  private List<Node> addComplexObserverReflectionCalls(final PolymerClassDefinition cls) {
+    List<Node> propertySinkStatements = new ArrayList<>();
+    Node classMembers = NodeUtil.getClassMembers(cls.definition);
+    Node getter = NodeUtil.getFirstGetterMatchingKey(classMembers, "observers");
+    if (getter != null) {
+      Node complexObservers = null;
+      for (Node child : NodeUtil.getFunctionBody(getter.getFirstChild()).children()) {
+        if (child.isReturn()) {
+          if (child.hasChildren() && child.getFirstChild().isArrayLit()) {
+            complexObservers = child.getFirstChild();
+            break;
+          }
+        }
+      }
+      if (complexObservers != null) {
+        for (Node complexObserver : complexObservers.children()) {
+          if (complexObserver.isString()) {
+            propertySinkStatements.addAll(
+                replaceMethodStringWithReflectedCalls(cls.target, complexObserver));
+          }
+        }
+      }
+    }
+    return propertySinkStatements;
+  }
+
+  /**
+   * Given a Polymer method call string such as: <code>"methodName(path.item, other.property.path)"
+   * </code> parse the string into a method name and arguments and build up a new string of property
+   * reflection calls so that the properties can be renamed consistently.
+   *
+   * <p>Returns a list of property sink statements to guard against dead code elimination.
+   */
+  private List<Node> replaceMethodStringWithReflectedCalls(Node className, Node methodSignature) {
+    checkArgument(methodSignature.isString());
+    List<Node> propertySinkStatements = new ArrayList<>();
+    String methodSignatureString = methodSignature.getString().trim();
+    int openParenIndex = methodSignatureString.indexOf('(');
+    if (methodSignatureString.charAt(methodSignatureString.length() - 1) != ')'
+        || openParenIndex < 1) {
+      compiler.report(JSError.make(methodSignature, PolymerPassErrors.POLYMER_UNPARSABLE_STRING));
+      return propertySinkStatements;
+    }
+
+    // Reflect property calls require an instance of a type. Since we don't have one,
+    // just cast an object literal to be that type. While not generally safe, it is
+    // safe for property reflection.
+    JSDocInfoBuilder classTypeDoc = new JSDocInfoBuilder(false);
+    JSTypeExpression classType =
+        new JSTypeExpression(
+            new Node(Token.BANG, IR.string(className.getQualifiedName())),
+            className.getSourceFileName());
+    classTypeDoc.recordType(classType);
+    Node classTypeExpression = IR.cast(IR.objectlit(), classTypeDoc.build());
+
+    // Add reflect and property sinks for the method name which will be a property on the class
+    String methodName = methodSignatureString.substring(0, openParenIndex).trim();
+    propertySinkStatements.add(
+        IR.exprResult(IR.getprop(className.cloneTree(), "prototype", methodName)));
+
+    Node reflectedMethodName =
+        IR.call(
+            IR.getprop(IR.name("$jscomp"), IR.string("reflectProperty")),
+            IR.string(methodName),
+            classTypeExpression.cloneTree());
+
+    Node reflectedSignature = reflectedMethodName;
+
+    // Process any parameters in the method call
+    Node reflectedParams = null;
+    String nextParamDelimeter = "(";
+    if (openParenIndex < methodSignatureString.length() - 2) {
+      String methodParamsString =
+          methodSignatureString
+              .substring(openParenIndex + 1, methodSignatureString.length() - 1)
+              .trim();
+
+      List<String> methodParams = parseMethodParams(methodParamsString, methodSignature);
+
+      // Add property reflection for each parameter
+      for (String methodParam : methodParams) {
+        Node reflectedTypeReference = classTypeExpression;
+        if (methodParam.length() == 0) {
+          continue;
+        }
+
+        if (isParamLiteral(methodParam)) {
+          Node term = IR.string(methodParam);
+
+          reflectedSignature =
+              IR.add(IR.add(reflectedSignature, IR.string(nextParamDelimeter)), term);
+        } else {
+          // Arguments in conmplex observer or computed property strings are property paths.
+          // We need to rename each path segment.
+          String[] paramParts = methodParam.split("\\.");
+          String nextPropertyTermDelimiter = nextParamDelimeter;
+          for (int i = 0; i < paramParts.length; i++) {
+            // Polymer property paths have two special terms recognized when they are the last
+            // path reference:
+            //   - * - any sub-property change
+            //   - splices - Adds or removes of array items
+            // These terms are not renamable and are left as is
+            if (i > 0
+                && i == paramParts.length - 1
+                && (paramParts[i].equals("*") || paramParts[i].equals("splices"))) {
+              reflectedSignature =
+                  IR.add(reflectedSignature, IR.string(nextPropertyTermDelimiter + paramParts[i]));
+            } else {
+              if (i == 0) {
+                // The root of the parameter will be a property reference on the class
+                // Create both a property sink and a reflection call
+                propertySinkStatements.add(
+                    IR.exprResult(
+                        IR.getprop(
+                            className.cloneTree(),
+                            IR.string("prototype"),
+                            IR.string(paramParts[i]))));
+              }
+              Node reflectedParamPart =
+                  IR.call(
+                      IR.getprop(IR.name("$jscomp"), IR.string("reflectProperty")),
+                      IR.string(paramParts[i]),
+                      reflectedTypeReference.cloneTree());
+              reflectedSignature =
+                  IR.add(
+                      IR.add(reflectedSignature, IR.string(nextPropertyTermDelimiter)),
+                      reflectedParamPart);
+
+              reflectedTypeReference =
+                  IR.getprop(reflectedTypeReference.cloneTree(), paramParts[i]);
+            }
+            nextPropertyTermDelimiter = ".";
+          }
+        }
+        nextParamDelimeter = ",";
+      }
+
+      if (methodParams.size() == 0) {
+        reflectedSignature = IR.add(reflectedSignature, IR.string("()"));
+      } else {
+        reflectedSignature = IR.add(reflectedSignature, IR.string(")"));
+      }
+    } else {
+      reflectedSignature = IR.add(reflectedSignature, IR.string("()"));
+    }
+
+    methodSignature.replaceWith(reflectedSignature.useSourceInfoFromForTree(methodSignature));
+    compiler.reportChangeToEnclosingScope(reflectedSignature);
+    return propertySinkStatements;
+  }
+
+  /**
+   * Parse the parameters string from a complex observer or computed property into distinct
+   * parameters. Since a parameter can be a quoted string literal, we can't just split on commas.
+   */
+  private List<String> parseMethodParams(String methodParameters, Node methodSignature) {
+    List<String> parsedParameters = new ArrayList<>();
+
+    char nextDelimeter = ',';
+    String currentTerm = "";
+    for (int i = 0; i < methodParameters.length(); i++) {
+      if (methodParameters.charAt(i) == nextDelimeter) {
+        if (nextDelimeter == ',') {
+          parsedParameters.add(currentTerm.trim());
+          currentTerm = "";
+        } else {
+          currentTerm += nextDelimeter;
+          nextDelimeter = ',';
+        }
+      } else {
+        currentTerm += methodParameters.charAt(i);
+        if (methodParameters.charAt(i) == '"' || methodParameters.charAt(i) == '\'') {
+          nextDelimeter = methodParameters.charAt(i);
+        }
+      }
+    }
+    if (nextDelimeter != ',') {
+      compiler.report(JSError.make(methodSignature, PolymerPassErrors.POLYMER_UNPARSABLE_STRING));
+      return parsedParameters;
+    }
+    if (currentTerm.length() > 0) {
+      parsedParameters.add(currentTerm.trim());
+    }
+    return parsedParameters;
+  }
+
+  /** Determine if the method parameter a quoted string or numeric literal recognized by Polymer. */
+  private static boolean isParamLiteral(String param) {
+    try {
+      Double.parseDouble(param);
+      return true;
+    } catch (NumberFormatException e) {
+    }
+
+    // Check to see if the parameter is a literal - either a quoted string or
+    // numeric literal
+    if (param.length() > 1
+        && (param.charAt(0) == '"' || param.charAt(0) == '\'')
+        && param.charAt(0) == param.charAt(param.length() - 1)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/src/com/google/javascript/jscomp/PolymerClassRewriter.java
+++ b/src/com/google/javascript/jscomp/PolymerClassRewriter.java
@@ -50,6 +50,7 @@ final class PolymerClassRewriter {
   @VisibleForTesting static final String POLYMER_ELEMENT_PROP_CONFIG = "PolymerElementProperties";
 
   private final Node polymerElementExterns;
+  boolean propertySinkExternInjected = false;
 
   PolymerClassRewriter(
       AbstractCompiler compiler,
@@ -270,8 +271,10 @@ final class PolymerClassRewriter {
       }
 
       if (propertySinks.size() > 0) {
-        if (traversal.getScope().getVar(CheckSideEffects.PROTECTOR_FN) == null) {
+        if (!propertySinkExternInjected
+            && traversal.getScope().getVar(CheckSideEffects.PROTECTOR_FN) == null) {
           CheckSideEffects.addExtern(compiler);
+          propertySinkExternInjected = true;
         }
 
         for (Node propertyRef : propertySinks) {

--- a/src/com/google/javascript/jscomp/PolymerPass.java
+++ b/src/com/google/javascript/jscomp/PolymerPass.java
@@ -164,7 +164,7 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
               polymerVersion,
               polymerExportPolicy,
               this.propertyRenamingEnabled);
-      rewriter.rewritePolymerClassDeclaration(node, def, traversal.inGlobalScope());
+      rewriter.rewritePolymerClassDeclaration(node, traversal, def);
     }
   }
 

--- a/src/com/google/javascript/jscomp/PolymerPass.java
+++ b/src/com/google/javascript/jscomp/PolymerPass.java
@@ -59,6 +59,7 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
   private ImmutableList<Node> polymerElementProps;
   private GlobalNamespace globalNames;
   private boolean warnedPolymer1ExternsMissing = false;
+  private boolean propertySinkExternInjected = false;
 
   PolymerPass(
       AbstractCompiler compiler,
@@ -164,7 +165,9 @@ final class PolymerPass extends AbstractPostOrderCallback implements HotSwapComp
               polymerVersion,
               polymerExportPolicy,
               this.propertyRenamingEnabled);
+      rewriter.propertySinkExternInjected = propertySinkExternInjected;
       rewriter.rewritePolymerClassDeclaration(node, traversal, def);
+      propertySinkExternInjected = rewriter.propertySinkExternInjected;
     }
   }
 

--- a/src/com/google/javascript/jscomp/PolymerPassErrors.java
+++ b/src/com/google/javascript/jscomp/PolymerPassErrors.java
@@ -87,5 +87,10 @@ final class PolymerPassErrors {
           "When a Polymer property is declared in the constructor, its JSDoc "
               + "should only be in the constructor, not on the Polymer properties configuration.");
 
+  static final DiagnosticType POLYMER_UNPARSABLE_STRING =
+      DiagnosticType.error(
+          "JSC_POLYMER_UNPARSABLE_STRING",
+          "The Polymer computed property or complex observer string could not be parsed.");
+
   private PolymerPassErrors() {}
 }

--- a/src/com/google/javascript/jscomp/js/util/reflectobject.js
+++ b/src/com/google/javascript/jscomp/js/util/reflectobject.js
@@ -33,3 +33,19 @@
 $jscomp.reflectObject = function(type, object) {
   return object;
 };
+
+/**
+ * Definition for object property reflection.
+ *
+ * Internal compiler version of closure library goog.reflect.objectProperty.
+ *
+ * Use this if you have a string that needs renamed as if it were an unquoted
+ * property of a class.
+ *
+ * @param {string} propName
+ * @param {?Object} type class, interface, or record
+ * @return {string}
+ */
+$jscomp.reflectProperty = function(propName, type) {
+  return propName;
+};

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -3949,6 +3949,12 @@ public class PolymerPassTest extends CompilerTestCase {
             "  _computePets() {}",
             "  _computeName(user, thingToDo) {}",
             "}",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._computePets;",
+            "  XElement.prototype._computeName;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.thingToDo;",
+            "})();",
             "/** @type {!User} @private */",
             "XElement.prototype.user_;",
             "/** @type {!Array} */",
@@ -3956,13 +3962,7 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @type {string} */",
             "XElement.prototype.name;",
             "/** @type {!Function} */",
-            "XElement.prototype.thingToDo;",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._computePets;",
-            "  XElement.prototype._computeName;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.thingToDo;",
-            "})()"));
+            "XElement.prototype.thingToDo;"));
   }
 
   @Test
@@ -4023,6 +4023,11 @@ public class PolymerPassTest extends CompilerTestCase {
             "  _computePets() {}",
             "  _computeName(user, thingToDo) {}",
             "}",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._computeName;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.user_;",
+            "})();",
             "/** @type {!User} @private */",
             "XElement.prototype.user_;",
             "/** @type {!Array} */",
@@ -4030,12 +4035,7 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @type {string} */",
             "XElement.prototype.name;",
             "/** @type {!Function} */",
-            "XElement.prototype.thingToDo;",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._computeName;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.user_;",
-            "})()"));
+            "XElement.prototype.thingToDo;"));
   }
 
   @Test
@@ -4164,6 +4164,13 @@ public class PolymerPassTest extends CompilerTestCase {
             "  _userChanged(user_) {}",
             "  _userOrThingToDoChanged(user, thingToDo) {}",
             "}",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._userChanged;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype._userOrThingToDoChanged;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.thingToDo;",
+            "})();",
             "/** @type {!User} @private */",
             "XElement.prototype.user_;",
             "/** @type {!Array} */",
@@ -4171,14 +4178,7 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @type {string} */",
             "XElement.prototype.name;",
             "/** @type {!Function} */",
-            "XElement.prototype.thingToDo;",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._userChanged;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype._userOrThingToDoChanged;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.thingToDo;",
-            "})()"));
+            "XElement.prototype.thingToDo;"));
   }
 
   @Override

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -3949,12 +3949,6 @@ public class PolymerPassTest extends CompilerTestCase {
             "  _computePets() {}",
             "  _computeName(user, thingToDo) {}",
             "}",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._computePets;",
-            "  XElement.prototype._computeName;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.thingToDo;",
-            "})();",
             "/** @type {!User} @private */",
             "XElement.prototype.user_;",
             "/** @type {!Array} */",
@@ -3962,7 +3956,13 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @type {string} */",
             "XElement.prototype.name;",
             "/** @type {!Function} */",
-            "XElement.prototype.thingToDo;"));
+            "XElement.prototype.thingToDo;",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._computePets;",
+            "  XElement.prototype._computeName;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.thingToDo;",
+            "})();"));
   }
 
   @Test
@@ -4023,11 +4023,6 @@ public class PolymerPassTest extends CompilerTestCase {
             "  _computePets() {}",
             "  _computeName(user, thingToDo) {}",
             "}",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._computeName;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.user_;",
-            "})();",
             "/** @type {!User} @private */",
             "XElement.prototype.user_;",
             "/** @type {!Array} */",
@@ -4035,7 +4030,12 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @type {string} */",
             "XElement.prototype.name;",
             "/** @type {!Function} */",
-            "XElement.prototype.thingToDo;"));
+            "XElement.prototype.thingToDo;",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._computeName;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.user_;",
+            "})();"));
   }
 
   @Test
@@ -4164,13 +4164,6 @@ public class PolymerPassTest extends CompilerTestCase {
             "  _userChanged(user_) {}",
             "  _userOrThingToDoChanged(user, thingToDo) {}",
             "}",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._userChanged;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype._userOrThingToDoChanged;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.thingToDo;",
-            "})();",
             "/** @type {!User} @private */",
             "XElement.prototype.user_;",
             "/** @type {!Array} */",
@@ -4178,7 +4171,14 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @type {string} */",
             "XElement.prototype.name;",
             "/** @type {!Function} */",
-            "XElement.prototype.thingToDo;"));
+            "XElement.prototype.thingToDo;",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._userChanged;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype._userOrThingToDoChanged;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.thingToDo;",
+            "})();"));
   }
 
   @Override

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -3957,12 +3957,10 @@ public class PolymerPassTest extends CompilerTestCase {
             "XElement.prototype.name;",
             "/** @type {!Function} */",
             "XElement.prototype.thingToDo;",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._computePets;",
-            "  XElement.prototype._computeName;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.thingToDo;",
-            "})();"));
+            "JSCOMPILER_PRESERVE(XElement.prototype._computePets);",
+            "JSCOMPILER_PRESERVE(XElement.prototype._computeName);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.user_);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.thingToDo);"));
   }
 
   @Test
@@ -4031,11 +4029,9 @@ public class PolymerPassTest extends CompilerTestCase {
             "XElement.prototype.name;",
             "/** @type {!Function} */",
             "XElement.prototype.thingToDo;",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._computeName;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.user_;",
-            "})();"));
+            "JSCOMPILER_PRESERVE(XElement.prototype._computeName);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.user_);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.user_);"));
   }
 
   @Test
@@ -4172,13 +4168,11 @@ public class PolymerPassTest extends CompilerTestCase {
             "XElement.prototype.name;",
             "/** @type {!Function} */",
             "XElement.prototype.thingToDo;",
-            "(/** @suppress {uselessCode} */ function() {",
-            "  XElement.prototype._userChanged;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype._userOrThingToDoChanged;",
-            "  XElement.prototype.user_;",
-            "  XElement.prototype.thingToDo;",
-            "})();"));
+            "JSCOMPILER_PRESERVE(XElement.prototype._userChanged);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.user_);",
+            "JSCOMPILER_PRESERVE(XElement.prototype._userOrThingToDoChanged);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.user_);",
+            "JSCOMPILER_PRESERVE(XElement.prototype.thingToDo);"));
   }
 
   @Override

--- a/test/com/google/javascript/jscomp/PolymerPassTest.java
+++ b/test/com/google/javascript/jscomp/PolymerPassTest.java
@@ -119,7 +119,15 @@ public class PolymerPassTest extends CompilerTestCase {
           " * @return {T}",
           " * @template T",
           " */",
-          "$jscomp.reflectObject = function (type, object) { return object; };");
+          "$jscomp.reflectObject = function (type, object) { return object; };",
+          "/**",
+          " * @param {string} propName",
+          " * @param {?Object} type class, interface, or record",
+          " * @return {string}",
+          " */",
+          "$jscomp.reflectProperty = function(propName, type) {",
+          "  return propName;",
+          "};");
 
   private int polymerVersion = 1;
   private PolymerExportPolicy polymerExportPolicy = PolymerExportPolicy.LEGACY;
@@ -3679,6 +3687,498 @@ public class PolymerPassTest extends CompilerTestCase {
             "/** @private @export */ TestElementElement.prototype.onBehavior2;",
             "/** @public @export */ TestElementElement.prototype.onBehavior1;",
             "/** @private @export */ TestElementElement.prototype.onAll;"));
+  }
+
+  @Test
+  public void testSimpleObserverStringsConvertedToReferences1() {
+    propertyRenamingEnabled = true;
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        observer: '_petsChanged'",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        observer: '_nameChanged'",
+            "      },",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  _petsChanged(newValue, oldValue) {}",
+            "  _nameChanged(newValue, oldValue) {}",
+            "}"),
+        lines(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(XElement, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        observer: XElement.prototype._petsChanged",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        observer: XElement.prototype._nameChanged",
+            "      },",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "  _petsChanged(newValue, oldValue) {}",
+            "  _nameChanged(newValue, oldValue) {}",
+            "}",
+            "/** @type {!User} @private */",
+            "XElement.prototype.user_;",
+            "/** @type {!Array} */",
+            "XElement.prototype.pets;",
+            "/** @type {string} */",
+            "XElement.prototype.name;",
+            "/** @type {!Function} */",
+            "XElement.prototype.thingToDo;"));
+  }
+
+  @Test
+  public void testSimpleObserverStringsConvertedToReferences2() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        observer: '_petsChanged'",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        observer: '_nameChanged'",
+            "      },",
+            "      thingToDo: Function",
+            "    };",
+            "  }",
+            "  _petsChanged(newValue, oldValue) {}",
+            "  _nameChanged(newValue, oldValue) {}",
+            "};"),
+        lines(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "var a = {};",
+            "a.B = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return  $jscomp.reflectObject(a.B, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        observer: a.B.prototype._petsChanged",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        observer: a.B.prototype._nameChanged",
+            "      },",
+            "      thingToDo: Function",
+            "    });",
+            "  }",
+            "  _petsChanged(newValue, oldValue) {}",
+            "  _nameChanged(newValue, oldValue) {}",
+            "};",
+            "/** @type {!User} @private */",
+            "a.B.prototype.user_;",
+            "/** @type {!Array} */",
+            "a.B.prototype.pets;",
+            "/** @type {string} */",
+            "a.B.prototype.name;",
+            "/** @type {!Function} */",
+            "a.B.prototype.thingToDo;"));
+  }
+
+  @Test
+  public void testSimpleObserverStringsConvertedToReferences3() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "const A = class extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        observer: '_petsChanged'",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        observer: '_nameChanged'",
+            "      },",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  _petsChanged(newValue, oldValue) {}",
+            "  _nameChanged(newValue, oldValue) {}",
+            "};"),
+        lines(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "const A = class extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(A, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        observer: A.prototype._petsChanged",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        observer: A.prototype._nameChanged",
+            "      },",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "  _petsChanged(newValue, oldValue) {}",
+            "  _nameChanged(newValue, oldValue) {}",
+            "};",
+            "/** @type {!User} @private */",
+            "A.prototype.user_;",
+            "/** @type {!Array} */",
+            "A.prototype.pets;",
+            "/** @type {string} */",
+            "A.prototype.name;",
+            "/** @type {!Function} */",
+            "A.prototype.thingToDo;"));
+  }
+
+  @Test
+  public void testReflectionForComputedPropertyStrings1() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        computed: '_computePets()'",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        computed: '_computeName(user_, thingToDo)'",
+            "      },",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  _computePets() {}",
+            "  _computeName(user, thingToDo) {}",
+            "}"),
+        lines(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(XElement, {",
+            "      user_: Object,",
+            "      pets: {",
+            "        type: Array,",
+            "        computed: $jscomp.reflectProperty(",
+            "            '_computePets', /** @type {!XElement} */ ({})) + '()'",
+            "      },",
+            "      name: {",
+            "        type: String,",
+            "        computed: $jscomp.reflectProperty(",
+            "            '_computeName', /** @type {!XElement} */ ({})) + '(' +",
+            "            $jscomp.reflectProperty('user_', /** @type {!XElement} */ ({})) + ',' + ",
+            "            $jscomp.reflectProperty('thingToDo', /** @type {!XElement} */ ({})) + ",
+            "            ')'",
+            "      },",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "  _computePets() {}",
+            "  _computeName(user, thingToDo) {}",
+            "}",
+            "/** @type {!User} @private */",
+            "XElement.prototype.user_;",
+            "/** @type {!Array} */",
+            "XElement.prototype.pets;",
+            "/** @type {string} */",
+            "XElement.prototype.name;",
+            "/** @type {!Function} */",
+            "XElement.prototype.thingToDo;",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._computePets;",
+            "  XElement.prototype._computeName;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.thingToDo;",
+            "})()"));
+  }
+
+  @Test
+  public void testReflectionForComputedPropertyStrings2() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @type {string} */ User.prototype.id;",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: Array,",
+            "      name: {",
+            "        type: String,",
+            "        computed: '_computeName(\"user\", 12.0, user_.id, user_.*)'",
+            "      },",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  _computePets() {}",
+            "  _computeName(user, thingToDo) {}",
+            "}"),
+        lines(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @type {string} */ User.prototype.id;",
+            "class XElement extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(XElement, {",
+            "      user_: Object,",
+            "      pets: Array,",
+            "      name: {",
+            "        type: String,",
+            "        computed: $jscomp.reflectProperty(",
+            "            '_computeName', /** @type {!XElement} */ ({})) + '(' +",
+            "            '\"user\"' + ',' + '12.0' + ',' + ",
+            "            $jscomp.reflectProperty('user_', /** @type {!XElement} */ ({})) + '.' + ",
+            "            $jscomp.reflectProperty('id', /** @type {!XElement} */ ({}).user_) + ',' + ",
+            "            $jscomp.reflectProperty('user_', /** @type {!XElement} */ ({})) + ",
+            "            '.*' + ')'",
+            "      },",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "  _computePets() {}",
+            "  _computeName(user, thingToDo) {}",
+            "}",
+            "/** @type {!User} @private */",
+            "XElement.prototype.user_;",
+            "/** @type {!Array} */",
+            "XElement.prototype.pets;",
+            "/** @type {string} */",
+            "XElement.prototype.name;",
+            "/** @type {!Function} */",
+            "XElement.prototype.thingToDo;",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._computeName;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.user_;",
+            "})()"));
+  }
+
+  @Test
+  public void testParseErrorForComputedPropertyStrings1() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    polymerVersion = 2;
+    super.testError(
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @type {string} */ User.prototype.id;",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: Array,",
+            "      name: {",
+            "        type: String,",
+            "        computed: '_computeName(\"user\", 12.0, user_.id'",
+            "      },",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  _computePets() {}",
+            "  _computeName(user, thingToDo) {}",
+            "}"),
+        PolymerPassErrors.POLYMER_UNPARSABLE_STRING);
+  }
+
+  @Test
+  public void testParseErrorForComputedPropertyStrings2() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    polymerVersion = 2;
+    super.testError(
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "/** @type {string} */ User.prototype.id;",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: Array,",
+            "      name: {",
+            "        type: String,",
+            "        computed: '_computeName(\"user)'",
+            "      },",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  _computePets() {}",
+            "  _computeName(user, thingToDo) {}",
+            "}"),
+        PolymerPassErrors.POLYMER_UNPARSABLE_STRING);
+  }
+
+  @Test
+  public void testReflectionForComplexObservers() {
+    propertyRenamingEnabled = true;
+
+    // Type checker doesn't currently understand ES6 code. Remove when it does.
+    disableTypeCheck();
+    test(
+        2,
+        lines(
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  static get is() { return 'x-element'; }",
+            "  static get properties() {",
+            "    return {",
+            "      /** @type {!User} @private */",
+            "      user_: Object,",
+            "      pets: Array,",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    };",
+            "  }",
+            "  static get observers() {",
+            "    return [",
+            "      '_userChanged(user_)',",
+            "      '_userOrThingToDoChanged(user_, thingToDo)'",
+            "    ];",
+            "  }",
+            "  _userChanged(user_) {}",
+            "  _userOrThingToDoChanged(user, thingToDo) {}",
+            "}"),
+        lines(
+            REFLECT_OBJECT_DEF,
+            "/** @constructor */",
+            "var User = function() {};",
+            "class XElement extends Polymer.Element {",
+            "  /** @return {string} */",
+            "  static get is() { return 'x-element'; }",
+            "  /** @return {" + POLYMER_ELEMENT_PROP_CONFIG + "} */",
+            "  static get properties() {",
+            "    return $jscomp.reflectObject(XElement, {",
+            "      user_: Object,",
+            "      pets: Array,",
+            "      name: String,",
+            "      thingToDo: Function,",
+            "    });",
+            "  }",
+            "  /** @return {!Array<string>} */",
+            "  static get observers() {",
+            "    return [",
+            "      $jscomp.reflectProperty('_userChanged', /** @type {!XElement} */ ({})) + '(' +",
+            "          $jscomp.reflectProperty('user_', /** @type {!XElement} */ ({})) + ')',",
+            "      $jscomp.reflectProperty(",
+            "          '_userOrThingToDoChanged', /** @type {!XElement} */ ({})) + '(' +",
+            "          $jscomp.reflectProperty('user_', /** @type {!XElement} */ ({})) + ',' + ",
+            "          $jscomp.reflectProperty('thingToDo', /** @type {!XElement} */ ({})) + ",
+            "          ')'",
+            "    ];",
+            "  }",
+            "  _userChanged(user_) {}",
+            "  _userOrThingToDoChanged(user, thingToDo) {}",
+            "}",
+            "/** @type {!User} @private */",
+            "XElement.prototype.user_;",
+            "/** @type {!Array} */",
+            "XElement.prototype.pets;",
+            "/** @type {string} */",
+            "XElement.prototype.name;",
+            "/** @type {!Function} */",
+            "XElement.prototype.thingToDo;",
+            "(/** @suppress {uselessCode} */ function() {",
+            "  XElement.prototype._userChanged;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype._userOrThingToDoChanged;",
+            "  XElement.prototype.user_;",
+            "  XElement.prototype.thingToDo;",
+            "})()"));
   }
 
   @Override


### PR DESCRIPTION
Polymer observers and computed properties use string reflection. When property renaming is enabled, add property reflection calls to these strings such that they are renamed consistently.

Example:

```js
class FooElement extends Polymer.Element {
  static get properties() {
    return {
      foo: {
        type: String,
        compute: '_computeFoo(bar)'
      },
      bar: {
        type: String,
        value: 'bar'
      }
    };
  }
  _computeFoo(bar) {
    return 'foo' + bar;
   }
}
```

The `'_computeFoo(bar)'` string will now be parsed and reflection calls added like:

```js
JSCompiler_renameProperty('_computeFoo', /** @type {!FooElement} */ ({})) + '(' +
    JSCompiler_renameProperty('bar', /** @type {!FooElement} */ ({})) + ')'
```