### PR TITLE
Use the PropertyCollapseLevel to guard for adding passes

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -616,7 +616,11 @@ public class CompilerOptions implements Serializable {
 
   private PropertyCollapseLevel collapsePropertiesLevel;
 
-  /** Flattens multi-level property names (e.g. a$b = x) */
+  /**
+   * Flattens multi-level property names (e.g. a$b = x)
+   *
+   * @deprecated use getPropertyCollapseLevel
+   */
   public boolean shouldCollapseProperties() {
     return collapsePropertiesLevel != PropertyCollapseLevel.NONE;
   }

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.AbstractCompiler.LifeCycleStage;
 import com.google.javascript.jscomp.CompilerOptions.ExtractPrototypeMemberDeclarationsMode;
+import com.google.javascript.jscomp.CompilerOptions.PropertyCollapseLevel;
 import com.google.javascript.jscomp.CompilerOptions.Reach;
 import com.google.javascript.jscomp.CoverageInstrumentationPass.CoverageReach;
 import com.google.javascript.jscomp.CoverageInstrumentationPass.InstrumentOption;
@@ -576,20 +577,21 @@ public final class DefaultPassConfig extends PassConfig {
     assertAllOneTimePasses(passes);
 
     // Inline aliases so that following optimizations don't have to understand alias chains.
-    if (options.shouldCollapseProperties()) {
+    if (options.getPropertyCollapseLevel() == PropertyCollapseLevel.ALL) {
       passes.add(aggressiveInlineAliases);
     }
 
     // Inline getters/setters in J2CL classes so that Object.defineProperties() calls (resulting
     // from desugaring) don't block class stripping.
-    if (options.j2clPassMode.shouldAddJ2clPasses() && options.shouldCollapseProperties()) {
+    if (options.j2clPassMode.shouldAddJ2clPasses()
+        && options.getPropertyCollapseLevel() == PropertyCollapseLevel.ALL) {
       // Relies on collapseProperties-triggered aggressive alias inlining.
       passes.add(j2clPropertyInlinerPass);
     }
 
     // Collapsing properties can undo constant inlining, so we do this before
     // the main optimization loop.
-    if (options.shouldCollapseProperties()) {
+    if (options.getPropertyCollapseLevel() != PropertyCollapseLevel.NONE) {
       passes.add(collapseProperties);
     }
 


### PR DESCRIPTION
Prevents a module collapse level from adding passes which are only safe when all properties can be potentially collapsed.

Mark the `shouldCollapse` helper method as deprecated to prevent further use.