### PR TITLE
Align the API with the standardized WebIDL

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2998,7 +2998,7 @@ WebSocket.prototype.onclose;
 /**
  * Transmits data using the connection.
  * @param {string|ArrayBuffer|ArrayBufferView} data
- * @return {boolean}
+ * @return {void}
  */
 WebSocket.prototype.send = function(data) {};
 


### PR DESCRIPTION
Historically some browsers (i.e. Gecko) returned a boolean from the
send method to indicate whether the message was successfully
buffered and/or sent. The modern specification specifies a void
return type [1] which is how it is implemented in modern browsers.

[1] https://html.spec.whatwg.org/multipage/web-sockets.html#the-websocket-interface