### PR TITLE
Changing HashMap to LinkedHashMap for deterministic iterations

### DIFF
--- a/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
+++ b/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -767,7 +768,7 @@ final class FunctionTypeBuilder {
 
     // Evaluate template type bounds with bootstrapped environment and reroute the bounds to these
     ImmutableList.Builder<TemplateType> templates = ImmutableList.builder();
-    HashMap<TemplateType, JSType> templatesToBounds = new HashMap<>();
+    Map<TemplateType, JSType> templatesToBounds = new LinkedHashMap<>();
     for (Map.Entry<String, JSTypeExpression> entry : infoTypeKeys.entrySet()) {
       JSType typeBound = typeRegistry.evaluateTypeExpression(entry.getValue(), templateScope);
       TemplateType template =


### PR DESCRIPTION
`com.google.javascript.jscomp.TypeInferenceTest#testNew4` can fail due to a different iteration order of a HashMap. The test parses some JS function with a specified order for the parameters, but the parameters are eventually inserted into a `HashMap` in `FunctionTypeBuilder`. When bounding the parameters, the `HashMap` in question is iterated over, but this iteration order is not guaranteed. However, the logic for building the templates implicitly assumes the order to be insertion order, as demonstrated by the test.  The proposed fix is to change the `HashMap` in question into a `LinkedHashMap` where order is guaranteed to be based on order of insertion.