### PR TITLE
Move Element.prototype.outerHTML w3c externs as it is now standardized

### DIFF
--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -1069,13 +1069,6 @@ Element.prototype.onselectstart;
 Element.prototype.onselectionchange;
 
 /**
- * @type {string}
- * @implicitCast
- * @see http://msdn.microsoft.com/en-us/library/aa752326(VS.85).aspx
- */
-Element.prototype.outerHTML;
-
-/**
  * @see http://msdn.microsoft.com/en-us/library/ms536689(VS.85).aspx
  * @return {undefined}
  */

--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -2978,4 +2978,10 @@ Window.prototype.open = function(url, windowName, windowFeatures, replace) {};
  */
 Element.prototype.innerHTML;
 
+/**
+ * @type {string}
+ * @implicitCast
+ * @see https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface
+ */
+Element.prototype.outerHTML;
 


### PR DESCRIPTION
See https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface