### PR TITLE
Remove Node.XPATH_NAMESPACE_NODE as no such constant.

### DIFF
--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -309,12 +309,6 @@ Node.TEXT_NODE;
  * @type {number}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
  */
-Node.XPATH_NAMESPACE_NODE;
-
-/**
- * @type {number}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
- */
 Node.NOTATION_NODE;
 
 /**


### PR DESCRIPTION
The correct location of this constant is XPathNamespace.XPATH_NAMESPACE_NODE
and it is correctly specified on this type in w3c_xml.js. The Node constants
are defined at https://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247