### PR TITLE
Prevent NPE when original source content is missing

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
@@ -508,7 +508,8 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
       if (i != 0) {
         out.append(",");
       }
-      out.append(escapeString(contents.get(i)));
+      String sourceContent = contents.get(i);
+      out.append(escapeString(sourceContent == null ? "" : sourceContent));
     }
     out.append("]");
     appendFieldEnd(out);


### PR DESCRIPTION
A null pointer exception was triggered when including original source content in the source map and the original source content was missing from the map. Simply add a guard for this case.

Closes #3234