### PR TITLE
root in IntersectionObserverInit could be nulled

### DIFF
--- a/externs/browser/intersection_observer.js
+++ b/externs/browser/intersection_observer.js
@@ -107,7 +107,7 @@ var IntersectionObserverCallback;
  *   threshold: (!Array<number>|number|undefined),
  *   delay: (number|undefined),
  *   trackVisibility: (boolean|undefined),
- *   root: (!Element|undefined),
+ *   root: (?Element|undefined),
  *   rootMargin: (string|undefined)
  * }}
  */


### PR DESCRIPTION
Per https://w3c.github.io/IntersectionObserver/v2/#intersection-observer-init root could be nulled in case if pointing to the implicit root element.