### PR TITLE
Ensure that the error constants in MediaError are correctly annotated

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2389,27 +2389,27 @@ MediaError.prototype.message;
 /**
  * The fetching process for the media resource was aborted by the user agent at
  * the user's request.
- * @type {number}
+ * @const {number}
  */
 MediaError.MEDIA_ERR_ABORTED;
 
 /**
  * A network error of some description caused the user agent to stop fetching
  * the media resource, after the resource was established to be usable.
- * @type {number}
+ * @const {number}
  */
 MediaError.MEDIA_ERR_NETWORK;
 
 /**
  * An error of some description occurred while decoding the media resource,
  * after the resource was established to be usable.
- * @type {number}
+ * @const {number}
  */
 MediaError.MEDIA_ERR_DECODE;
 
 /**
  * The media resource indicated by the src attribute was not suitable.
- * @type {number}
+ * @const {number}
  */
 MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED;
 


### PR DESCRIPTION
Constant values extracted from https://developer.mozilla.org/en-US/docs/Web/API/MediaError

This fixes google/elemental2#71