### PR TITLE
Fix the constructor so that it can accept an array of strings

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2919,7 +2919,7 @@ TimeRanges.prototype.end = function(index) { return 0; };
  * @see http://dev.w3.org/html5/websockets/
  * @constructor
  * @param {string} url
- * @param {string=} opt_protocol
+ * @param {(string|!Array<string>)=} opt_protocol
  * @implements {EventTarget}
  */
 function WebSocket(url, opt_protocol) {}


### PR DESCRIPTION
This is needed to align with the spec/WebIDL.

See

https://www.w3.org/TR/websockets/#handler-websocket-onmessage