### PR TITLE
Move Node.prototype.insertAdjacentElement from ie_dom.js to html5.js

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -55,6 +55,17 @@ Node.prototype.contains = function(n) {};
 Node.prototype.isConnected;
 
 /**
+ * Inserts the given HTML Element into the node at the location.
+ * @param {string} where Where to insert the HTML text, one of 'beforeBegin',
+ *     'afterBegin', 'beforeEnd', 'afterEnd'.
+ * @param {!Element} element DOM Element to insert.
+ * @return {?Element} The element that was inserted, or null, if the
+ *     insertion failed.
+ * @see https://dom.spec.whatwg.org/#dom-element-insertadjacentelement
+ */
+Node.prototype.insertAdjacentElement = function(where, element) {};
+
+/**
  * @type {boolean}
  * @see https://html.spec.whatwg.org/multipage/scripting.html#the-script-element
  */

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -185,19 +185,6 @@ Node.prototype.document;
  */
 Node.prototype.insertAdjacentHTML = function(sWhere, sText) {};
 
-
-/**
- * Inserts the given HTML Element into the node at the location.
- * @param {string} sWhere Where to insert the HTML text, one of 'beforeBegin',
- *     'afterBegin', 'beforeEnd', 'afterEnd'.
- * @param {!Element} sElement DOM Element to insert.
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement
- * @return {?Element} The element that was inserted, or null, if the
- *     insertion failed.
- */
-Node.prototype.insertAdjacentElement = function(sWhere, sElement) {};
-
-
 /**
  * @type {*}
  * @see http://msdn.microsoft.com/en-us/library/ms762308(VS.85).aspx


### PR DESCRIPTION
The @see annotation was updated to refer current spec and the parameter
names have been updated to align with the names in the spec.

Fixes #2715