### PR TITLE
Attempt to fix the travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ install: true
 script:
   # Builds the compiler and runs tests
   - mvn -Dstyle.color=always install
-  # Install yarn version 1.10 by downloading its install script and executing it in bash
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
+  - nvm install 10
+  # Install yarn version 1.16 by downloading its install script and executing it in bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
   - export PATH="$HOME/.yarn/bin:$PATH"
   # Run the npm package tests
   - yarn install

--- a/travis_util/test_npm.sh
+++ b/travis_util/test_npm.sh
@@ -7,6 +7,7 @@ yarn install && cd ${TRAVIS_BUILD_DIR}/node_modules/closure-compiler-npm && yarn
 cp ${TRAVIS_BUILD_DIR}/target/closure-compiler-1.0-SNAPSHOT.jar ${TRAVIS_BUILD_DIR}/node_modules/closure-compiler-npm/packages/google-closure-compiler-java/compiler.jar
 cp ${TRAVIS_BUILD_DIR}/target/closure-compiler-1.0-SNAPSHOT.jar ${TRAVIS_BUILD_DIR}/node_modules/closure-compiler-npm/packages/google-closure-compiler-osx/compiler.jar
 cp ${TRAVIS_BUILD_DIR}/target/closure-compiler-1.0-SNAPSHOT.jar ${TRAVIS_BUILD_DIR}/node_modules/closure-compiler-npm/packages/google-closure-compiler-linux/compiler.jar
+cp ${TRAVIS_BUILD_DIR}/target/closure-compiler-1.0-SNAPSHOT.jar ${TRAVIS_BUILD_DIR}/node_modules/closure-compiler-npm/packages/google-closure-compiler-windows/compiler.jar
 cp ${TRAVIS_BUILD_DIR}/target/closure-compiler-gwt-1.0-SNAPSHOT/jscomp/jscomp.js ${TRAVIS_BUILD_DIR}/node_modules/closure-compiler-npm/packages/google-closure-compiler-js/jscomp.js
 
 # Build then test each project


### PR DESCRIPTION
Travis [switched the default linux distribution](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) and builds started failing. The error message wasn't helpful, but appeared to be the Node version being used.

Updating to Node 10 solves the problem.