### PR TITLE
Switches CommonJS modules to use the module metadata map

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -676,9 +676,6 @@ public abstract class AbstractCompiler implements SourceExcerptProvider {
    */
   abstract ModuleLoader getModuleLoader();
 
-  /** Lookup the type of a module from its name. */
-  abstract CompilerInput.ModuleType getModuleTypeByName(String moduleName);
-
   /**
    * Sets an annotation for the given key.
    *

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -3578,13 +3578,6 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     }
   }
 
-  /** Returns the module type for the provided namespace. */
-  @Override
-  @Nullable
-  CompilerInput.ModuleType getModuleTypeByName(String moduleName) {
-    return moduleTypesByName.get(moduleName);
-  }
-
   private ModuleMetadataMap moduleMetadataMap;
 
   @Override

--- a/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
+++ b/src/com/google/javascript/jscomp/ProcessCommonJSModules.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.jscomp.deps.ModuleLoader.ModulePath;
+import com.google.javascript.jscomp.modules.Module;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.JSDocInfoBuilder;
@@ -160,8 +161,8 @@ public final class ProcessCommonJSModules extends NodeTraversal.AbstractPreOrder
   }
 
   public String getBasePropertyImport(String moduleName) {
-    CompilerInput.ModuleType moduleType = compiler.getModuleTypeByName(moduleName);
-    if (moduleType != null && moduleType != CompilerInput.ModuleType.COMMONJS) {
+    Module module = compiler.getModuleMap().getModule(moduleName);
+    if (module != null && !module.metadata().isCommonJs()) {
       return moduleName;
     }
 


### PR DESCRIPTION
The metadata provides the module type of the imported module. Also adds module interop integration tests.

I added 2 failing tests that need fixed. Both seem to indicate a problem with ES Module rewriting and default properties.

Fixes #3360