### PR TITLE
Remove values from externs

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -1180,7 +1180,7 @@ ApplicationCache.prototype.dispatchEvent = function(evt) {};
  * is no manifest file.
  * @const {number}
  */
-ApplicationCache.prototype.UNCACHED = 0;
+ApplicationCache.prototype.UNCACHED;
 
 /**
  * The object isn't associated with an application cache. This can occur if the
@@ -1188,69 +1188,69 @@ ApplicationCache.prototype.UNCACHED = 0;
  * is no manifest file.
  * @const {number}
  */
-ApplicationCache.UNCACHED = 0;
+ApplicationCache.UNCACHED;
 
 /**
  * The cache is idle.
  * @const {number}
  */
-ApplicationCache.prototype.IDLE = 1;
+ApplicationCache.prototype.IDLE;
 
 /**
  * The cache is idle.
  * @const {number}
  */
-ApplicationCache.IDLE = 1;
+ApplicationCache.IDLE;
 
 /**
  * The update has started but the resources are not downloaded yet - for
  * example, this can happen when the manifest file is fetched.
  * @const {number}
  */
-ApplicationCache.prototype.CHECKING = 2;
+ApplicationCache.prototype.CHECKING;
 
 /**
  * The update has started but the resources are not downloaded yet - for
  * example, this can happen when the manifest file is fetched.
  * @const {number}
  */
-ApplicationCache.CHECKING = 2;
+ApplicationCache.CHECKING;
 
 /**
  * The resources are being downloaded into the cache.
  * @const {number}
  */
-ApplicationCache.prototype.DOWNLOADING = 3;
+ApplicationCache.prototype.DOWNLOADING;
 
 /**
  * The resources are being downloaded into the cache.
  * @const {number}
  */
-ApplicationCache.DOWNLOADING = 3;
+ApplicationCache.DOWNLOADING;
 
 /**
  * Resources have finished downloading and the new cache is ready to be used.
  * @const {number}
  */
-ApplicationCache.prototype.UPDATEREADY = 4;
+ApplicationCache.prototype.UPDATEREADY;
 
 /**
  * Resources have finished downloading and the new cache is ready to be used.
  * @const {number}
  */
-ApplicationCache.UPDATEREADY = 4;
+ApplicationCache.UPDATEREADY;
 
 /**
  * The cache is obsolete.
  * @const {number}
  */
-ApplicationCache.prototype.OBSOLETE = 5;
+ApplicationCache.prototype.OBSOLETE;
 
 /**
  * The cache is obsolete.
  * @const {number}
  */
-ApplicationCache.OBSOLETE = 5;
+ApplicationCache.OBSOLETE;
 
 /**
  * The current status of the application cache.

--- a/externs/browser/nonstandard_fileapi.js
+++ b/externs/browser/nonstandard_fileapi.js
@@ -1040,109 +1040,109 @@ function FileException() {}
  * @see http://www.w3.org/TR/FileAPI/#dfn-NOT_FOUND_ERR
  * @type {number}
  */
-FileException.prototype.NOT_FOUND_ERR = 1;
+FileException.prototype.NOT_FOUND_ERR;
 
 /** @type {number} */
-FileException.NOT_FOUND_ERR = 1;
+FileException.NOT_FOUND_ERR;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-SECURITY_ERR
  * @type {number}
  */
-FileException.prototype.SECURITY_ERR = 2;
+FileException.prototype.SECURITY_ERR;
 
 /** @type {number} */
-FileException.SECURITY_ERR = 2;
+FileException.SECURITY_ERR;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#widl-FileException-ABORT_ERR
  * @type {number}
  */
-FileException.prototype.ABORT_ERR = 3;
+FileException.prototype.ABORT_ERR;
 
 /** @type {number} */
-FileException.ABORT_ERR = 3;
+FileException.ABORT_ERR;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#widl-FileException-NOT_READABLE_ERR
  * @type {number}
  */
-FileException.prototype.NOT_READABLE_ERR = 4;
+FileException.prototype.NOT_READABLE_ERR;
 
 /** @type {number} */
-FileException.NOT_READABLE_ERR = 4;
+FileException.NOT_READABLE_ERR;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#widl-FileException-ENCODING_ERR
  * @type {number}
  */
-FileException.prototype.ENCODING_ERR = 5;
+FileException.prototype.ENCODING_ERR;
 
 /** @type {number} */
-FileException.ENCODING_ERR = 5;
+FileException.ENCODING_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-NO_MODIFICATION_ALLOWED_ERR
  * @type {number}
  */
-FileException.prototype.NO_MODIFICATION_ALLOWED_ERR = 6;
+FileException.prototype.NO_MODIFICATION_ALLOWED_ERR;
 
 /** @type {number} */
-FileException.NO_MODIFICATION_ALLOWED_ERR = 6;
+FileException.NO_MODIFICATION_ALLOWED_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-INVALID_STATE_ERR
  * @type {number}
  */
-FileException.prototype.INVALID_STATE_ERR = 7;
+FileException.prototype.INVALID_STATE_ERR;
 
 /** @type {number} */
-FileException.INVALID_STATE_ERR = 7;
+FileException.INVALID_STATE_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-SYNTAX_ERR
  * @type {number}
  */
-FileException.prototype.SYNTAX_ERR = 8;
+FileException.prototype.SYNTAX_ERR;
 
 /** @type {number} */
-FileException.SYNTAX_ERR = 8;
+FileException.SYNTAX_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileException-INVALID_MODIFICATION_ERR
  * @type {number}
  */
-FileException.prototype.INVALID_MODIFICATION_ERR = 9;
+FileException.prototype.INVALID_MODIFICATION_ERR;
 
 /** @type {number} */
-FileException.INVALID_MODIFICATION_ERR = 9;
+FileException.INVALID_MODIFICATION_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileException-QUOTA_EXCEEDED_ERR
  * @type {number}
  */
-FileException.prototype.QUOTA_EXCEEDED_ERR = 10;
+FileException.prototype.QUOTA_EXCEEDED_ERR;
 
 /** @type {number} */
-FileException.QUOTA_EXCEEDED_ERR = 10;
+FileException.QUOTA_EXCEEDED_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileException-TYPE_MISMATCH_ERR
  * @type {number}
  */
-FileException.prototype.TYPE_MISMATCH_ERR = 11;
+FileException.prototype.TYPE_MISMATCH_ERR;
 
 /** @type {number} */
-FileException.TYPE_MISMATCH_ERR = 11;
+FileException.TYPE_MISMATCH_ERR;
 
 /**
  * @see http://www.w3.org/TR/file-system-api/#widl-FileException-PATH_EXISTS_ERR
  * @type {number}
  */
-FileException.prototype.PATH_EXISTS_ERR = 12;
+FileException.prototype.PATH_EXISTS_ERR;
 
 /** @type {number} */
-FileException.PATH_EXISTS_ERR = 12;
+FileException.PATH_EXISTS_ERR;
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-code-exception


### PR DESCRIPTION
See #3293 for the reasoning but the short version is that closure
compiler does not use the values and reads the values at runtime.
If any tool were to start using it and the values were incorrect,
then incorrect behaviour will occur.