### PR TITLE
Move extern Node.prototype.parentElement to w3c externs

### DIFF
--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -217,12 +217,6 @@ Node.prototype.nodeTypeString;
 Node.prototype.parsed;
 
 /**
- * @type {Element}
- * @see http://msdn.microsoft.com/en-us/library/ms534327(VS.85).aspx
- */
-Node.prototype.parentElement;
-
-/**
  * @type {boolean}
  * @see http://msdn.microsoft.com/en-us/library/ms753816(VS.85).aspx
  */

--- a/externs/browser/w3c_dom4.js
+++ b/externs/browser/w3c_dom4.js
@@ -214,3 +214,9 @@ CharacterData.prototype.after = function(nodes) {};
  * @see https://dom.spec.whatwg.org/#dom-element-toggleattribute
  */
 Element.prototype.toggleAttribute = function(name, force) {};
+
+/**
+ * @type {Element}
+ * @see http://msdn.microsoft.com/en-us/library/ms534327(VS.85).aspx
+ */
+Node.prototype.parentElement;


### PR DESCRIPTION
It is defined as part of DOM Level 4 so should be in that extern.
See https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement

This also makes it available to downstream consumers such as elemental2