### PR TITLE
Remove extern for ViewCSS.prototype.getMatchedCSSRules

### DIFF
--- a/externs/browser/webkit_dom.js
+++ b/externs/browser/webkit_dom.js
@@ -127,16 +127,6 @@ Selection.prototype.setBaseAndExtent =
 Selection.prototype.modify = function(alter, direction, granularity) {};
 
 /**
- * @param {Element} element
- * @param {string} pseudoElement
- * @param {boolean=} opt_authorOnly
- * @return {CSSRuleList}
- * @nosideeffects
- */
-ViewCSS.prototype.getMatchedCSSRules =
-    function(element, pseudoElement, opt_authorOnly) {};
-
-/**
  * @param {string} contextId
  * @param {string} name
  * @param {number} width


### PR DESCRIPTION
The api was deprecated in 2014, disabled by default since M63 and removed
Apr 2018.

See https://bugs.chromium.org/p/chromium/issues/detail?id=437569