### PR TITLE
Move Element.prototype.id to w3c_dom1.js

### DIFF
--- a/contrib/externs/svg.js
+++ b/contrib/externs/svg.js
@@ -8823,13 +8823,6 @@ SVGElementInstanceList.prototype.item = function(opt_index){};
  */
 function SVGElement(){}
 
-
-/**
- * @type {string}
- */
-SVGElement.prototype.id;
-
-
 /**
  * @type {string}
  */

--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -587,15 +587,6 @@ Element.prototype.children;
 Element.prototype.firebugIgnore;
 
 /**
- * Note: According to the spec, id is actually defined on HTMLElement and
- * SVGElement, rather than Element. Deliberately ignore this so that saying
- * Element.id is allowed.
- * @type {string}
- * @implicitCast
- */
-Element.prototype.id;
-
-/**
  * Note: According to the spec, name is defined on specific types of
  * HTMLElements, rather than on Node, Element, or HTMLElement directly.
  * Ignore this.

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -592,6 +592,13 @@ Attr.prototype.value;
 function Element() {}
 
 /**
+ * @type {string}
+ * @implicitCast
+ * @see https://dom.spec.whatwg.org/index.html#dom-element-id
+ */
+Element.prototype.id;
+
+/**
  * An Element always contains a non-null NamedNodeMap containing the attributes
  * of this node.
  * @type {!NamedNodeMap<!Attr>}

--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -427,13 +427,6 @@ TreeWalker.prototype.currentNode;
 function HTMLElement() {}
 
 /**
- * @implicitCast
- * @type {string}
- * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-63534901
- */
-HTMLElement.prototype.id;
-
-/**
  * @type {string}
  * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-78276800
  */


### PR DESCRIPTION
Historically this id was defined on HTMLElement and SVGElement but
this is no longer the case - See [1]. As a result of moving id onto
Element it is now possible to remove the id property from these subtypes.

Fixes google/elemental2#38

[1] https://dom.spec.whatwg.org/index.html#interface-element