### PR TITLE
Update definition for well-known symbols

### DIFF
--- a/externs/es3.js
+++ b/externs/es3.js
@@ -63,13 +63,82 @@ Symbol.keyFor = function(sym) {};
 
 // Well known symbols
 
-/** @const {symbol} */
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
+ * @const {symbol}
+ */
+Symbol.asyncIterator;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
+ * @const {symbol}
+ */
+Symbol.hasInstance;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
+ * @const {symbol}
+ */
+Symbol.isConcatSpreadable;
+
+/** 
+ * @const {symbol}
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator
+ */
 Symbol.iterator;
 
-/** @const {symbol} */
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match
+ * @const {symbol}
+ */
+Symbol.match;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
+ * @const {symbol}
+ */
+Symbol.matchAll;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace
+ * @const {symbol}
+ */
+Symbol.replace;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search
+ * @const {symbol}
+ */
+Symbol.search;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species
+ * @const {symbol}
+ */
+Symbol.species;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split
+ * @const {symbol}
+ */
+Symbol.split;
+
+/** 
+ * @const {symbol}
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
+ */
+Symbol.toPrimitive;
+
+/**
+ * @const {symbol}
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
+ */
 Symbol.toStringTag;
 
-/** @const {symbol} */
+/** 
+ * @const {symbol}
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
+ */
 Symbol.unscopables;
 
 

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -21,7 +21,12 @@
  * @externs
  */
 
-
+/**
+ * Some es6 definitions:
+ * Symbol, IIterableResult, Iterable, IteratorIterable, Iterator, IteratorIterable
+ * moved to es3 file, because some base type requires them, and we want to keep them together.
+ * If you add new externs related to those types define them together in the es3 file.
+ */
 
 /**
  * @interface
@@ -1762,13 +1767,6 @@ Atomics.wake = function(typedArray, index, count) {}
  * @return {number}
  */
 Atomics.xor = function(typedArray, index, value) {}
-
-
-/**
- * @see https://tc39.github.io/proposal-async-iteration/
- * @const {symbol}
- */
-Symbol.asyncIterator;
 
 
 /**


### PR DESCRIPTION
This PR define well-known Symbols, which is not defined previously, and fix this issue: #3346
Also, I added the @see annotation to previously defined symbols