### PR TITLE
Fix nullability of jQuery.makeArray extern

### DIFF
--- a/contrib/externs/jquery-3.3.js
+++ b/contrib/externs/jquery-3.3.js
@@ -1320,7 +1320,7 @@ jQuery.prototype.length;
 
 /**
  * @param {*} obj
- * @return {Array<*>}
+ * @return {!Array<*>}
  * @nosideeffects
  */
 jQuery.makeArray = function(obj) {};


### PR DESCRIPTION
Docs: https://api.jquery.com/jQuery.makeArray/
Code: https://code.jquery.com/jquery-3.3.0.js
```
	// results is for internal usage only
	makeArray: function( arr, results ) {
		var ret = results || [];

		if ( arr != null ) {
			if ( isArrayLike( Object( arr ) ) ) {
				jQuery.merge( ret,
					typeof arr === "string" ?
					[ arr ] : arr
				);
			} else {
				push.call( ret, arr );
			}
		}

		return ret;
	},
```