### PR TITLE
Migrate the standardized Console to a separate top-level extern

### DIFF
--- a/externs/browser/webkit_dom.js
+++ b/externs/browser/webkit_dom.js
@@ -94,86 +94,6 @@ ScriptProfile.prototype.uid;
 ScriptProfile.prototype.head;
 
 /**
- * @constructor
- * @see https://console.spec.whatwg.org/
- */
-function Console() {};
-
-/**
- * @param {*} condition
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.assert = function(condition, var_args) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.error = function(var_args) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.info = function(var_args) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.log = function(var_args) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.warn = function(var_args) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.debug = function(var_args) {};
-
-/**
- * @param {*} value
- * @return {undefined}
- */
-Console.prototype.dir = function(value) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.dirxml = function(var_args) {};
-
-/**
- * @param {!Object} data
- * @param {*=} opt_columns
- * @return {undefined}
- */
-Console.prototype.table = function(data, opt_columns) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.trace = function(var_args) {};
-
-/**
- * @param {string=} label
- * @return {undefined}
- */
-Console.prototype.count = function(label) {};
-
-/**
- * @param {string=} label
- * @return {undefined}
- */
-Console.prototype.countReset = function(label) {};
-
-/**
  * @param {*} value
  * @return {undefined}
  */
@@ -195,63 +115,16 @@ Console.prototype.profiles;
 Console.prototype.profileEnd = function(opt_title) {};
 
 /**
- * @param {string} name
- * @return {undefined}
- */
-Console.prototype.time = function(name) {};
-
-/**
- * @param {string} label
- * @param {...*} data
- * @return {undefined}
- */
-Console.prototype.timeLog = function(label, data) {};
-
-/**
- * @param {string} name
- * @return {undefined}
- */
-Console.prototype.timeEnd = function(name) {};
-
-/**
  * @param {*} value
  * @return {undefined}
  */
 Console.prototype.timeStamp = function(value) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.group = function(var_args) {};
-
-/**
- * @param {...*} var_args
- * @return {undefined}
- */
-Console.prototype.groupCollapsed = function(var_args) {};
-
-/**
- * @return {undefined}
- */
-Console.prototype.groupEnd = function() {};
-
-/**
- * @return {undefined}
- */
-Console.prototype.clear = function() {};
 
 /** @type {MemoryInfo} */
 Console.prototype.memory;
 
 /** @type {!Console} */
 Window.prototype.console;
-
-/**
- * @type {!Console}
- * @suppress {duplicate}
- */
-var console;
 
 /**
  * @type {number}

--- a/externs/browser/whatwg_console.js
+++ b/externs/browser/whatwg_console.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for console debugging facilities.
+ * See the specification at https://console.spec.whatwg.org/.
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @see https://console.spec.whatwg.org/
+ */
+function Console() {};
+
+/**
+ * If condition is false, perform Logger("error", data).
+ * @param {*} condition
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.assert = function(condition, var_data) {};
+
+/**
+ * @return {undefined}
+ */
+Console.prototype.clear = function() {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.debug = function(var_data) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.error = function(var_data) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.info = function(var_data) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.log = function(var_data) {};
+
+/**
+ * @param {!Object} tabularData
+ * @param {*=} opt_properties
+ * @return {undefined}
+ */
+Console.prototype.table = function(tabularData, opt_properties) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.trace = function(var_data) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.warn = function(var_data) {};
+
+/**
+ * @param {*} item
+ * @return {undefined}
+ */
+Console.prototype.dir = function(item) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.dirxml = function(var_data) {};
+
+/**
+ * @param {string=} label
+ * @return {undefined}
+ */
+Console.prototype.count = function(label) {};
+
+/**
+ * @param {string=} label
+ * @return {undefined}
+ */
+Console.prototype.countReset = function(label) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.group = function(var_data) {};
+
+/**
+ * @param {...*} var_data
+ * @return {undefined}
+ */
+Console.prototype.groupCollapsed = function(var_data) {};
+
+/**
+ * @return {undefined}
+ */
+Console.prototype.groupEnd = function() {};
+
+/**
+ * @param {string} label
+ * @return {undefined}
+ */
+Console.prototype.time = function(label) {};
+
+/**
+ * @param {string} label
+ * @param {...*} data
+ * @return {undefined}
+ */
+Console.prototype.timeLog = function(label, data) {};
+
+/**
+ * @param {string} label
+ * @return {undefined}
+ */
+Console.prototype.timeEnd = function(label) {};
+
+/**
+ * @type {!Console}
+ * @suppress {duplicate}
+ */
+var console;

--- a/src/com/google/javascript/jscomp/DefaultExterns.java
+++ b/src/com/google/javascript/jscomp/DefaultExterns.java
@@ -50,6 +50,7 @@ public final class DefaultExterns {
           "w3c_dom4.js",
           "gecko_dom.js",
           "ie_dom.js",
+          "whatwg_console.js",
           "webkit_dom.js",
           "w3c_css.js",
           "gecko_css.js",


### PR DESCRIPTION
The purpose is to allow projects that only want to support the standardized part of the API to pull in that single extern. Currently google/elemental2 has copy pasted the relevant section into the downstream project. Non-standardized aspects will continue to be present in `webkit_dom.js`. This patch also renames some parameter names to align with the names in the spec and orders the declarations as they appear in the spec.
