### PR TITLE
Move the remaining window extension methods from cssom-view to w3c_css.js

### DIFF
--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -392,41 +392,9 @@ Window.prototype.execScript;
 
 
 /**
- * @param {number} x
- * @param {number} y
- * @see http://msdn.microsoft.com/en-us/library/ms536618(VS.85).aspx
- * @return {undefined}
- */
-Window.prototype.moveBy = function(x, y) {};
-
-/**
- * @param {number} x
- * @param {number} y
- * @see http://msdn.microsoft.com/en-us/library/ms536626(VS.85).aspx
- * @return {undefined}
- */
-Window.prototype.moveTo = function(x, y) {};
-
-/**
  * @see http://msdn.microsoft.com/en-us/library/ms536638(VS.85).aspx
  */
 Window.prototype.navigate;
-
-/**
- * @param {number} width
- * @param {number} height
- * @see http://msdn.microsoft.com/en-us/library/ms536722(VS.85).aspx
- * @return {undefined}
- */
-Window.prototype.resizeBy = function(width, height) {};
-
-/**
- * @param {number} width
- * @param {number} height
- * @see http://msdn.microsoft.com/en-us/library/ms536723(VS.85).aspx
- * @return {undefined}
- */
-Window.prototype.resizeTo = function(width, height) {};
 
 /**
  * @see http://msdn.microsoft.com/en-us/library/ms536738(VS.85).aspx

--- a/externs/browser/w3c_css.js
+++ b/externs/browser/w3c_css.js
@@ -2177,6 +2177,44 @@ Window.prototype.outerWidth;
 Window.prototype.outerHeight;
 
 /**
+ * @type {number}
+ * @see https://www.w3.org/TR/cssom-view/#dom-window-devicepixelratio
+ */
+Window.prototype.devicePixelRatio;
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ * @see https://www.w3.org/TR/cssom-view/#dom-window-moveto
+ */
+Window.prototype.moveTo = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ * @see https://www.w3.org/TR/cssom-view/#dom-window-moveby
+ */
+Window.prototype.moveBy = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ * @see https://www.w3.org/TR/cssom-view/#dom-window-resizeto
+ */
+Window.prototype.resizeTo = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ * @see https://www.w3.org/TR/cssom-view/#dom-window-resizeby
+ */
+Window.prototype.resizeBy = function(x, y) {};
+
+/**
  * @constructor
  * @implements {EventTarget}
  * @see http://www.w3.org/TR/cssom-view/#mediaquerylist


### PR DESCRIPTION
These methods have been standardized and are no longer ie specific. Moving
them to w3c_css.js makes them available in google/elemental2

The @see jsdoc tags where updated with references to the spec and the
parameter names where updated to match those in the spec.