### PR TITLE
Explicitly mark const values

### DIFF
--- a/externs/browser/fileapi.js
+++ b/externs/browser/fileapi.js
@@ -373,110 +373,110 @@ function FileError() {}
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-NOT_FOUND_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.NOT_FOUND_ERR = 1;
 
-/** @type {number} */
+/** @const {number} */
 FileError.NOT_FOUND_ERR = 1;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-SECURITY_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.SECURITY_ERR = 2;
 
-/** @type {number} */
+/** @const {number} */
 FileError.SECURITY_ERR = 2;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-ABORT_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.ABORT_ERR = 3;
 
-/** @type {number} */
+/** @const {number} */
 FileError.ABORT_ERR = 3;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-NOT_READABLE_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.NOT_READABLE_ERR = 4;
 
-/** @type {number} */
+/** @const {number} */
 FileError.NOT_READABLE_ERR = 4;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-ENCODING_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.ENCODING_ERR = 5;
 
-/** @type {number} */
+/** @const {number} */
 FileError.ENCODING_ERR = 5;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileError-NO_MODIFICATION_ALLOWED_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.NO_MODIFICATION_ALLOWED_ERR = 6;
 
-/** @type {number} */
+/** @const {number} */
 FileError.NO_MODIFICATION_ALLOWED_ERR = 6;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-INVALID_STATE_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.INVALID_STATE_ERR = 7;
 
-/** @type {number} */
+/** @const {number} */
 FileError.INVALID_STATE_ERR = 7;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-SYNTAX_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.SYNTAX_ERR = 8;
 
-/** @type {number} */
+/** @const {number} */
 FileError.SYNTAX_ERR = 8;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileError-INVALID_MODIFICATION_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.INVALID_MODIFICATION_ERR = 9;
 
-/** @type {number} */
+/** @const {number} */
 FileError.INVALID_MODIFICATION_ERR = 9;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileError-QUOTA_EXCEEDED_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.QUOTA_EXCEEDED_ERR = 10;
 
-/** @type {number} */
+/** @const {number} */
 FileError.QUOTA_EXCEEDED_ERR = 10;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileException-TYPE_MISMATCH_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.TYPE_MISMATCH_ERR = 11;
 
-/** @type {number} */
+/** @const {number} */
 FileError.TYPE_MISMATCH_ERR = 11;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileException-PATH_EXISTS_ERR
- * @type {number}
+ * @const {number}
  */
 FileError.prototype.PATH_EXISTS_ERR = 12;
 
-/** @type {number} */
+/** @const {number} */
 FileError.PATH_EXISTS_ERR = 12;
 
 /**
@@ -635,19 +635,19 @@ FileSaver.prototype.abort = function() {};
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-INIT
- * @type {number}
+ * @const {number}
  */
 FileSaver.prototype.INIT = 0;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-WRITING
- * @type {number}
+ * @const {number}
  */
 FileSaver.prototype.WRITING = 1;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-DONE
- * @type {number}
+ * @const {number}
  */
 FileSaver.prototype.DONE = 2;
 
@@ -785,13 +785,13 @@ Metadata.prototype.size;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-TEMPORARY
- * @type {number}
+ * @const {number}
 */
 Window.prototype.TEMPORARY = 0;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-PERSISTENT
- * @type {number}
+ * @const {number}
 */
 Window.prototype.PERSISTENT = 1;
 
@@ -944,13 +944,13 @@ function StorageInfo() {}
 
 /**
  * @see https://developers.google.com/chrome/whitepapers/storage
- * @type {number}
+ * @const {number}
  * */
 StorageInfo.prototype.TEMPORARY = 0;
 
 /**
  * @see https://developers.google.com/chrome/whitepapers/storage
- * @type {number}
+ * @const {number}
  */
 StorageInfo.prototype.PERSISTENT = 1;
 

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -1167,38 +1167,38 @@ DOMApplicationCache.prototype.dispatchEvent = function(evt) {};
  * The object isn't associated with an application cache. This can occur if the
  * update process fails and there is no previous cache to revert to, or if there
  * is no manifest file.
- * @type {number}
+ * @const {number}
  */
 DOMApplicationCache.prototype.UNCACHED = 0;
 
 /**
  * The cache is idle.
- * @type {number}
+ * @const {number}
  */
 DOMApplicationCache.prototype.IDLE = 1;
 
 /**
  * The update has started but the resources are not downloaded yet - for
  * example, this can happen when the manifest file is fetched.
- * @type {number}
+ * @const {number}
  */
 DOMApplicationCache.prototype.CHECKING = 2;
 
 /**
  * The resources are being downloaded into the cache.
- * @type {number}
+ * @const {number}
  */
 DOMApplicationCache.prototype.DOWNLOADING = 3;
 
 /**
  * Resources have finished downloading and the new cache is ready to be used.
- * @type {number}
+ * @const {number}
  */
 DOMApplicationCache.prototype.UPDATEREADY = 4;
 
 /**
  * The cache is obsolete.
- * @type {number}
+ * @const {number}
  */
 DOMApplicationCache.prototype.OBSOLETE = 5;
 
@@ -3812,10 +3812,10 @@ Document.prototype.msFullscreenEnabled;
 /** @type {Element} */
 Document.prototype.msFullscreenElement;
 
-/** @type {number} */
+/** @const {number} */
 Element.ALLOW_KEYBOARD_INPUT = 1;
 
-/** @type {number} */
+/** @const {number} */
 Element.prototype.ALLOW_KEYBOARD_INPUT = 1;
 
 

--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -236,49 +236,49 @@ CSSRule.prototype.style;
 
 /**
  * Indicates that the rule is a {@see CSSUnknownRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.UNKNOWN_RULE = 0;
 
 /**
  * Indicates that the rule is a {@see CSSStyleRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.STYLE_RULE = 1;
 
 /**
  * Indicates that the rule is a {@see CSSCharsetRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.CHARSET_RULE = 2;
 
 /**
  * Indicates that the rule is a {@see CSSImportRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.IMPORT_RULE = 3;
 
 /**
  * Indicates that the rule is a {@see CSSMediaRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.MEDIA_RULE = 4;
 
 /**
  * Indicates that the rule is a {@see CSSFontFaceRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.FONT_FACE_RULE = 5;
 
 /**
  * Indicates that the rule is a {@see CSSPageRule}.
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
  */
 CSSRule.PAGE_RULE = 6;
@@ -558,25 +558,25 @@ CSSValue.prototype.cssText;
 CSSValue.prototype.cssValueType;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
  */
 CSSValue.CSS_INHERIT = 0;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
  */
 CSSValue.CSS_PRIMITIVE_VALUE = 1;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
  */
 CSSValue.CSS_VALUE_LIST = 2;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
  */
 CSSValue.CSS_CUSTOM = 3;
@@ -595,157 +595,157 @@ function CSSPrimitiveValue() {}
 CSSPrimitiveValue.prototype.primitiveType;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_UNKNOWN = 0;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_NUMBER = 1;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_PERCENTAGE = 2;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_EMS = 3;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_EXS = 4;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_PX = 5;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_CM = 6;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_MM = 7;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_IN = 8;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_PT = 9;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_PC = 10;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_DEG = 11;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_RAD = 12;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_GRAD = 13;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_MS = 14;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_S = 15;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_HZ = 16;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_KHZ = 17;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_DIMENSION = 18;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_STRING = 19;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_URI = 20;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_IDENT = 21;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_ATTR = 22;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_COUNTER = 23;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_RECT = 24;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
  */
 CSSPrimitiveValue.CSS_RGBCOLOR = 25;

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -32,61 +32,61 @@
 function DOMException(message, name) {}
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.INDEX_SIZE_ERR = 1;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.DOMSTRING_SIZE_ERR = 2;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.HIERARCHY_REQUEST_ERR = 3;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.WRONG_DOCUMENT_ERR = 4;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.INVALID_CHARACTER_ERR = 5;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.NO_DATA_ALLOWED_ERR = 6;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.NO_MODIFICATION_ALLOWED_ERR = 7;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.NOT_FOUND_ERR = 8;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.NOT_SUPPORTED_ERR = 9;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
  */
 DOMException.INUSE_ATTRIBUTE_ERR = 10;

--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -2734,31 +2734,31 @@ HTMLIFrameElement.prototype.src;
 HTMLIFrameElement.prototype.width;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
  */
 DOMException.INVALID_STATE_ERR = 11;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
  */
 DOMException.SYNTAX_ERR = 12;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
  */
 DOMException.INVALID_MODIFICATION_ERR = 13;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
  */
 DOMException.NAMESPACE_ERR = 14;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
  */
 DOMException.INVALID_ACCESS_ERR = 15;

--- a/externs/browser/w3c_dom3.js
+++ b/externs/browser/w3c_dom3.js
@@ -32,13 +32,13 @@
 DOMException.prototype.code;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-258A00AF
  */
 DOMException.VALIDATION_ERR = 16;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-258A00AF
  */
 DOMException.TYPE_MISMATCH_ERR = 17;
@@ -617,31 +617,31 @@ TypeInfo.prototype.isDerivedFrom = function(typeNamespaceArg, typeNameArg, deriv
 function UserDataHandler() {}
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-CLONED
  */
 UserDataHandler.prototype.NODE_CLONED = 1;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-IMPORTED
  */
 UserDataHandler.prototype.NODE_IMPORTED = 2;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-DELETED
  */
 UserDataHandler.prototype.NODE_DELETED = 3;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-RENAMED
  */
 UserDataHandler.prototype.NODE_RENAMED = 4;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-ADOPTED
  */
 UserDataHandler.prototype.NODE_ADOPTED = 5;
@@ -689,19 +689,19 @@ DOMError.prototype.relatedData;
 DOMError.prototype.relatedException;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity-warning
  */
 DOMError.SEVERITY_WARNING = 1;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity-error
  */
 DOMError.SEVERITY_ERROR = 2;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity-fatal-error
  */
 DOMError.SEVERITY_FATAL_ERROR = 3;

--- a/externs/browser/w3c_dom4.js
+++ b/externs/browser/w3c_dom4.js
@@ -69,49 +69,49 @@ DOMException.prototype.name;
 DOMException.prototype.message;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.SECURITY_ERR = 18;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.NETWORK_ERR = 19;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.ABORT_ERR = 20;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.URL_MISMATCH_ERR = 21;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.QUOTA_EXCEEDED_ERR = 22;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.TIMEOUT_ERR = 23;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.INVALID_NODE_TYPE_ERR = 24;
 
 /**
- * @type {number}
+ * @const {number}
  * @see https://www.w3.org/TR/2015/REC-dom-20151119/#dfn-error-names-table
  */
 DOMException.DATA_CLONE_ERR = 25;

--- a/externs/browser/w3c_navigation_timing.js
+++ b/externs/browser/w3c_navigation_timing.js
@@ -114,10 +114,10 @@ function PerformanceNavigationTiming() {}
 
 /** @constructor */
 function PerformanceNavigation() {}
-/** @type {number} */ PerformanceNavigation.prototype.TYPE_NAVIGATE = 0;
-/** @type {number} */ PerformanceNavigation.prototype.TYPE_RELOAD = 1;
-/** @type {number} */ PerformanceNavigation.prototype.TYPE_BACK_FORWARD = 2;
-/** @type {number} */ PerformanceNavigation.prototype.TYPE_RESERVED = 255;
+/** @const {number} */ PerformanceNavigation.prototype.TYPE_NAVIGATE = 0;
+/** @const {number} */ PerformanceNavigation.prototype.TYPE_RELOAD = 1;
+/** @const {number} */ PerformanceNavigation.prototype.TYPE_BACK_FORWARD = 2;
+/** @const {number} */ PerformanceNavigation.prototype.TYPE_RESERVED = 255;
 /** @type {number} */ PerformanceNavigation.prototype.type;
 /** @type {number} */ PerformanceNavigation.prototype.redirectCount;
 

--- a/externs/browser/w3c_xml.js
+++ b/externs/browser/w3c_xml.js
@@ -40,13 +40,13 @@
 function XPathException() {}
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#INVALID_EXPRESSION_ERR
  */
 XPathException.INVALID_EXPRESSION_ERR = 52;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#TYPE_ERR
  */
 XPathException.TYPE_ERR = 52;
@@ -202,61 +202,61 @@ XPathResult.prototype.iterateNext = function() {};
 XPathResult.prototype.snapshotItem = function(index) {};
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ANY-TYPE
  */
 XPathResult.ANY_TYPE = 0;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-NUMBER-TYPE
  */
 XPathResult.NUMBER_TYPE = 1;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-STRING-TYPE
  */
 XPathResult.STRING_TYPE = 2;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-BOOLEAN-TYPE
  */
 XPathResult.BOOLEAN_TYPE = 3;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-UNORDERED-NODE-ITERATOR-TYPE
  */
 XPathResult.UNORDERED_NODE_ITERATOR_TYPE = 4;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ORDERED-NODE-ITERATOR-TYPE
  */
 XPathResult.ORDERED_NODE_ITERATOR_TYPE = 5;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-UNORDERED-NODE-SNAPSHOT-TYPE
  */
 XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE = 6;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ORDERED-NODE-SNAPSHOT-TYPE
  */
 XPathResult.ORDERED_NODE_SNAPSHOT_TYPE = 7;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ANY-UNORDERED-NODE-TYPE
  */
 XPathResult.ANY_UNORDERED_NODE_TYPE = 8;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-FIRST-ORDERED-NODE-TYPE
  */
 XPathResult.FIRST_ORDERED_NODE_TYPE = 9;
@@ -275,7 +275,7 @@ function XPathNamespace() {}
 XPathNamespace.prototype.ownerElement;
 
 /**
- * @type {number}
+ * @const {number}
  * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPATH_NAMESPACE_NODE
  */
 XPathNamespace.XPATH_NAMESPACE_NODE = 13;


### PR DESCRIPTION
If a value is defined as "const" in the WebIDL or the spec it
should be marked as such. The advantage is that this flows into
downstream consumers such as google/elemental2 allowing those
projects to define values as constants.