### PR TITLE
Fix printing of comma operators in object literals.

### DIFF
--- a/src/com/google/javascript/jscomp/CodeGenerator.java
+++ b/src/com/google/javascript/jscomp/CodeGenerator.java
@@ -1061,7 +1061,9 @@ public class CodeGenerator {
           }
         }
         add("[");
-        add(first);
+        // Must use addExpr() with a priority of 1, because comma expressions aren't allowed.
+        // https://www.ecma-international.org/ecma-262/9.0/index.html#prod-ComputedPropertyName
+        addExpr(first, 1, Context.OTHER);
         add("]");
         // TODO(martinprobst): There's currently no syntax for properties in object literals that
         // have type declarations on them (a la `{foo: number: 12}`). This comes up for, e.g.,
@@ -1084,8 +1086,10 @@ public class CodeGenerator {
             // Object literal value.
             checkState(
                 !isInClass, "initializers should only exist in object literals, not classes");
-            cc.addOp(":", false);
-            add(initializer);
+            cc.add(":");
+            // Must use addExpr() with a priority of 1, because a comma expression here would cause
+            // a syntax error within the object literal.
+            addExpr(initializer, 1, Context.OTHER);
           } else {
             // Computed properties must either have an initializer or be computed member-variable
             // properties that exist for their type declaration.

--- a/test/com/google/javascript/jscomp/CodePrinterTest.java
+++ b/test/com/google/javascript/jscomp/CodePrinterTest.java
@@ -140,6 +140,15 @@ public final class CodePrinterTest extends CodePrinterTestBase {
   }
 
   @Test
+  public void testObjectLiteralWithComma() {
+    languageMode = LanguageMode.ECMASCRIPT_NEXT;
+    assertPrintSame("({[(a,b)]:c})");
+    assertPrintSame("({a:(b,c)})");
+    assertPrintSame("({[(a,b)]:(c,d)})");
+    assertPrintSame("({[(a,b)]:c,[d]:(e,f)})");
+  }
+
+  @Test
   public void testPrint() {
     assertPrint("10 + a + b", "10+a+b");
     assertPrint("10 + (30*50)", "10+30*50");


### PR DESCRIPTION
Both in a computed property key, and in value position.

Closes #3358.