### PR TITLE
Duplicate EventSource constants onto symbol

### DIFF
--- a/externs/browser/w3c_eventsource.js
+++ b/externs/browser/w3c_eventsource.js
@@ -57,17 +57,32 @@ EventSource.prototype.withCredentials;
 /**
  * @const {number}
  */
-EventSource.prototype.CONNECTING = 0;
+EventSource.prototype.CONNECTING;
 
 /**
  * @const {number}
  */
-EventSource.prototype.OPEN = 1;
+EventSource.CONNECTING;
 
 /**
  * @const {number}
  */
-EventSource.prototype.CLOSED = 2;
+EventSource.prototype.OPEN;
+
+/**
+ * @const {number}
+ */
+EventSource.OPEN;
+
+/**
+ * @const {number}
+ */
+EventSource.prototype.CLOSED;
+
+/**
+ * @const {number}
+ */
+EventSource.CLOSED;
 
 /**
  * @type {number}


### PR DESCRIPTION
This aligns with the spec and ensures that Elemental2 generates these as static final fields rather than instance fields