### PR TITLE
Prevent renaming of the FS module method

### DIFF
--- a/src/com/google/javascript/jscomp/gwt/client/JsRunnerMain.java
+++ b/src/com/google/javascript/jscomp/gwt/client/JsRunnerMain.java
@@ -305,7 +305,7 @@ public final class JsRunnerMain {
       if (typeof process === 'object' && process.version) {
         jsFiles.push({
           path: jsFilePaths[i],
-          src: require('fs').readFileSync(jsFilePaths[i], 'utf8')
+          src: require('fs')['readFileSync'](jsFilePaths[i], 'utf8')
         });
       }
     }


### PR DESCRIPTION
The j2cl build does not recognize the readFileSync method utilized to read files when running in a Node environment. Use quoted syntax to prevent renaming of the method.