### PR TITLE
Fixed re-declared namespace to match filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/
 /bin
 /yarn.lock
 /node_modules
+/.metadata/

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/polyfill_isolation_chrome_test.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/polyfill_isolation_chrome_test.js
@@ -19,7 +19,7 @@
  * symbols if present. (This is tested for by checking for a native Symbol
  * implementation.)
  */
-goog.module('jscomp.runtime_tests.polyfill_tests.polyfill_isolation_test');
+goog.module('jscomp.runtime_tests.polyfill_tests.polyfill_isolation_chrome_test');
 goog.setTestOnly();
 
 const testSuite = goog.require('goog.testing.testSuite');

--- a/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/polyfill_isolation_ie_test.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/polyfill_tests/polyfill_isolation_ie_test.js
@@ -18,7 +18,7 @@
  * @fileoverview Test that --isolate_polyfills prevents injection of polyfills
  * directly into the global scope.
  */
-goog.module('jscomp.runtime_tests.polyfill_tests.polyfill_isolation_test');
+goog.module('jscomp.runtime_tests.polyfill_tests.polyfill_isolation_ie_test');
 goog.setTestOnly();
 
 const testSuite = goog.require('goog.testing.testSuite');


### PR DESCRIPTION
Removes an error thrown by Closure Builder when run with `--root test/com/google/javascript/jscomp/runtime_tests`. 