### PR TITLE
Make it possible to pass a Blob to webSocket.send()

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2997,7 +2997,7 @@ WebSocket.prototype.onclose;
 
 /**
  * Transmits data using the connection.
- * @param {string|ArrayBuffer|ArrayBufferView} data
+ * @param {string|ArrayBuffer|ArrayBufferView|Blob} data
  * @return {boolean}
  */
 WebSocket.prototype.send = function(data) {};


### PR DESCRIPTION
This is required to support scenario where websocket.binaryType = 'blob'