### PR TITLE
converts uppercase with Locale.US - TypeTransformationParser.Keywords

### DIFF
--- a/src/com/google/javascript/jscomp/TypeTransformation.java
+++ b/src/com/google/javascript/jscomp/TypeTransformation.java
@@ -36,6 +36,7 @@ import com.google.javascript.rhino.jstype.StaticTypedSlot;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Locale;
 
 /**
  * A class for processing type transformation expressions
@@ -129,7 +130,7 @@ class TypeTransformation {
   }
 
   private Keywords nameToKeyword(String s) {
-    return TypeTransformationParser.Keywords.valueOf(s.toUpperCase());
+    return TypeTransformationParser.Keywords.valueOf(s.toUpperCase(Locale.US));
   }
 
   private JSType getType(String typeName) {


### PR DESCRIPTION
Related issue can be found in `https://github.com/google/closure-compiler/issues/3490`.

To reproduce the problem, either you can set your OS language to Turkish or you can run the following code.

```
import java.util.Locale;

public class LocalTest {
    public static void main(String[] args) {
        String isUnknown = "isunknown";

        // -- without locale
        // in my case, default local instance is tr-TR
        String upperCase = isUnknown.toUpperCase();

        // local tr-TR
        Locale tr = new Locale("tr", "TR");
        String upperCaseWithLocaleTR = isUnknown.toUpperCase(tr);

        // locale en-US
        Locale us = Locale.US;
        String upperCaseWithLocaleUS = isUnknown.toUpperCase(us);

        // print results
        System.out.println("Default locale " + upperCase);
        System.out.println("With Locale tr-TR " + upperCaseWithLocaleTR);
        System.out.println("With Locale en-US " + upperCaseWithLocaleUS);
    }
}
```

and you can run with 

```
javac LocalTest.java
java -Duser.country=TR -Duser.language=tr LocalTest
```