### PR TITLE
Move standardized document methods to w3c_dom1.js

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -302,11 +302,6 @@ Document.prototype.vlinkColor;
 Document.prototype.clear = function() {};
 
 /**
- * @see https://developer.mozilla.org/en/DOM/document.close
- */
-Document.prototype.close;
-
-/**
  * @param {string} type
  * @return {Event}
  */
@@ -331,11 +326,6 @@ Document.prototype.execCommand;
  */
 Document.prototype.load = function(uri) {};
 Document.prototype.loadOverlay;
-
-/**
- * @see https://developer.mozilla.org/en/DOM/document.open
- */
-Document.prototype.open;
 
 /**
  * @see https://developer.mozilla.org/en/Midas
@@ -368,20 +358,6 @@ Document.prototype.queryCommandSupported;
  * @see http://msdn.microsoft.com/en-us/library/ms536683(VS.85).aspx
  */
 Document.prototype.queryCommandValue;
-
-/**
- * @see https://developer.mozilla.org/en/DOM/document.write
- * @param {!TrustedHTML|string} text
- * @return {undefined}
- */
-Document.prototype.write = function(text) {};
-
-/**
- * @see https://developer.mozilla.org/en/DOM/document.writeln
- * @param {!TrustedHTML|string} text
- * @return {undefined}
- */
-Document.prototype.writeln = function(text) {};
 
 Document.prototype.ononline;
 Document.prototype.onoffline;

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -423,6 +423,32 @@ Document.prototype.createTextNode = function(data) {};
 Document.prototype.getElementsByTagName = function(tagname) {};
 
 /**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/open
+ * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open
+ */
+Document.prototype.open;
+
+/**
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-close
+ */
+Document.prototype.close = function() {};
+
+/**
+ * @param {!TrustedHTML|string} text
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write
+ */
+Document.prototype.write = function(text) {};
+
+/**
+ * @param {!TrustedHTML|string} text
+ * @return {undefined}
+ * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln
+ */
+Document.prototype.writeln = function(text) {};
+
+/**
  * @constructor
  * @implements {IArrayLike<T>}
  * @implements {Iterable<T>}

--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -251,29 +251,6 @@ HTMLDocument.prototype.cookie;
 HTMLDocument.prototype.open = function(opt_mimeType, opt_replace) {};
 
 /**
- * @return {undefined}
- * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-98948567
- * @override
- */
-HTMLDocument.prototype.close = function() {};
-
-/**
- * @param {!TrustedHTML|string} text
- * @return {undefined}
- * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75233634
- * @override
- */
-HTMLDocument.prototype.write = function(text) {};
-
-/**
- * @param {!TrustedHTML|string} text
- * @return {undefined}
- * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-35318390
- * @override
- */
-HTMLDocument.prototype.writeln = function(text) {};
-
-/**
  * @param {string} elementName
  * @return {!NodeList<!Element>}
  * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-71555259


### PR DESCRIPTION
The `open(...)`, `close()`, `write(...)` and `writeln(...)` methods on `Document` are
now part of the standard and have been moved to `w3c_dom1.js` to reflect this.

The typing of `Document.prototype.open` and `Document.prototype.close` was
previously incomplete. These have been aligned with the specification
and with the methods in `HTMLDocument` that overrode these methods. This
may impact type checking but that would be very surprising.

The overrides in `HTMLDocument` have been removed. This is done due to
limitations of the `jsinterop-generator` tool that is more fully described
in google/jsinterop-generator#35 While the specifications explicitly
indicate that these overrides are present and annotates (requiring the
`[OverrideBuiltins]` attribute be applied to the containing interface in
WebIDL) it is not expected that this has any practical impact on programs
type checking against the externs.