### PR TITLE
Array concat optimizations

### DIFF
--- a/test/com/google/javascript/jscomp/PeepholeReplaceKnownMethodsTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeReplaceKnownMethodsTest.java
@@ -628,6 +628,32 @@ public final class PeepholeReplaceKnownMethodsTest extends CompilerTestCase {
     foldSame("returnArrayType().concat([1,2,3])");
     // Call method with the same name as Array.prototype.concat
     foldSame("obj.concat([1,2,3])");
+
+    fold(
+      "[1,2].concat(1).concat(2,['abc']).concat('abc')",
+      "[1,2].concat(1,2,['abc'],'abc')");
+    // because function returnArrayType() or returnUnionType()
+    // possibly can produce a side effects
+    // we can't fold all concatenation chaining
+    fold(
+      "returnArrayType().concat(returnArrayType()).concat(1).concat(2)",
+      "returnArrayType().concat(returnArrayType(),1,2)");
+    fold(
+      "returnArrayType().concat(returnUnionType()).concat(1).concat(2)",
+      "returnArrayType().concat(returnUnionType(),1,2)");
+    fold(
+      "[1,2,1].concat(1).concat(returnArrayType()).concat(2)",
+      "[1,2,1].concat(1).concat(returnArrayType(),2)");
+    fold(
+      "[1].concat(1).concat(2).concat(returnArrayType())",
+      "[1].concat(1,2).concat(returnArrayType())");
+    foldSame("[].concat(1).concat(returnArrayType())");
+    // Call method with the same name as Array.prototype.concat
+    foldSame("obj.concat([1,2]).concat(1)");
+ 
+    fold(
+      "[].concat(['abc']).concat(1).concat([2,3])",
+      "['abc'].concat(1,[2,3])");
   }
 
   private void foldSame(String js) {


### PR DESCRIPTION
### This PR introduces 2 optimizations for an array concatenation described in this issue #3211
---
##### 1. Replacing empty array literal from the front of concatenation by the first argument of concat function call.
```javascript
[].concat(arr1,arr2,arr3) -> arr1.concat(arr2,arr3);
[].concat(funWithArrayReturnType(),funWithArrayReturnType()) -> funWithArrayReturnType().concat(funWithArrayReturnType())
```
This optimization can be performed only when we know that the first argument of concatenation is always an array.
for example here we can't perform this optimization:
```javascript
/**
 * @param {!Array<?>|string}
*/
function fn(param){
     return [].concat(param);
}
```
Overall this optimization ***saves 3 or 2 bytes***. And make sense to be added.

##### 2. Add folding of chained concat functions.
```javascript
arr0.concat(arr1).concat(arr2).concat(arr3) -> arr0.concat(arr1,arr2,arr3);
arr.concat(pureFnCall()).concat(1) -> arr.concat(pureFnCall(),1);
```
This one is very useful because it can potentially ***save 8\*chainCount bytes***
and this code pattern is very common, for example, code from gdrive minified source
```javascript
a.R.Lka.concat(a.R.NQ).concat(a.R.nla).concat(a.R.rla)
```
So this optimization can be performed everywhere, except when concat arguments can produce side effects.
Here we can't fold concatenation
```javascript
var a = [];
a.concat(1).concat(a.push(1)); // [1,1]
/*can't fold to */a.concat(1,a.push(1)); // [1,1,1]
```