### PR TITLE
Move some standardized HTMLInputElement properties to html5.js

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -616,21 +616,6 @@ Element.prototype.click = function() {};
 Element.prototype.focus = function(focusOption) {};
 
 /** @type {number} */
-HTMLInputElement.prototype.selectionStart;
-
-/** @type {number} */
-HTMLInputElement.prototype.selectionEnd;
-
-/**
- * @param {number} selectionStart
- * @param {number} selectionEnd
- * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#dom-textarea/input-setselectionrange
- * @return {undefined}
- */
-HTMLInputElement.prototype.setSelectionRange =
-    function(selectionStart, selectionEnd) {};
-
-/** @type {number} */
 HTMLTextAreaElement.prototype.selectionStart;
 
 /** @type {number} */

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -3808,6 +3808,24 @@ HTMLInputElement.prototype.labels;
 /** @type {string} */
 HTMLInputElement.prototype.validationMessage;
 
+/** @type {number} */
+HTMLInputElement.prototype.selectionStart;
+
+/** @type {number} */
+HTMLInputElement.prototype.selectionEnd;
+
+/** @type {string} */
+HTMLInputElement.prototype.selectionDirection;
+
+/**
+ * @param {number} start
+ * @param {number} end
+ * @param {string=} opt_direction
+ * @see https://html.spec.whatwg.org/#dom-textarea/input-setselectionrange
+ * @return {undefined}
+ */
+HTMLInputElement.prototype.setSelectionRange = function(start, end, opt_direction) {};
+
 /**
  * @const {ValidityState}
  */


### PR DESCRIPTION
The change involves
* Moving `selectionStart`, `selectionEnd` and `setSelectionRange` symbols to `html5.js`
* Adding an additional optional parameter to `setSelectionRange` method defined by the spec and implemented by both chrome and gecko
* Adding the missing `HTMLInputElement.prototype.selectionDirection` symbol

The spec WebIDL is at https://html.spec.whatwg.org/#the-input-element while the gecko WebIDL is at https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/HTMLInputElement.webidl#L121-L126

It should be noted that the existing typings used non-nullable properties for `selectionStart` and `selectionEnd` despite the spec indicating they are nullable. Chrome does not conform to the spec and always returns values for these properties (namely `0`) rather than `null`. It was decided to leave the typings as is to match browser implementations rather than aspirational typings defined by the specs.