### PR TITLE
Specify the return type of some console functions.

### DIFF
--- a/externs/browser/webkit_dom.js
+++ b/externs/browser/webkit_dom.js
@@ -218,8 +218,14 @@ Console.prototype.group = function(var_args) {};
  */
 Console.prototype.groupCollapsed = function(var_args) {};
 
+/**
+ * @return {undefined}
+ */
 Console.prototype.groupEnd = function() {};
 
+/**
+ * @return {undefined}
+ */
 Console.prototype.clear = function() {};
 
 /** @type {MemoryInfo} */


### PR DESCRIPTION
This aligns the types with the whatwg spec and with contrib/nodejs/globals.js