### PR TITLE
Remove the non-standard parameter opt_distance from History.prototype.back

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -3150,7 +3150,7 @@ function History() {}
  *
  * @return {undefined}
  */
-History.prototype.back = function(opt_distance) {};
+History.prototype.back = function() {};
 
 /**
  * Goes forward one step in the joint session history.


### PR DESCRIPTION
This was meant to be removed in #3330 as it is non-standard, not supported
in most browsers and easily replaceable with `history.go(-distance)`. Instead
#3330 incorrectly removed the type annotation but left the parameter in the
symbol definition, making this parameter required.

Fixes #3418