### PR TITLE
Move atob and btoa to html5.js

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -105,28 +105,10 @@ Window.prototype.sessionStorage;
 Window.prototype.sidebar;
 
 /**
- * Decodes a string of data which has been encoded using base-64 encoding.
- *
- * @param {string} encodedData
- * @return {string}
- * @see https://developer.mozilla.org/en/DOM/window.atob
- * @nosideeffects
- */
-function atob(encodedData) {}
-
-/**
  * @see https://developer.mozilla.org/en/DOM/window.back
  * @return {undefined}
  */
 Window.prototype.back = function() {};
-
-/**
- * @param {string} stringToEncode
- * @return {string}
- * @see https://developer.mozilla.org/en/DOM/window.btoa
- * @nosideeffects
- */
-function btoa(stringToEncode) {}
 
 /** @deprecated */
 Window.prototype.captureEvents;

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -1331,6 +1331,24 @@ Window.prototype.applicationCache;
 Window.prototype.importScripts = function(var_args) {};
 
 /**
+ * Decodes a string of data which has been encoded using base-64 encoding.
+ *
+ * @param {string} encodedData
+ * @return {string}
+ * @nosideeffects
+ * @see https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob
+ */
+function atob(encodedData) {}
+
+/**
+ * @param {string} stringToEncode
+ * @return {string}
+ * @nosideeffects
+ * @see https://html.spec.whatwg.org/multipage/webappapis.html#dom-btoa
+ */
+function btoa(stringToEncode) {}
+
+/**
  * @see https://developer.mozilla.org/En/DOM/Worker/Functions_available_to_workers
  * @param {...!TrustedScriptURL|string} var_args
  * @return {undefined}


### PR DESCRIPTION
The methods have been standardized and can be moved out of the
vendor specific extern into the standardized extern. This makes
these methods available in google/elemental2

See https://html.spec.whatwg.org/multipage/webappapis.html#atob