### PR TITLE
Allow to suppress import in typedef JSDoc parse error.

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -228,6 +228,7 @@ public class DiagnosticGroups {
           "nonStandardJsDocs",
           RhinoErrorReporter.BAD_JSDOC_ANNOTATION,
           RhinoErrorReporter.INVALID_PARAM,
+          RhinoErrorReporter.JSDOC_IMPORT_TYPE_WARNING,
           CheckJSDoc.JSDOC_IN_BLOCK_COMMENT);
 
   public static final DiagnosticGroup INVALID_CASTS =

--- a/src/com/google/javascript/jscomp/RhinoErrorReporter.java
+++ b/src/com/google/javascript/jscomp/RhinoErrorReporter.java
@@ -48,6 +48,10 @@ class RhinoErrorReporter {
   static final DiagnosticType JSDOC_MISSING_TYPE_WARNING =
       DiagnosticType.disabled("JSC_JSDOC_MISSING_TYPE_WARNING", "{0}");
 
+  // Import is supported by VSCode and is pretty much a standard now.
+  static final DiagnosticType JSDOC_IMPORT_TYPE_WARNING =
+      DiagnosticType.disabled("JSC_JSDOC_IMPORT_TYPE_WARNING", "{0}");
+
   static final DiagnosticType TOO_MANY_TEMPLATE_PARAMS =
       DiagnosticType.disabled("JSC_TOO_MANY_TEMPLATE_PARAMS", "{0}");
 
@@ -152,6 +156,9 @@ class RhinoErrorReporter {
 
             // Unresolved types that aren't forward declared.
             .put(Pattern.compile(".*Unknown type.*"), UNRECOGNIZED_TYPE_ERROR)
+
+            // Import annotation errors.
+            .put(Pattern.compile("^Bad type annotation. Import in typedef.*"), JSDOC_IMPORT_TYPE_WARNING)
 
             // Type annotation errors.
             .put(Pattern.compile("^Bad type annotation.*"), TYPE_PARSE_ERROR)

--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -1941,7 +1941,11 @@ public final class JsDocInfoParser {
       if (typeNode != null) {
         skipEOLs();
         if (!match(JsDocToken.RIGHT_CURLY)) {
-          reportTypeSyntaxWarning("msg.jsdoc.missing.rc");
+          if (typeNode.isString() && typeNode.getString() == "import") {
+            reportTypeSyntaxWarning("msg.jsdoc.import");
+          } else {
+            reportTypeSyntaxWarning("msg.jsdoc.missing.rc");
+          }
         } else {
           next();
         }

--- a/src/com/google/javascript/rhino/Messages.properties
+++ b/src/com/google/javascript/rhino/Messages.properties
@@ -351,3 +351,6 @@ msg.jsdoc.typetransformation.extra.param =\
 
 msg.jsdoc.typetransformation.invalid.inside =\
     Invalid expression inside {0}
+
+msg.jsdoc.import =\
+    Import in typedef is not supported.

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -692,6 +692,13 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
   }
 
   @Test
+  public void testParseImportTypeError() {
+    parse(
+        "@type {import('http').Stream} */",
+        "Bad type annotation. Import in typedef is not supported." + BAD_TYPE_WIKI_LINK);
+  }
+
+  @Test
   public void testParseFunctionalTypeError1() {
     parse(
         "@type {function number):string}*/",


### PR DESCRIPTION
This is to allow writing stuff like because everyone is using `import` since VSCode has enabled it. It'd be great to have this in Closure as well otherwise types have to be imported via externs and that stops advanced mangling. 
```js
/**
 * @suppress {nonStandardJsDocs}
 * @typedef {import('restream').Rule} restream.Rule
 */
```