### PR TITLE
Remove some historic functions that not present in modern browsers

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -281,6 +281,8 @@ Document.prototype.tooltipNode;
  */
 Document.prototype.vlinkColor;
 
+/** @type {number} */ Document.prototype.width;
+
 // Methods of Document
 /**
  * @see https://developer.mozilla.org/en/DOM/document.clear

--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -167,7 +167,6 @@ Document.prototype.anchors;
  * @type {HTMLCollection<!HTMLAppletElement>}
  */
 Document.prototype.applets;
-/** @type {boolean} */ Document.prototype.async;
 /** @type {?string} */ Document.prototype.baseURI;
 
 /**
@@ -228,9 +227,6 @@ Document.prototype.fgColor;
  */
 Document.prototype.forms;
 
-/** @type {number} */
-Document.prototype.height;
-
 /** @type {HTMLCollection<!HTMLImageElement>} */
 Document.prototype.images;
 
@@ -285,8 +281,6 @@ Document.prototype.tooltipNode;
  */
 Document.prototype.vlinkColor;
 
-/** @type {number} */ Document.prototype.width;
-
 // Methods of Document
 /**
  * @see https://developer.mozilla.org/en/DOM/document.clear
@@ -313,11 +307,6 @@ Document.prototype.evaluate;
  */
 Document.prototype.execCommand;
 
-/**
- * @param {string} uri
- * @return {undefined}
- */
-Document.prototype.load = function(uri) {};
 Document.prototype.loadOverlay;
 
 /**

--- a/externs/browser/ie_dom.js
+++ b/externs/browser/ie_dom.js
@@ -121,14 +121,6 @@ XMLDOMDocument.prototype.abort = function() {};
 XMLDOMDocument.prototype.createNode = function(type, name, namespaceURI) {};
 
 /**
- * @param {string} xmlSource
- * @return {undefined}
- * @see http://msdn.microsoft.com/en-us/library/ms762722(VS.85).aspx
- * @override
- */
-XMLDOMDocument.prototype.load = function(xmlSource) {};
-
-/**
  * @param {string} xmlString
  * @return {boolean}
  * @see http://msdn.microsoft.com/en-us/library/ms754585(VS.85).aspx
@@ -690,11 +682,6 @@ Document.prototype.charset;
  * @see http://msdn.microsoft.com/en-us/library/ms533693(VS.85).aspx
  */
 Document.prototype.cookie;
-
-/**
- * @see http://msdn.microsoft.com/en-us/library/ms533714(VS.85).aspx
- */
-Document.prototype.defaultCharset;
 
 /**
  * @see http://msdn.microsoft.com/en-us/library/ms533731(VS.85).aspx

--- a/externs/browser/w3c_dom3.js
+++ b/externs/browser/w3c_dom3.js
@@ -155,12 +155,6 @@ Document.prototype.documentURI;
 Document.prototype.inputEncoding;
 
 /**
- * @type {boolean}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-strictErrorChecking
- */
-Document.prototype.strictErrorChecking;
-
-/**
  * @type {string}
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-encoding
  */
@@ -177,21 +171,6 @@ Document.prototype.xmlStandalone;
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-version
  */
 Document.prototype.xmlVersion;
-
-/**
- * @return {undefined}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-normalizeDocument
- */
-Document.prototype.normalizeDocument = function() {};
-
-/**
- * @param {Node} n
- * @param {?string} namespaceURI
- * @param {string} qualifiedName
- * @return {Node}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-renameNode
- */
-Document.prototype.renameNode = function(n, namespaceURI, qualifiedName) {};
 
 /**
  * @type {?string}
@@ -361,12 +340,6 @@ Node.prototype.querySelectorAll = function(query) {};
 Attr.prototype.ownerElement;
 
 /**
- * @type {boolean}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Attr-isId
- */
-Attr.prototype.isId;
-
-/**
  * @param {?string} namespaceURI
  * @param {string} localName
  * @return {Attr}
@@ -435,31 +408,6 @@ Element.prototype.setAttributeNodeNS = function(newAttr) {};
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetAttrNS
  */
 Element.prototype.setAttributeNS = function(namespaceURI, qualifiedName, value) {};
-
-/**
- * @param {string} name
- * @param {boolean} isId
- * @return {undefined}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetIdAttr
- */
-Element.prototype.setIdAttribute = function(name, isId) {};
-
-/**
- * @param {Attr} idAttr
- * @param {boolean} isId
- * @return {undefined}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetIdAttrNode
- */
-Element.prototype.setIdAttributeNode = function(idAttr, isId) {};
-
-/**
- * @param {?string} namespaceURI
- * @param {string} localName
- * @param {boolean} isId
- * @return {undefined}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetIdAttrNS
- */
-Element.prototype.setIdAttributeNS = function(namespaceURI, localName, isId) {};
 
 /**
  * @type {string}
@@ -587,12 +535,6 @@ DOMLocator.prototype.uri;
  * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-utf16Offset
  */
 DOMLocator.prototype.utf16Offset;
-
-/**
- * @type {string}
- * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-Core-DocType-internalSubset
- */
-DocumentType.prototype.internalSubset;
 
 /**
  * @type {string}

--- a/externs/browser/w3c_dom3.js
+++ b/externs/browser/w3c_dom3.js
@@ -340,6 +340,12 @@ Node.prototype.querySelectorAll = function(query) {};
 Attr.prototype.ownerElement;
 
 /**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Attr-isId
+ */
+Attr.prototype.isId;
+
+/**
  * @param {?string} namespaceURI
  * @param {string} localName
  * @return {Attr}


### PR DESCRIPTION
I can break this commit up if you prefer but given how old these properties are and how unlikely they are to be used, it seems like less work to perform change in a single commit