### PR TITLE
Remove MediaStreamTrack.getSources as no modern browser supports it

### DIFF
--- a/externs/browser/w3c_rtc.js
+++ b/externs/browser/w3c_rtc.js
@@ -304,13 +304,6 @@ MediaTrackSupportedConstraints.prototype.groupId;
 function MediaStreamTrack() {}
 
 /**
- * @param {!function(!Array<!SourceInfo>)} callback
- * @return {undefined}
- * @deprecated Use MediaDevices.enumerateDevices().
- */
-MediaStreamTrack.getSources = function(callback) {};
-
-/**
  * @type {string}
  * @const
  */


### PR DESCRIPTION
See support at https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack

It was removed from Chrome a long time ago (in web terms). See https://www.chromestatus.com/features/4765305641369600