### PR TITLE
Excluded j2lc compatible version of ResourceLoader.java in Maven build config

### DIFF
--- a/pom-gwt.xml
+++ b/pom-gwt.xml
@@ -288,7 +288,8 @@
             <exclude>**/super-gwt/**</exclude>
             <exclude>**/testing/**</exclude>
             <exclude>**/transpile/**</exclude>
-            <exclude>**/webservice/**</exclude>
+	    <exclude>**/webservice/**</exclude>
+	    <exclude>**/super-j2cl/**</exclude>
           </excludes>
           <testExcludes>
             <testExclude>**/bundle/**</testExclude>

--- a/pom-main.xml
+++ b/pom-main.xml
@@ -278,7 +278,8 @@
             <exclude>**/super-gwt/**</exclude>
             <exclude>**/super/**</exclude>
             <exclude>**/testing/**</exclude>
-            <exclude>**/webservice/**</exclude>
+	    <exclude>**/webservice/**</exclude>
+	    <exclude>**/super-j2cl/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/src/com/google/JsComp.gwt.xml
+++ b/src/com/google/JsComp.gwt.xml
@@ -23,7 +23,7 @@
   <inherits name="com.google.re2j.RE2J"/>
   <inherits name="elemental2.core.Core"/>
   <source path="debugging/sourcemap"/>
-  <source path="javascript/jscomp" excludes=".svn,.git,**/ant/**,**/refactoring/**,**/webservice/**,**/testing/**,**/transpile/**,**/linker/**,**/j2cl/**"/>
+  <source path="javascript/jscomp" excludes=".svn,.git,**/ant/**,**/refactoring/**,**/webservice/**,**/testing/**,**/transpile/**,**/linker/**,**/j2cl/**,**/super-j2cl/**"/>
   <source path="javascript/rhino" excludes=".svn,.git,**/testing/**"/>
   <super-source path="javascript/jscomp/gwt/super"/>
   <super-source path="javascript/jscomp/resources/super-gwt"/>


### PR DESCRIPTION
To fix Travis build by excluding conflicting J2cl compatible version of ResourceLoader.java in the maven build config.