### PR TITLE
Remove historic Entity, EntityReference, NameList and Notation types

### DIFF
--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -390,14 +390,6 @@ Document.prototype.createDocumentFragment = function() {};
 Document.prototype.createElement = function(tagName, opt_typeExtension) {};
 
 /**
- * @param {string} name
- * @return {!EntityReference}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createEntityReference
- * @nosideeffects
- */
-Document.prototype.createEntityReference = function(name) {};
-
-/**
  * @param {string} target
  * @param {string} data
  * @return {!ProcessingInstruction}
@@ -785,73 +777,10 @@ function CDATASection() {}
 function DocumentType() {}
 
 /**
- * @type {NamedNodeMap<!Entity>}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1788794630
- */
-DocumentType.prototype.entities;
-
-/**
  * @type {string}
  * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1844763134
  */
 DocumentType.prototype.name;
-
-/**
- * @type {NamedNodeMap<!Notation>}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D46829EF
- */
-DocumentType.prototype.notations;
-
-/**
- * @constructor
- * @extends {Node}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-5431D1B9
- */
-function Notation() {}
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-54F2B4D0
- */
-Notation.prototype.publicId;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-E8AAB1D0
- */
-Notation.prototype.systemId;
-
-/**
- * @constructor
- * @extends {Node}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-527DCFF2
- */
-function Entity() {}
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D7303025
- */
-Entity.prototype.publicId;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D7C29F3E
- */
-Entity.prototype.systemId;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-6ABAEB38
- */
-Entity.prototype.notationName;
-
-/**
- * @constructor
- * @extends {Node}
- * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-11C98490
- */
-function EntityReference() {}
 
 /**
  * @constructor

--- a/externs/browser/w3c_dom3.js
+++ b/externs/browser/w3c_dom3.js
@@ -74,52 +74,6 @@ DOMStringList.prototype.item = function(index) {};
 
 /**
  * @constructor
- * @implements {IArrayLike<string>}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList
- */
-function NameList() {}
-
-/**
- * @type {number}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-length
- */
-NameList.prototype.length;
-
-/**
- * @param {string} str
- * @return {boolean}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-contains
- * @nosideeffects
- */
-NameList.prototype.contains = function(str) {};
-
-/**
- * @param {?string} namespaceURI
- * @param {string} name
- * @return {boolean}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-containsNS
- * @nosideeffects
- */
-NameList.prototype.containsNS = function(namespaceURI, name) {};
-
-/**
- * @param {number} index
- * @return {string}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-getName
- * @nosideeffects
- */
-NameList.prototype.getName = function(index) {};
-
-/**
- * @param {number} index
- * @return {string}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-getNamespaceURI
- * @nosideeffects
- */
-NameList.prototype.getNamespaceURI = function(index) {};
-
-/**
- * @constructor
  * @implements {IArrayLike<!DOMImplementation>}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMImplementationList
  */
@@ -832,21 +786,3 @@ DocumentType.prototype.publicId;
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-Core-DocType-systemId
  */
 DocumentType.prototype.systemId;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Entity3-inputEncoding
- */
-Entity.prototype.inputEncoding;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Entity3-encoding
- */
-Entity.prototype.xmlEncoding;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Entity3-version
- */
-Entity.prototype.xmlVersion;


### PR DESCRIPTION
They are no longer supported in modern browsers