### PR TITLE
Define typedefs for callbacks, naming the typedefs as per the spec

### DIFF
--- a/externs/browser/w3c_geolocation.js
+++ b/externs/browser/w3c_geolocation.js
@@ -27,8 +27,18 @@
 function Geolocation() {}
 
 /**
- * @param {function(!GeolocationPosition)} successCallback
- * @param {(function(!GeolocationPositionError)|null)=} opt_errorCallback
+ * @typedef {function(!GeolocationPosition): void}
+ */
+var PositionCallback;
+
+/**
+ * @typedef {function(!GeolocationPositionError): void}
+ */
+var PositionErrorCallback;
+
+/**
+ * @param {PositionCallback} successCallback
+ * @param {PositionErrorCallback=} opt_errorCallback
  * @param {GeolocationPositionOptions=} opt_options
  * @return {undefined}
  */
@@ -37,8 +47,8 @@ Geolocation.prototype.getCurrentPosition = function(successCallback,
                                                        opt_options) {};
 
 /**
- * @param {function(!GeolocationPosition)} successCallback
- * @param {(function(!GeolocationPositionError)|null)=} opt_errorCallback
+ * @param {PositionCallback} successCallback
+ * @param {PositionErrorCallback=} opt_errorCallback
  * @param {GeolocationPositionOptions=} opt_options
  * @return {number}
  */


### PR DESCRIPTION
The callbacks have also been fixed to return void as declared in the spec.

This PR has been extracted from #3297 