### PR TITLE
Enable support for polyfilling incomplete Promise implementations.

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -49,6 +49,7 @@ $jscomp.polyfill('Promise',
       return NativePromise;
     }
     try {
+      /** @suppress {checkTypes} */
       new NativePromise(function(resolve) {
         resolve();
       });

--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -26,6 +26,12 @@
  */
 $jscomp.FORCE_POLYFILL_PROMISE = false;
 
+/**
+ * Should we try to polyfill native Promise implementations that are flawed?
+ * @define {boolean}
+ */
+$jscomp.POLYFILL_INCOMPLETE_PROMISE = false;
+
 
 $jscomp.polyfill('Promise',
     /**
@@ -39,7 +45,18 @@ $jscomp.polyfill('Promise',
   //     that fails to reject attempts to fulfill it with itself, but that
   //     isn't reasonably testable here.
   if (NativePromise && !$jscomp.FORCE_POLYFILL_PROMISE) {
-    return NativePromise;
+    if (!$jscomp.POLYFILL_INCOMPLETE_PROMISE) {
+      return NativePromise;
+    }
+    try {
+      new NativePromise(function(resolve) {
+        resolve();
+      });
+      return NativePromise;
+    } catch () {
+      // The Promise wasn't able to be handle the resolve function, so use the
+      // polyfill.
+    }
   }
 
   /**

--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -35,7 +35,7 @@ $jscomp.POLYFILL_INCOMPLETE_PROMISE = false;
 
 $jscomp.polyfill('Promise',
     /**
-     * @param {function(new:*, *)|null} NativePromise
+     * @param {*} NativePromise
      * @return {*}
      * @suppress {reportUnknownTypes}
      */
@@ -49,9 +49,10 @@ $jscomp.polyfill('Promise',
       return NativePromise;
     }
     try {
-      new NativePromise(function(resolve) {
-        resolve();
-      });
+      new /** @type {function(new: Promise, function())} */(NativePromise)(
+        function(resolve) {
+          resolve();
+        });
       return NativePromise;
     } catch (e) {
       // The Promise wasn't able to be handle the resolve function, so use the

--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -35,7 +35,7 @@ $jscomp.POLYFILL_INCOMPLETE_PROMISE = false;
 
 $jscomp.polyfill('Promise',
     /**
-     * @param {*} NativePromise
+     * @param {function(new:*, *)} NativePromise
      * @return {*}
      * @suppress {reportUnknownTypes}
      */
@@ -49,7 +49,6 @@ $jscomp.polyfill('Promise',
       return NativePromise;
     }
     try {
-      /** @suppress {checkTypes} */
       new NativePromise(function(resolve) {
         resolve();
       });

--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -35,7 +35,7 @@ $jscomp.POLYFILL_INCOMPLETE_PROMISE = false;
 
 $jscomp.polyfill('Promise',
     /**
-     * @param {function(new:*, *)} NativePromise
+     * @param {function(new:*, *)|null} NativePromise
      * @return {*}
      * @suppress {reportUnknownTypes}
      */

--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -53,7 +53,7 @@ $jscomp.polyfill('Promise',
         resolve();
       });
       return NativePromise;
-    } catch () {
+    } catch (e) {
       // The Promise wasn't able to be handle the resolve function, so use the
       // polyfill.
     }

--- a/src/com/google/javascript/jscomp/js/es6/promise/promise.js
+++ b/src/com/google/javascript/jscomp/js/es6/promise/promise.js
@@ -49,8 +49,8 @@ $jscomp.polyfill('Promise',
       return NativePromise;
     }
     try {
-      new /** @type {function(new: Promise, function())} */(NativePromise)(
-        function(resolve) {
+      new /** @type {function(new: Promise, function(function()))} */(
+        NativePromise)(function(resolve) {
           resolve();
         });
       return NativePromise;


### PR DESCRIPTION
There are some TV browser devices that have partial support for Promises. Trying to use the Promise should let us know for sure if it's a reliable implementation or not.

Hiding this under a flag since most users won't need to worry about this.