### PR TITLE
Cleanup EventSource externs

### DIFF
--- a/externs/browser/w3c_eventsource.js
+++ b/externs/browser/w3c_eventsource.js
@@ -16,7 +16,7 @@
 
 /**
  * @fileoverview Definitions for W3C's EventSource API.
- * @see http://www.w3.org/TR/eventsource/
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
  *
  * @externs
  */
@@ -47,29 +47,25 @@ EventSource.prototype.removeEventListener = function(
 EventSource.prototype.dispatchEvent = function(evt) {};
 
 /**
- * @type {string}
- * @const
+ * @const {string}
  */
 EventSource.prototype.url;
 
-/** @type {boolean} */
+/** @const {boolean} */
 EventSource.prototype.withCredentials;
 
 /**
- * @type {number}
- * @const
+ * @const {number}
  */
 EventSource.prototype.CONNECTING = 0;
 
 /**
- * @type {number}
- * @const
+ * @const {number}
  */
 EventSource.prototype.OPEN = 1;
 
 /**
- * @type {number}
- * @const
+ * @const {number}
  */
 EventSource.prototype.CLOSED = 2;
 
@@ -80,17 +76,17 @@ EventSource.prototype.CLOSED = 2;
 EventSource.prototype.readyState;
 
 /**
- * @type {?function(!Event)}
+ * @type {?function(!Event): void}
  */
 EventSource.prototype.onopen = function(e) {};
 
 /**
- * @type {?function(!MessageEvent<*>)}
+ * @type {?function(!MessageEvent<*>): void}
  */
 EventSource.prototype.onmessage = function(e) {};
 
 /**
- * @type {?function(!Event)}
+ * @type {?function(!Event): void}
  */
 EventSource.prototype.onerror = function(e) {};
 


### PR DESCRIPTION
* Mark withCredentials as @const to align with the spec [1]
* Updated spec url
* Corrected the return type of onopen, onmessage and onerror to be void
* Collapsed '@type {X} @const' declarations to '@const {X}'

[1] https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface