### PR TITLE
Improve ant task

### DIFF
--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -101,6 +101,7 @@ public final class CompileTask
   private File sourceMapOutputFile;
   private String sourceMapLocationMapping;
   private boolean applyInputSourceMaps;
+  private boolean strictModeInput;
 
   public CompileTask() {
     this.languageIn = CompilerOptions.LanguageMode.ECMASCRIPT_2015;
@@ -109,6 +110,7 @@ public final class CompileTask
     this.debugOptions = false;
     this.compilationLevel = CompilationLevel.SIMPLE_OPTIMIZATIONS;
     this.environment = CompilerOptions.Environment.BROWSER;
+    this.strictModeInput = true;
     this.manageDependencies = false;
     this.prettyPrint = false;
     this.printInputDelimiter = false;
@@ -213,6 +215,10 @@ public final class CompileTask
       throw new BuildException(
           "Unrecognized 'compilation' option value (" + value + ")");
     }
+  }
+  
+  public void setStrictModeInput(boolean strictModeInput) {
+    this.strictModeInput = strictModeInput;
   }
 
   public void setManageDependencies(boolean value) {
@@ -427,6 +433,7 @@ public final class CompileTask
     }
 
     options.setEnvironment(this.environment);
+    options.setStrictModeInput(this.strictModeInput);
 
     options.setPrettyPrint(this.prettyPrint);
     options.setPrintInputDelimiter(this.printInputDelimiter);

--- a/src/com/google/javascript/jscomp/ant/CompileTask.java
+++ b/src/com/google/javascript/jscomp/ant/CompileTask.java
@@ -127,25 +127,12 @@ public final class CompileTask
   }
 
   private static CompilerOptions.LanguageMode parseLanguageMode(String value) {
-    switch (value) {
-      case "ECMASCRIPT6_STRICT":
-      case "ES6_STRICT":
-      case "ECMASCRIPT6":
-      case "ES6":
-        return CompilerOptions.LanguageMode.ECMASCRIPT_2015;
-      case "ECMASCRIPT5_STRICT":
-      case "ES5_STRICT":
-        return CompilerOptions.LanguageMode.ECMASCRIPT5_STRICT;
-      case "ECMASCRIPT5":
-      case "ES5":
-        return CompilerOptions.LanguageMode.ECMASCRIPT5;
-      case "ECMASCRIPT3":
-      case "ES3":
-        return CompilerOptions.LanguageMode.ECMASCRIPT3;
-      default:
+    CompilerOptions.LanguageMode language = CompilerOptions.LanguageMode.fromString(value);
+    if (language == null) {
         throw new BuildException(
             "Unrecognized 'languageIn' option value (" + value + ")");
     }
+    return language;
   }
 
   /**


### PR DESCRIPTION
Two small improvements to ant CompileTask: exposing `strictModeInput` option, and using `LanguageMode.fromString()` to parse language modes instead of switch with few hardcoded modes.