### PR TITLE
Move nonstandard property to a separate extern

### DIFF
--- a/externs/browser/nonstandard_navigation_timing.js
+++ b/externs/browser/nonstandard_navigation_timing.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2011 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Nonstandard Definitions for W3C's Navigation Timing specification.
+ *
+ * @externs
+ */
+
+// Nonstandard. Only available in Blink.
+// Returns more granular results with the --enable-memory-info flag.
+/** @type {MemoryInfo} */ Performance.prototype.memory;
+
+/**
+ * Clear out the buffer of performance timing events for webkit browsers.
+ * @return {undefined}
+ */
+Performance.prototype.webkitClearResourceTimings = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+Performance.prototype.webkitNow = function() {};

--- a/externs/browser/w3c_navigation_timing.js
+++ b/externs/browser/w3c_navigation_timing.js
@@ -288,6 +288,8 @@ function PerformanceObserverInit() {}
 
 /** @type {undefined|!Array<string>} */
 PerformanceObserverInit.prototype.entryTypes;
+/** @type {undefined|string} */
+PerformanceObserverInit.prototype.type;
 /** @type {undefined|boolean} */
 PerformanceObserverInit.prototype.buffered;
 

--- a/externs/browser/w3c_navigation_timing.js
+++ b/externs/browser/w3c_navigation_timing.js
@@ -114,9 +114,13 @@ function PerformanceNavigationTiming() {}
 
 /** @constructor */
 function PerformanceNavigation() {}
+/** @const {number} */ PerformanceNavigation.TYPE_NAVIGATE;
 /** @const {number} */ PerformanceNavigation.prototype.TYPE_NAVIGATE;
+/** @const {number} */ PerformanceNavigation.TYPE_RELOAD;
 /** @const {number} */ PerformanceNavigation.prototype.TYPE_RELOAD;
+/** @const {number} */ PerformanceNavigation.TYPE_BACK_FORWARD;
 /** @const {number} */ PerformanceNavigation.prototype.TYPE_BACK_FORWARD;
+/** @const {number} */ PerformanceNavigation.TYPE_RESERVED;
 /** @const {number} */ PerformanceNavigation.prototype.TYPE_RESERVED;
 /** @type {number} */ PerformanceNavigation.prototype.type;
 /** @type {number} */ PerformanceNavigation.prototype.redirectCount;

--- a/externs/browser/w3c_navigation_timing.js
+++ b/externs/browser/w3c_navigation_timing.js
@@ -163,12 +163,6 @@ Performance.prototype.timeOrigin;
 Performance.prototype.clearResourceTimings = function() {};
 
 /**
- * Clear out the buffer of performance timing events for webkit browsers.
- * @return {undefined}
- */
-Performance.prototype.webkitClearResourceTimings = function() {};
-
-/**
  * A callback that is invoked when the resourcetimingbufferfull event is fired.
  * @type {?function(Event)}
  */
@@ -208,21 +202,11 @@ Performance.prototype.getEntriesByType = function(entryType) {};
  */
 Performance.prototype.getEntriesByName = function(name, opt_entryType) {};
 
-// Nonstandard. Only available in Blink.
-// Returns more granular results with the --enable-memory-info flag.
-/** @type {MemoryInfo} */ Performance.prototype.memory;
-
 /**
  * @return {number}
  * @nosideeffects
  */
 Performance.prototype.now = function() {};
-
-/**
- * @return {number}
- * @nosideeffects
- */
-Performance.prototype.webkitNow = function() {};
 
 /**
  * @param {string} markName


### PR DESCRIPTION
This makes it possible to import the extern and only receive the standardized externs which stops downstream projects such as google/elemental2 from patching the extern.

This needs to be simultaneously applied with google/elemental2#113