### PR TITLE
Move manifest generation into the package phase

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -327,7 +327,7 @@
         <executions>
           <execution>
             <id>bundle-manifest</id>
-            <phase>process-classes</phase>
+            <phase>package</phase>
             <goals>
               <goal>manifest</goal>
             </goals>


### PR DESCRIPTION
This speeds up local development by not blocking unit tests on
manifest generation.