### PR TITLE
Add missing extern, chrome.bluetoothPrivate.connect

### DIFF
--- a/contrib/externs/chrome_extensions.js
+++ b/contrib/externs/chrome_extensions.js
@@ -10518,6 +10518,16 @@ chrome.bluetoothPrivate.TransportType = {
 
 
 /**
+ * Connects to the given device. This will only throw an error if the device
+ * address is invalid or the device is already connected. Otherwise this will
+ * succeed and invoke |callback| with ConnectResultType.
+ * @param {string} deviceAddress
+ * @param {function(!chrome.bluetoothPrivate.ConnectResultType):void=} callback
+ */
+chrome.bluetoothPrivate.connect = function(deviceAddress, callback) {};
+
+
+/**
  * @const
  * @see http://goo.gl/XmVdHm
  */


### PR DESCRIPTION
The chrome.bluetoothPrivate api has diverged from this extern definition (committed in 2014).

This proposes its removal for the following reasons:
1. the extern is wrong and incomplete
2. chrome.bluetoothPrivate is indeed private
3. extensions wishing to use it should be part of chrome's main repopsitory and utilize the externs generated there which are kept up-to-date