### PR TITLE
add ECMASCRIPT6, ECMASCRIPT_2016, ECMASCRIPT_2017 to --language_out options

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -685,8 +685,8 @@ public class CommandLineRunner extends
         name = "--language_out",
         usage =
             "Sets the language spec to which output should conform. "
-                + "Options: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT, "
-                + "ECMASCRIPT_2015, STABLE")
+                + "Options: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT, ECMASCRIPT6, "
+                + "ECMASCRIPT_2015, ECMASCRIPT_2016, ECMASCRIPT_2017, STABLE")
     private String languageOut = "STABLE";
 
 


### PR DESCRIPTION
add new --language_out options values for wiki Flags and Options, because these options values are fully supported since v20190301.