### PR TITLE
Add `name` and `message` to DOMException

### DIFF
--- a/externs/browser/w3c_dom4.js
+++ b/externs/browser/w3c_dom4.js
@@ -55,6 +55,20 @@ CharacterData.prototype.remove = function() {};
 DocumentType.prototype.replaceWith = function(nodes) {};
 
 /**
+ * @type {string}
+ * @const
+ * @see https://www.w3.org/TR/2015/REC-dom-20151119/#sec-domerror
+ */
+DOMException.prototype.name;
+
+/**
+ * @type {string}
+ * @const
+ * @see https://www.w3.org/TR/2015/REC-dom-20151119/#sec-domerror
+ */
+DOMException.prototype.message;
+
+/**
  * @type {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */


### PR DESCRIPTION
Follow up to https://github.com/google/closure-compiler/issues/3266