### PR TITLE
Only mark a module as CommonJS when an export statement is encountered

### DIFF
--- a/src/com/google/javascript/jscomp/GatherModuleMetadata.java
+++ b/src/com/google/javascript/jscomp/GatherModuleMetadata.java
@@ -261,8 +261,9 @@ public final class GatherModuleMetadata implements HotSwapCompilerPass {
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
       if (processCommonJsModules && currentModule != null && currentModule.isScript()) {
-        if (ProcessCommonJSModules.isCommonJsExport(t, n, moduleResolutionMode)
-            || ProcessCommonJSModules.isCommonJsImport(n, moduleResolutionMode)) {
+        // A common JS import (call to "require") does not force a module to be rewritten as
+        // commonJS. Only an export statement.
+        if (ProcessCommonJSModules.isCommonJsExport(t, n, moduleResolutionMode)) {
           currentModule.moduleType(ModuleType.COMMON_JS, t, n);
           return;
         }


### PR DESCRIPTION
The CommonJS "require" call can be used as a module loader from a script tag. The presence of a "require" call does not indicate that the file is a CommonJS module.

Fixes #3324