### PR TITLE
Selection api nonnull updates

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -506,7 +506,7 @@ Selection.prototype.isCollapsed;
 Selection.prototype.rangeCount;
 
 /**
- * @param {Range} range
+ * @param {!Range} range
  * @return {undefined}
  * @see https://w3c.github.io/selection-api/#dom-selection-addrange
  */
@@ -514,7 +514,7 @@ Selection.prototype.addRange = function(range) {};
 
 /**
  * @param {number} index
- * @return {Range}
+ * @return {!Range}
  * @nosideeffects
  * @see https://w3c.github.io/selection-api/#dom-selection-getrangeat
  */
@@ -549,7 +549,7 @@ Selection.prototype.collapseToEnd = function() {};
 Selection.prototype.collapseToStart = function() {};
 
 /**
- * @param {Node} node
+ * @param {!Node} node
  * @param {boolean=} allowPartialContainment
  * @return {boolean}
  * @nosideeffects
@@ -564,7 +564,7 @@ Selection.prototype.containsNode = function(node, allowPartialContainment) {};
 Selection.prototype.deleteFromDocument = function() {};
 
 /**
- * @param {Node} parentNode
+ * @param {!Node} parentNode
  * @param {number=} offset
  * @return {undefined}
  * @see https://w3c.github.io/selection-api/#dom-selection-extend
@@ -578,14 +578,14 @@ Selection.prototype.extend = function(parentNode, offset) {};
 Selection.prototype.removeAllRanges = function() {};
 
 /**
- * @param {Range} range
+ * @param {!Range} range
  * @return {undefined}
  * @see https://w3c.github.io/selection-api/#dom-selection-removerange
  */
 Selection.prototype.removeRange = function(range) {};
 
 /**
- * @param {Node} parentNode
+ * @param {!Node} parentNode
  * @see http://w3c.github.io/selection-api/#dom-selection-selectallchildren
  */
 Selection.prototype.selectAllChildren;

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -1057,7 +1057,7 @@ Element.prototype.onmouseenter;
 Element.prototype.onmouseleave;
 
 /**
- * @type {?function(Event)}
+ * @type {?function(!Event): void}
  * @see https://w3c.github.io/selection-api/#dom-globaleventhandlers-onselectstart
  */
 Element.prototype.onselectstart;

--- a/externs/browser/webkit_dom.js
+++ b/externs/browser/webkit_dom.js
@@ -108,15 +108,15 @@ Selection.prototype.type;
 Selection.prototype.empty = function() {};
 
 /**
- * @param {Node} baseNode
- * @param {number} baseOffset
- * @param {Node} extentNode
- * @param {number} extentOffset
+ * @param {!Node} anchorNode
+ * @param {number} anchorOffset
+ * @param {!Node} focusNode
+ * @param {number} focusOffset
  * @return {undefined}
  * @see https://w3c.github.io/selection-api/#dom-selection-setbaseandextent
  */
 Selection.prototype.setBaseAndExtent =
- function(baseNode, baseOffset, extentNode, extentOffset) {};
+ function(anchorNode, anchorOffset, focusNode, focusOffset) {};
 
 /**
  * @param {string} alter


### PR DESCRIPTION
Specify values as nonnull in Selection API to align with the spec
    
This includes:
  - the return type of `Selection.prototype.getRangeAt`
  - the `range` parameter of `Selection.prototype.addRange`
  - the `range` parameter of `Selection.prototype.removeRange`
  - the `node` parameter of `Selection.prototype.extend`
  - the `node` parameter of `Selection.prototype.containsNode`
  - the `node` parameter of `Selection.prototype.selectAllChildren`
  - the `anchorNode` and `focusNode` parameters of `Selection.prototype.setBaseAndExtent`
  - the `event` parameter of the `Element.prototype.onselectstart` callback
    
The parameters in Selection.prototype.setBaseAndExtent have also be
updated to align with the names used in the spec.

The return type of `Element.prototype.onselectstart` was also marked as void