### PR TITLE
Added to Element.insertAdjacent* to externs

### DIFF
--- a/externs/browser/w3c_dom4.js
+++ b/externs/browser/w3c_dom4.js
@@ -248,3 +248,30 @@ Document.prototype.getElementsByClassName = function(name) {};
  * @see https://dom.spec.whatwg.org/#dom-element-getelementsbyclassname-classnames-classnames
  */
 Element.prototype.getElementsByClassName = function(classNames) {};
+
+/**
+ * @param {string} where
+ * @param {Element} element
+ * @return {!Element}
+ * @throws {DOMException}
+ * @see https://dom.spec.whatwg.org/#dom-element-insertadjacentelement
+ */
+Element.prototype.insertAdjacentElement = function(where, element) {};
+
+/**
+ * @param {string} position
+ * @param {string} text
+ * @return {undefined}
+ * @throws {DOMException}
+ * @see https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml
+ */
+Element.prototype.insertAdjacentHTML = function(position, text) {};
+
+/**
+ * @param {string} where
+ * @param {string} data
+ * @return {undefined}
+ * @throws {DOMException}
+ * @see https://dom.spec.whatwg.org/#dom-element-insertadjacenttext
+ */
+Element.prototype.insertAdjacentText = function(where, data) {};

--- a/externs/browser/w3c_dom4.js
+++ b/externs/browser/w3c_dom4.js
@@ -260,7 +260,7 @@ Element.prototype.insertAdjacentElement = function(where, element) {};
 
 /**
  * @param {string} position
- * @param {string} text
+ * @param {(!TrustedHTML|string)} text
  * @return {undefined}
  * @throws {DOMException}
  * @see https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml


### PR DESCRIPTION
This is a pull request for (https://github.com/google/closure-compiler/issues/3516)

Adds support for `Element.insertAdjacentElement`, `Element.insertAdjacentHTML`, and `Element.insertAdjacentText`. These methods have good browser support have been added to `w3c_dom4.js`.