### PR TITLE
Allow recursive union type definitions

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -649,7 +649,7 @@ public abstract class AbstractCompiler implements SourceExcerptProvider, Compile
    * currently being compiled.
    */
   public AstAnalyzer getAstAnalyzer() {
-    return new AstAnalyzer(this, getOptions().getAssumeGettersAndSettersAreSideEffectFree());
+    return new AstAnalyzer(this, getOptions().getAssumeGettersArePure());
   }
 
   public abstract ModuleMetadataMap getModuleMetadataMap();

--- a/src/com/google/javascript/jscomp/AstAnalyzer.java
+++ b/src/com/google/javascript/jscomp/AstAnalyzer.java
@@ -68,11 +68,11 @@ public class AstAnalyzer {
       ImmutableSet.of("match", "replace", "search", "split");
 
   private final AbstractCompiler compiler;
-  private final boolean assumeGettersAndSettersAreSideEffectFree;
+  private final boolean assumeGettersArePure;
 
-  AstAnalyzer(AbstractCompiler compiler, boolean assumeGettersAndSettersAreSideEffectFree) {
+  AstAnalyzer(AbstractCompiler compiler, boolean assumeGettersArePure) {
     this.compiler = checkNotNull(compiler);
-    this.assumeGettersAndSettersAreSideEffectFree = assumeGettersAndSettersAreSideEffectFree;
+    this.assumeGettersArePure = assumeGettersArePure;
   }
 
   /**
@@ -265,7 +265,7 @@ public class AstAnalyzer {
       case SPREAD:
         if (parent.isObjectPattern() || parent.isObjectLit()) {
           // Object-rest and object-spread may trigger a getter.
-          if (assumeGettersAndSettersAreSideEffectFree) {
+          if (assumeGettersArePure) {
             break; // We still need to inspect the children.
           }
           return true;
@@ -508,7 +508,7 @@ public class AstAnalyzer {
       case SPREAD:
         if (n.getParent().isObjectPattern() || n.getParent().isObjectLit()) {
           // Object-rest and object-spread may trigger a getter.
-          return !assumeGettersAndSettersAreSideEffectFree;
+          return !assumeGettersArePure;
         } else if (NodeUtil.iteratesImpureIterable(n)) {
           return true;
         }
@@ -529,7 +529,7 @@ public class AstAnalyzer {
   }
 
   private PropertyAccessKind getPropertyKind(String name) {
-    return assumeGettersAndSettersAreSideEffectFree
+    return assumeGettersArePure
         ? PropertyAccessKind.NORMAL
         : compiler.getAccessorSummary().getKind(name);
   }

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1129,24 +1129,24 @@ public class CompilerOptions implements Serializable {
   }
 
   /**
-   * Ignore the possibility of side-effects from getter and setter invocations.
+   * Ignore the possibility that getter invocations (gets) can have side-effects and that the
+   * results of gets can be side-effected by local state mutations.
    *
-   * <p>When {@code true}, it doesn't necessarily mean that all gets/sets are considered
-   * side-effectful. Gets/sets that can be proven to be side-effect free may still be considered as
-   * such.
+   * <p>When {@code true}, it doesn't necessarily mean that all gets are considered side-effectful
+   * or side-effected. Gets that can be proven to be pure may still be considered as such.
    *
    * <p>Recall that object-spread is capable of triggering getters. Since the syntax doesn't
    * explicitly specifiy a property, it is essentailly impossible to prove it has no side-effects
    * without this assumption.
    */
-  private boolean assumeGettersAndSettersAreSideEffectFree = true;
+  private boolean assumeGettersArePure = true;
 
-  public void setAssumeGettersAndSettersAreSideEffectFree(boolean x) {
-    this.assumeGettersAndSettersAreSideEffectFree = x;
+  public void setAssumeGettersArePure(boolean x) {
+    this.assumeGettersArePure = x;
   }
 
-  public boolean getAssumeGettersAndSettersAreSideEffectFree() {
-    return assumeGettersAndSettersAreSideEffectFree;
+  public boolean getAssumeGettersArePure() {
+    return assumeGettersArePure;
   }
 
   /**
@@ -2892,9 +2892,7 @@ public class CompilerOptions implements Serializable {
             .add("angularPass", angularPass)
             .add("anonymousFunctionNaming", anonymousFunctionNaming)
             .add("assumeClosuresOnlyCaptureReferences", assumeClosuresOnlyCaptureReferences)
-            .add(
-                "assumeGettersAndSettersAreSideEffectFree",
-                assumeGettersAndSettersAreSideEffectFree)
+            .add("assumeGettersArePure", assumeGettersArePure)
             .add("assumeStrictThis", assumeStrictThis())
             .add("browserResolverPrefixReplacements", browserResolverPrefixReplacements)
             .add("brokenClosureRequiresLevel", brokenClosureRequiresLevel)

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -1886,13 +1886,19 @@ class TypeInference
       // example: @param {Array.<T>|NodeList|Arguments|{length:number}}
       UnionType unionType = paramType.toMaybeUnionType();
       for (JSType alternate : unionType.getAlternates()) {
-        maybeResolveTemplatedType(alternate, argType, resolvedTypes, seenTypes);
+        if (seenTypes.add(alternate)) {
+          maybeResolveTemplatedType(alternate, argType, resolvedTypes, seenTypes);
+          seenTypes.remove(alternate);
+        }
       }
       return;
     } else if (argType.isUnionType()) {
       UnionType unionType = argType.toMaybeUnionType();
       for (JSType alternate : unionType.getAlternates()) {
-        maybeResolveTemplatedType(paramType, alternate, resolvedTypes, seenTypes);
+        if (seenTypes.add(alternate)) {
+          maybeResolveTemplatedType(paramType, alternate, resolvedTypes, seenTypes);
+          seenTypes.remove(alternate);
+        } 
       }
       return;
     }

--- a/src/com/google/javascript/rhino/jstype/ModificationVisitor.java
+++ b/src/com/google/javascript/rhino/jstype/ModificationVisitor.java
@@ -195,11 +195,14 @@ public class ModificationVisitor implements Visitor<JSType> {
 
     ImmutableList.Builder<JSType> builder = ImmutableList.builder();
     for (JSType beforeTemplateType : type.getTemplateTypes()) {
-      JSType afterTemplateType = beforeTemplateType.visit(this);
-      if (beforeTemplateType != afterTemplateType) {
-        changed = true;
+      if (this.seenTypes.add(beforeTemplateType)) {
+        JSType afterTemplateType = beforeTemplateType.visit(this);
+        if (beforeTemplateType != afterTemplateType) {
+          changed = true;
+        }
+        builder.add(afterTemplateType);
+        this.seenTypes.remove(beforeTemplateType);
       }
-      builder.add(afterTemplateType);
     }
 
     if (changed) {

--- a/src/com/google/javascript/rhino/jstype/UnionTypeBuilder.java
+++ b/src/com/google/javascript/rhino/jstype/UnionTypeBuilder.java
@@ -51,6 +51,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.javascript.rhino.jstype.JSType.SubtypingMode;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -159,9 +160,17 @@ public final class UnionTypeBuilder implements Serializable {
 
   // A specific override that avoid creating an iterator.  This version is currently used when
   // adding a union as an alternate.
-  public UnionTypeBuilder addAlternates(ImmutableList<JSType> list) {
+  public UnionTypeBuilder addAlternates(ImmutableList<JSType> list, Set<JSType> seenTypes) {
     for (int i = 0; i < list.size(); i++) {
-      addAlternate(list.get(i));
+      addAlternate(list.get(i), seenTypes);
+    }
+    return this;
+  }
+
+  public UnionTypeBuilder addAlternate(JSType alternate, Set<JSType> seenTypes) {
+    if (seenTypes.add(alternate)) {
+      addAlternate(alternate);
+      seenTypes.remove(alternate);
     }
     return this;
   }

--- a/test/com/google/javascript/jscomp/AstAnalyzerTest.java
+++ b/test/com/google/javascript/jscomp/AstAnalyzerTest.java
@@ -93,7 +93,7 @@ public final class AstAnalyzerTest {
     String js;
     Token token;
     boolean globalRegExp;
-    boolean assumeGettersAndSettersAreSideEffectFree;
+    boolean assumeGettersArePure;
 
     AnalysisCase expect(boolean b) {
       this.expect = b;
@@ -115,8 +115,8 @@ public final class AstAnalyzerTest {
       return this;
     }
 
-    AnalysisCase assumeGettersAndSettersAreSideEffectFree(boolean b) {
-      this.assumeGettersAndSettersAreSideEffectFree = b;
+    AnalysisCase assumeGettersArePure(boolean b) {
+      this.assumeGettersArePure = b;
       return this;
     }
 
@@ -171,10 +171,7 @@ public final class AstAnalyzerTest {
     Node parseCase(AnalysisCase kase) {
       resetCompiler();
       compiler.setHasRegExpGlobalReferences(kase.globalRegExp);
-      compiler
-          .getOptions()
-          .setAssumeGettersAndSettersAreSideEffectFree(
-              kase.assumeGettersAndSettersAreSideEffectFree);
+      compiler.getOptions().setAssumeGettersArePure(kase.assumeGettersArePure);
 
       Node root = parseInternal(kase.js);
       if (kase.token == null) {
@@ -266,36 +263,12 @@ public final class AstAnalyzerTest {
           kase().js("new SomeClassINeverHeardOf()").token(NEW).expect(true),
 
           // Getters and setters - object rest and spread
-          kase()
-              .js("({...x});")
-              .token(SPREAD)
-              .assumeGettersAndSettersAreSideEffectFree(false)
-              .expect(true),
-          kase()
-              .js("const {...x} = y;")
-              .token(REST)
-              .assumeGettersAndSettersAreSideEffectFree(false)
-              .expect(true),
-          kase()
-              .js("({...x});")
-              .token(SPREAD)
-              .assumeGettersAndSettersAreSideEffectFree(true)
-              .expect(false),
-          kase()
-              .js("const {...x} = y;")
-              .token(REST)
-              .assumeGettersAndSettersAreSideEffectFree(true)
-              .expect(false),
-          kase()
-              .js("({...f().x});")
-              .token(SPREAD)
-              .assumeGettersAndSettersAreSideEffectFree(true)
-              .expect(true),
-          kase()
-              .js("({...f().x} = y);")
-              .token(REST)
-              .assumeGettersAndSettersAreSideEffectFree(true)
-              .expect(true),
+          kase().js("({...x});").token(SPREAD).assumeGettersArePure(false).expect(true),
+          kase().js("const {...x} = y;").token(REST).assumeGettersArePure(false).expect(true),
+          kase().js("({...x});").token(SPREAD).assumeGettersArePure(true).expect(false),
+          kase().js("const {...x} = y;").token(REST).assumeGettersArePure(true).expect(false),
+          kase().js("({...f().x});").token(SPREAD).assumeGettersArePure(true).expect(true),
+          kase().js("({...f().x} = y);").token(REST).assumeGettersArePure(true).expect(true),
 
           // Getters and setters
           kase().js("x.getter;").token(GETPROP).expect(true),

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -676,7 +676,7 @@ public abstract class CompilerTestCase {
     options.setLanguageOut(languageOut);
     options.setModuleResolutionMode(moduleResolutionMode);
     options.setPreserveTypeAnnotations(true);
-    options.setAssumeGettersAndSettersAreSideEffectFree(false); // Default to the complex case.
+    options.setAssumeGettersArePure(false); // Default to the complex case.
 
     // This doesn't affect whether checkSymbols is run--it just affects
     // whether variable warnings are filtered.
@@ -1902,7 +1902,7 @@ public abstract class CompilerTestCase {
   }
 
   private void verifyGetterAndSetterCollection(Compiler compiler, Node externsRoot, Node mainRoot) {
-    if (compiler.getOptions().getAssumeGettersAndSettersAreSideEffectFree()) {
+    if (compiler.getOptions().getAssumeGettersArePure()) {
       assertWithMessage("Should not be validated when getter / setters are side-effect free")
           .that(verifyGetterAndSetterUpdates)
           .isFalse();

--- a/test/com/google/javascript/jscomp/GetterAndSetterIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/GetterAndSetterIntegrationTest.java
@@ -68,7 +68,7 @@ public final class GetterAndSetterIntegrationTest extends IntegrationTestCase {
     options.setEmitUseStrict(false);
     // renaming doesn't matter for these tests, and just makes them harder to read
     options.setRenamingPolicy(VariableRenamingPolicy.OFF, PropertyRenamingPolicy.OFF);
-    options.setAssumeGettersAndSettersAreSideEffectFree(false);
+    options.setAssumeGettersArePure(false);
     return options;
   }
 

--- a/test/com/google/javascript/jscomp/IntegrationTest.java
+++ b/test/com/google/javascript/jscomp/IntegrationTest.java
@@ -6569,7 +6569,7 @@ public final class IntegrationTest extends IntegrationTestCase {
     options.setDevMode(DevMode.EVERY_PASS);
     options.setCodingConvention(new GoogleCodingConvention());
     options.setRenamePrefixNamespaceAssumeCrossChunkNames(true);
-    options.setAssumeGettersAndSettersAreSideEffectFree(false);
+    options.setAssumeGettersArePure(false);
     options.setWarningLevel(DiagnosticGroups.FEATURES_NOT_SUPPORTED_BY_PASS, CheckLevel.OFF);
     return options;
   }

--- a/test/com/google/javascript/jscomp/TypeCheckTest.java
+++ b/test/com/google/javascript/jscomp/TypeCheckTest.java
@@ -23981,24 +23981,37 @@ public final class TypeCheckTest extends TypeCheckTestCase {
 
   @Test
   public void testCyclicUnionTypedefs() {
-    // TODO(b/112964849): This case should not throw anything.
-    assertThrows(
-        StackOverflowError.class,
-        () -> {
-          testTypes(
-              lines(
-                  "/** @typedef {Foo|string} */",
-                  "var Bar;",
-                  "/** @typedef {Bar|number} */",
-                  "var Foo;",
-                  "var /** Foo */ foo;",
-                  "var /** null */ x = foo;",
-                  ""),
-              lines(
-                  "initializing variable", //
-                  "found   : (number|string)",
-                  "required: null"));
-        });
+    testTypes(
+      lines(
+          "/** @typedef {Foo|string} */",
+          "var Bar;",
+          "/** @typedef {Bar|number} */",
+          "var Foo;",
+          "var /** Foo */ foo;",
+          "var /** null */ x = foo;",
+          ""),
+      lines(
+          "initializing variable", //
+          "found   : (number|string)",
+          "required: null"));
+  }
+
+  @Test 
+  public void testRecursiveTemplatizedTypedefs() {
+    testTypes(
+      lines(
+        "/** @typedef {string|number} */",
+        "var Bar;",
+        "/** @typedef {Bar|BarArray} */",
+        "var Foo;",
+        "/** @typedef {Array<Foo>} */",
+        "var BarArray;",
+        "/**",
+        "* @param {Foo} foo",
+        "*/",
+        "function testFoo(foo) { }",
+        "var /** Array<Array<Array<Bar>>> */ x = [];",
+        "testFoo(x);"));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes a few different cases of infinite recursion errors for templatized and union type definitions. 

Fixes https://github.com/google/closure-compiler/issues/3027, added test case for this as well. Also fixes existing issue b/112964849 (internal issue? not sure).

The `Set<JSType> seenTypes` already existed in `ModificationVisitor`, so I added functionality in other classes to conform to this previous convention. However - as this is something that affects many parts of TemplatizedTypes and UnionTypes - there might be a better way to abstract this than how I implemented it. I'll leave that for discussion.

Regarding travis CI build: I merged master branch into my own this morning and it seems like the closure-compiler-version-SNAPSHOT.jar no longer builds? Not sure if this is an issue upstream or just my fork, would appreciate advice on this.