### PR TITLE
Correct nullability of Document.prototype.activeElement property

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -5348,8 +5348,7 @@ var StorageEstimate;
  */
 
 /**
- * TODO(blickly): This should be nullable as per spec
- * @type {!Element}
+ * @type {?Element}
  * @see https://html.spec.whatwg.org/multipage/interaction.html#dom-document-activeelement
  */
 Document.prototype.activeElement;


### PR DESCRIPTION
The property can be null according to the spec so this has been fixed. The
symbol definition has also been moved to the standardized externs so it is
available in google/elemental2 based consumers.