### PR TITLE
Allow Number.is[Nan|Finite|Integer|SafeInteger] to take * input

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -1524,7 +1524,7 @@ Number.parseInt = function(string, radix) {};
 Number.parseFloat = function(string) {};
 
 /**
- * @param {number} value
+ * @param {*} value
  * @return {boolean}
  * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
@@ -1532,7 +1532,7 @@ Number.parseFloat = function(string) {};
 Number.isNaN = function(value) {};
 
 /**
- * @param {number} value
+ * @param {*} value
  * @return {boolean}
  * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite
@@ -1540,7 +1540,7 @@ Number.isNaN = function(value) {};
 Number.isFinite = function(value) {};
 
 /**
- * @param {number} value
+ * @param {*} value
  * @return {boolean}
  * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
@@ -1548,7 +1548,7 @@ Number.isFinite = function(value) {};
 Number.isInteger = function(value) {};
 
 /**
- * @param {number} value
+ * @param {*} value
  * @return {boolean}
  * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger


### PR DESCRIPTION
Spec gives the strong impression that any type could be
expected as input for these functions
https://www.ecma-international.org/ecma-262/6.0/#sec-number.isinteger

And practically, it is useful to allow code such as:

/** @type {number|string} */
let foo;

if (Number.isInteger(foo)) {
...
}

Currently, this code must be written as:

if (typeof foo == 'number' && Number.isInteger(foo)) {
...
}

See https://chromium-review.googlesource.com/c/apps/libapps/+/1816332