### PR TITLE
Fixed extern $.merge type

### DIFF
--- a/contrib/externs/jquery-1.12_and_2.2.js
+++ b/contrib/externs/jquery-1.12_and_2.2.js
@@ -1265,9 +1265,10 @@ jQuery.map = function(arg1, callback) {};
 jQuery.prototype.map = function(callback) {};
 
 /**
- * @param {Array<*>} first
- * @param {Array<*>} second
- * @return {Array<*>}
+ * @template T, U
+ * @param {!Array<T>} first
+ * @param {!Array<U>} second
+ * @return {!Array<(T|U)>}
  */
 jQuery.merge = function(first, second) {};
 


### PR DESCRIPTION
Corrected the type signature of $.merge to indicate that its arguments are mandatory and its return value is never null/undefined