### PR TITLE
Adding WebStorage to the list of default browser externs.

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -90,9 +90,6 @@ Window.prototype.scrollMaxX;
  */
 Window.prototype.scrollMaxY;
 
-/** @see https://developer.mozilla.org/en/DOM/Storage#sessionStorage */
-Window.prototype.sessionStorage;
-
 /** @see https://developer.mozilla.org/en/DOM/window.sidebar */
 Window.prototype.sidebar;
 

--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -72,11 +72,6 @@ Window.prototype.directories;
  */
 Window.prototype.fullScreen;
 
-/**
- * @see https://developer.mozilla.org/en/DOM/Storage#globalStorage
- */
-Window.prototype.globalStorage;
-
 /** @see https://developer.mozilla.org/en/DOM/window.pkcs11 */
 Window.prototype.pkcs11;
 

--- a/externs/browser/w3c_dom1.js
+++ b/externs/browser/w3c_dom1.js
@@ -858,3 +858,4 @@ Window.prototype.onerror;
 /** @type {?function (Event)} */ Window.prototype.onunhandledrejection;
 /** @type {?function (Event)} */ Window.prototype.onunload;
 /** @type {?function (Event)} */ Window.prototype.onwheel;
+/** @type {?function (Event)} */ Window.prototype.onstorage;

--- a/externs/browser/webstorage.js
+++ b/externs/browser/webstorage.js
@@ -15,7 +15,7 @@
  */
 /**
  * @fileoverview Definitions for W3C's WebStorage specification.
- * This file depends on html5.js.
+ * This file depends on w3c_dom1.js and w3c_event.js.
  * @externs
  */
 

--- a/src/com/google/javascript/jscomp/DefaultExterns.java
+++ b/src/com/google/javascript/jscomp/DefaultExterns.java
@@ -55,6 +55,7 @@ public final class DefaultExterns {
           "ie_css.js",
           "webkit_css.js",
           "w3c_touch_event.js",
+          "webstorage.js",
           "whatwg_console.js",
           "nonstandard_console.js",
           // w3d_rtc.js must be evaluated before nonstandard_rtc.js


### PR DESCRIPTION
Removed `globalStorage` from `geko_dom.js` as it is deprecated and doesn't work since FF13.
Removed `sessionStorage` from `geko_dom.js` as it is defined in `webstorage.js`.

Changed dependency comment in `webstorage.js` because I couldn't find any dependencies on `html5.js`. But I found dependencies on: `Event` from `w3c_event.js`, `EventInit` from `w3c_event.js` and `Window` from `w3c_dom1.js`.
Probably previously, 11 years ago, before WebStorage became stable it had a different set of dependencies. But as of right now it doesn't depend on `html5.js`.

Added missing `storage` event to `w3c_dom1.js`

Added `webstorage.js` to `BROWSER_EXTERN_DEP_ORDER` to make it a default extern.

---

Partialy fixes #2480, This PR doesn't fix issue with the `Proxy` declaration.