### PR TITLE
Move the standardized focus management APIs to html5.js

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -620,17 +620,7 @@ Element.prototype.style;
 Element.prototype.cloneNode = function(deep) {};
 
 /** @return {undefined} */
-Element.prototype.blur = function() {};
-
-/** @return {undefined} */
 Element.prototype.click = function() {};
-
-/**
- * @param {{preventScroll: boolean}=} focusOption
- * @return {undefined}
- * @see https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis
- */
-Element.prototype.focus = function(focusOption) {};
 
 /** @type {number} */
 HTMLInputElement.prototype.selectionStart;

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -5272,3 +5272,34 @@ StorageManager.prototype.estimate = function() {};
  * }}
  */
 var StorageEstimate;
+
+/*
+ * Focus Management APIs
+ *
+ * See https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis
+ */
+
+/**
+ * @type {!Element}
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#dom-document-activeelement
+ */
+Document.prototype.activeElement;
+
+/**
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#dom-document-hasfocus
+ * @return {boolean}
+ */
+Document.prototype.hasFocus = function() {};
+
+/**
+ * @param {{preventScroll: boolean}=} options
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#dom-focus
+ */
+Element.prototype.focus = function(options) {};
+
+/**
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#dom-blur
+ */
+Element.prototype.blur = function() {};

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -745,12 +745,6 @@ Document.prototype.loadXML;
 // http://msdn.microsoft.com/en-us/library/ms531073(VS.85).aspx
 
 /**
- * @type {!Element}
- * @see http://msdn.microsoft.com/en-us/library/ms533065(VS.85).aspx
- */
-Document.prototype.activeElement;
-
-/**
  * @see http://msdn.microsoft.com/en-us/library/ms533553(VS.85).aspx
  */
 Document.prototype.charset;
@@ -868,12 +862,6 @@ Document.prototype.detachEvent;
  * @see http://msdn.microsoft.com/en-us/library/ms536425(VS.85).aspx
  */
 Document.prototype.focus;
-
-/**
- * @see http://msdn.microsoft.com/en-us/library/ms536447(VS.85).aspx
- * @return {boolean}
- */
-Document.prototype.hasFocus = function() {};
 
 /**
  * @see http://msdn.microsoft.com/en-us/library/ms536614(VS.85).aspx


### PR DESCRIPTION
The @see annotations have also been updated to refer to
the whatwg specs. The parameter to Element.prototype.focus
was also changed to align with the spec.

This will fix google/elemental2#40