### PR TITLE
SourceFileTest.testSourceFileResolvesZipEntries failes for Windows #3206

### DIFF
--- a/src/com/google/javascript/jscomp/SourceFile.java
+++ b/src/com/google/javascript/jscomp/SourceFile.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -358,13 +359,13 @@ public class SourceFile implements StaticSourceFile, Serializable {
   private static final String JAR_URL_PREFIX = "jar:file:";
 
   private static boolean isZipEntry(String path) {
-    return path.contains(".zip!/") && (path.endsWith(".js") || path.endsWith(".js.map"));
+    return path.contains(".zip!" + File.separator) && (path.endsWith(".js") || path.endsWith(".js.map"));
   }
 
   @GwtIncompatible("java.io.File")
   private static SourceFile fromZipEntry(String zipURL, Charset inputCharset) {
     checkArgument(isZipEntry(zipURL));
-    String[] components = zipURL.split(BANG_SLASH);
+    String[] components = zipURL.split(Pattern.quote(BANG_SLASH.replace("/",  File.separator)));
     try {
       String zipPath = components[0];
       String relativePath = components[1];
@@ -378,7 +379,7 @@ public class SourceFile implements StaticSourceFile, Serializable {
   public static SourceFile fromZipEntry(
       String originalZipPath, String absoluteZipPath, String entryPath, Charset inputCharset)
       throws MalformedURLException {
-    String zipEntryPath = JAR_URL_PREFIX + absoluteZipPath + BANG_SLASH + entryPath;
+    String zipEntryPath = JAR_URL_PREFIX + absoluteZipPath + BANG_SLASH + entryPath.replace(File.separator,  "/");
     URL zipEntryUrl = new URL(zipEntryPath);
 
     return builder()


### PR DESCRIPTION
And fixes parts of "Support the workflow under Windows. #9" (https://github.com/google/j2cl/issues/9) from j2cl