### PR TITLE
Type ViewCSS as an interface to align with the spec

### DIFF
--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -906,7 +906,7 @@ Counter.prototype.listStyle;
 Counter.prototype.separator;
 
 /**
- * @constructor
+ * @interface
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-ViewCSS
  */
 function ViewCSS() {}


### PR DESCRIPTION
The incorrect typing results in the need to perform an unchecked cast
in downstream libraries. See google/elemental2#61 for details.

See https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-ViewCSS