### PR TITLE
Fix Travis CI issue with GWT composed sourcemaps

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -295,7 +295,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   private static class ResolvedSourceMap {
     public String originalPath;
     public String sourceMapPath;
-    public SourceFile sourceFile;
+    public String relativePath;
   }
 
   /**
@@ -2891,15 +2891,15 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     // First check to see if the original file was loaded from an input source map.
     String sourceMapOriginalPath = sourceMap.getOriginalPath();
     String resultOriginalPath = result.getOriginalFile();
-    SourceFile source = null;
+    final String relativePath;
 
     // Resolving the paths to a source file is expensive, so check the cache first.
     if (sourceMapOriginalPath.equals(resolvedSourceMap.originalPath)
         && resultOriginalPath.equals(resolvedSourceMap.sourceMapPath)) {
-      source = resolvedSourceMap.sourceFile;
+      relativePath = resolvedSourceMap.relativePath;
     } else {
-      String relativePath = resolveSibling(sourceMapOriginalPath, resultOriginalPath);
-      source = getSourceFileByName(relativePath);
+      relativePath = resolveSibling(sourceMapOriginalPath, resultOriginalPath);
+      SourceFile source = getSourceFileByName(relativePath);
       if (source == null && !isNullOrEmpty(resultOriginalPath)) {
         source =
             SourceMapResolver.getRelativePath(
@@ -2912,11 +2912,11 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       // Cache this resolved source for the next caller.
       resolvedSourceMap.originalPath = sourceMapOriginalPath;
       resolvedSourceMap.sourceMapPath = resultOriginalPath;
-      resolvedSourceMap.sourceFile = source;
+      resolvedSourceMap.relativePath = relativePath;
     }
 
     return result.toBuilder()
-        .setOriginalFile(source.getOriginalPath())
+        .setOriginalFile(relativePath)
         .setColumnPosition(result.getColumnPosition() - 1)
         .build();
   }


### PR DESCRIPTION
The GWT compiler supersources do not support `SourceMapResolver#getRelativePath`. This means https://github.com/google/closure-compiler/commit/dac995ac563bfe3170280899112699845768e135 caused a regression that only affected the GWT version of the compiler, as it started relying on getRelativePath.

Partially addresses https://github.com/google/closure-compiler/issues/3631.