### PR TITLE
DocumentRange should be an interface

### DIFF
--- a/externs/browser/w3c_range.js
+++ b/externs/browser/w3c_range.js
@@ -239,7 +239,7 @@ Range.prototype.detach = function() {};
 
 // Introduced in DOM Level 2:
 /**
- * @constructor
+ * @interface
  * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-DocumentRange-idl
  */
 function DocumentRange() {}


### PR DESCRIPTION
From the linked spec, this is the idl, indicating that this should not have a constructor, but just be an interface.
```
// Introduced in DOM Level 2:
interface DocumentRange {
  Range              createRange();
};
```
Would it be more appropriate to also/instead declare `Document.prototype.createRange=function(){};` in this same file?