### PR TITLE
Fix return type of extern `Symbol.for()`

### DIFF
--- a/externs/es3.js
+++ b/externs/es3.js
@@ -47,7 +47,7 @@ Symbol.prototype.description;
 
 /**
  * @param {string} sym
- * @return {symbol|undefined}
+ * @return {symbol}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for
  */
 Symbol.for = function(sym) {};


### PR DESCRIPTION
`Symbol.for()` returns `symbol` according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for