### PR TITLE
Fix contentEditable definition

### DIFF
--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -1025,7 +1025,7 @@ Element.prototype.componentFromPoint = function(iCoordX, iCoordY) {};
 
 
 /**
- * @type {string}
+ * @type {string|boolean}
  * @see http://msdn.microsoft.com/en-us/library/ms533690(VS.85).aspx
  */
 Element.prototype.contentEditable;

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -1025,7 +1025,7 @@ Element.prototype.componentFromPoint = function(iCoordX, iCoordY) {};
 
 
 /**
- * @type {boolean}
+ * @type {string}
  * @see http://msdn.microsoft.com/en-us/library/ms533690(VS.85).aspx
  */
 Element.prototype.contentEditable;
@@ -1073,6 +1073,7 @@ Element.prototype.hideFocus;
 Element.prototype.innerText;
 
 /**
+ * @type {boolean}
  * @see http://msdn.microsoft.com/en-us/library/ms537838(VS.85).aspx
  */
 Element.prototype.isContentEditable;


### PR DESCRIPTION
It has always been a string and not a boolean, and is being extended with new values in a W3C proposal, which now fail the check.

isContentEditable, on the other hand, is a boolean but was defined without a type.