### PR TITLE
Migrate standardized History API to html5.js from ie_dom.js

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -3100,8 +3100,42 @@ WebSocket.prototype.binaryType;
 // HTML5 History
 /**
  * @constructor
+ * @see http://w3c.github.io/html/browsers.html#the-history-interface
  */
 function History() {}
+
+/**
+ * Goes back one step in the joint session history.
+ * If there is no previous page, does nothing.
+ *
+ * @return {undefined}
+ */
+History.prototype.back = function(opt_distance) {};
+
+/**
+ * Goes forward one step in the joint session history.
+ * If there is no next page, does nothing.
+ *
+ * @return {undefined}
+ */
+History.prototype.forward = function() {};
+
+/**
+ * The number of entries in the joint session history.
+ *
+ * @type {number}
+ */
+History.prototype.length;
+
+/**
+ * Goes back or forward the specified number of steps in the joint session history.
+ * A zero delta will reload the current page.
+ * If the delta is out of range, does nothing.
+ *
+ * @param {number} delta The number of entries to go back.
+ * @return {undefined}
+ */
+History.prototype.go = function(delta) {};
 
 /**
  * Pushes a new state into the session history.

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -483,34 +483,6 @@ Window.prototype.external;
 Window.prototype.msCrypto;
 
 /**
- * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
- * @param {number|string} delta The number of entries to go back, or
- *     the URL to which to go back. (URL form is supported only in IE)
- * @return {undefined}
- */
-History.prototype.go = function(delta) {};
-
-/**
- * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
- * @param {number=} opt_distance The number of entries to go back
- *     (Mozilla doesn't support distance -- use #go instead)
- * @return {undefined}
- */
-History.prototype.back = function(opt_distance) {};
-
-/**
- * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
- * @type {number}
- */
-History.prototype.length;
-
-/**
- * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
- * @return {undefined}
- */
-History.prototype.forward = function() {};
-
-/**
  * @type {boolean}
  * @implicitCast
  * @see http://msdn.microsoft.com/en-us/library/ie/ms533072(v=vs.85).aspx


### PR DESCRIPTION
IE10 and IE11 also support passing a string parameter as a parameter
to History.prototype.go function and passing an optional delta parameter
to History.prototype.back both of which are easily replaced with standards
equivalents (i.e. using "window.location.href = ..." or "history.go(delta)").

The externs for these non-standard parameters has been removed as part
of this PR as it seems very unlikely that there is limited if any use
of these parameters any more.