### PR TITLE
Implementation of branch instrumentation

### DIFF
--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2617,7 +2617,7 @@ public final class CommandLineRunnerTest {
             "module$exports$instrument$code.instrumentCodeInstance = new"
                 + " module$contents$instrument$code_InstrumentCode;",
             "function foo() {",
-            "  module$exports$instrument$code.instrumentCodeInstance.instrumentCode(\"C\", 1);",
+            "  module$exports$instrument$code.instrumentCodeInstance.instrumentCode(\"C\", 1, 0);",
             "  console.log(\"Hello\");",
             "}",
             ";");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2638,7 +2638,7 @@ public final class CommandLineRunnerTest {
     assertThat(variableMapFile.get(0)).startsWith(" FileNames:[");
     assertThat(variableMapFile.get(0)).endsWith("sourceCode.js]");
     assertThat(variableMapFile.get(1)).isEqualTo(" FunctionNames:[foo]");
-    assertThat(variableMapFile.get(2)).isEqualTo(" Types:[Type.FUNCTION]");
+    assertThat(variableMapFile.get(2)).isEqualTo(" Types:[FUNCTION]");
     assertThat(variableMapFile.get(3)).isEqualTo("C:AAA");
   }
 

--- a/test/com/google/javascript/jscomp/integration/ProductionCoverageInstrumentationPassIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/integration/ProductionCoverageInstrumentationPassIntegrationTest.java
@@ -352,7 +352,7 @@ public final class ProductionCoverageInstrumentationPassIntegrationTest
         .isEqualTo("[i1.js]");
     assertWithMessage("Types in the parameter mapping are not properly set")
         .that(paramMap.get(" Types"))
-        .isEqualTo("[Type.FUNCTION]");
+        .isEqualTo("[FUNCTION]");
     assertWithMessage("Array index encoding is not performed properly")
         .that(paramMap.get("C"))
         .isEqualTo("AAA");

--- a/test/com/google/javascript/jscomp/integration/ProductionCoverageInstrumentationPassIntegrationTest.java
+++ b/test/com/google/javascript/jscomp/integration/ProductionCoverageInstrumentationPassIntegrationTest.java
@@ -58,6 +58,15 @@ public final class ProductionCoverageInstrumentationPassIntegrationTest
           "module$exports$instrument$code.instrumentCodeInstance = ",
           "new module$contents$instrument$code_InstrumentCode;");
 
+  private final String noTranspilationInstrumentCodeExpected =
+      lines(
+          "var module$exports$instrument$code = {}",
+          "class module$contents$instrument$code_InstrumentCode {",
+          "   instrumentCode(a, b) {};",
+          "}",
+          "module$exports$instrument$code.instrumentCodeInstance = ",
+          "new module$contents$instrument$code_InstrumentCode;");
+
   @Test
   public void testFunctionInstrumentation() {
     CompilerOptions options = createCompilerOptions();
@@ -69,8 +78,8 @@ public final class ProductionCoverageInstrumentationPassIntegrationTest
     String expected =
         lines(
             "function foo() { ",
-            "   module$exports$instrument$code.instrumentCodeInstance.instrumentCode(\"C\", 1);",
-            "   console.log('Hello'); ",
+               getInstrumentCodeLine("C", 1, 0), ";",
+            "  console.log('Hello'); ",
             "}");
 
     String[] expectedArr = {instrumentCodeExpected, expected};
@@ -101,23 +110,192 @@ public final class ProductionCoverageInstrumentationPassIntegrationTest
 
     String[] sourceArr = {instrumentCodeSource, source};
 
-    String noTranspilationInstrumentCodeExpected =
-        lines(
-            "var module$exports$instrument$code = {}",
-            "class module$contents$instrument$code_InstrumentCode {",
-            "   instrumentCode(a, b) {};",
-            "}",
-            "module$exports$instrument$code.instrumentCodeInstance = ",
-            "new module$contents$instrument$code_InstrumentCode;");
-
     String expected =
         lines(
             "function foo() { ",
-            "   module$exports$instrument$code.instrumentCodeInstance.instrumentCode(\"C\", 1);",
+                getInstrumentCodeLine("C", 1, 0), ";",
             "   console.log('Hello'); ",
             "}");
 
     String[] expectedArr = {noTranspilationInstrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testIfInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source =
+        lines(
+            "if (tempBool) {",
+            "   console.log('Hello');",
+            "}");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "if (tempBool) { ",
+               getInstrumentCodeLine("C", 1, 0), ";",
+            "  console.log('Hello'); ",
+            "} else {",
+               getInstrumentCodeLine("E", 1, 0), ";",
+            "}");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testOrInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source =
+        lines("tempObj.a || tempObj.b;");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "tempObj.a || (",
+            getInstrumentCodeLine("C", 1, 13), ", tempObj.b)");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testAndInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source =
+        lines("tempObj.a && tempObj.b;");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "tempObj.a && (",
+            getInstrumentCodeLine("C", 1, 13), ", tempObj.b)");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testCoalesceInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    options.setLanguageIn(LanguageMode.ECMASCRIPT_2020);
+    options.setLanguageOut(LanguageMode.NO_TRANSPILE);
+
+    String source = lines("someObj ?? 24");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "someObj ?? (",
+            getInstrumentCodeLine("C", 1, 11), ", 24)");
+
+    String[] expectedArr = {noTranspilationInstrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testTernaryInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source = lines("flag ? foo() : fooBar()");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "flag ? (",
+            getInstrumentCodeLine("C", 1, 7), ", foo()) :",
+            "(",
+            getInstrumentCodeLine("C", 1, 15), ", fooBar())");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testForLoopInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source =
+        lines(
+            "for(var i = 0 ; i < 10 ; ++i) {",
+            "   console.log('*');",
+            "}");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "for(var i = 0 ; i < 10 ; ++i) {",
+                getInstrumentCodeLine("C", 1, 0), ";",
+            "   console.log('*');",
+            "}",
+            getInstrumentCodeLine("E", 1, 0), ";");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testSwitchInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source =
+        lines(
+            "switch (x) {",
+            "   case 1: ",
+            "      x = 5;",
+            "};");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "switch (x) {",
+            "   case 1: ",
+                   getInstrumentCodeLine("C", 2, 3), ";",
+            "      x = 5;",
+            "   default: ",
+                   getInstrumentCodeLine("E", 1, 0), ";",
+            "};");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
+    test(options, sourceArr, expectedArr);
+  }
+
+  @Test
+  public void testNestedIfInstrumentation() {
+    CompilerOptions options = createCompilerOptions();
+
+    String source =
+        lines("if (tempBool) if(someBool) console.log('*');");
+
+    String[] sourceArr = {instrumentCodeSource, source};
+
+    String expected =
+        lines(
+            "if (tempBool) {",
+                getInstrumentCodeLine("C", 1, 0), ";",
+            "  if (someBool) {",
+                 getInstrumentCodeLine("C", 1, 14), ";",
+            "    console.log('*');",
+            "   } else {",
+                  getInstrumentCodeLine("E", 1, 14), ";",
+            "   }",
+            "} else {",
+              getInstrumentCodeLine("E", 1, 0), ";",
+            "}");
+
+    String[] expectedArr = {instrumentCodeExpected, expected};
     test(options, sourceArr, expectedArr);
   }
 
@@ -148,6 +326,11 @@ public final class ProductionCoverageInstrumentationPassIntegrationTest
     assertWithMessage("Array index encoding is not performed properly")
         .that(paramMap.get("C"))
         .isEqualTo("AAA");
+  }
+
+  private String getInstrumentCodeLine(String encodedParam, int lineNo, int colNo){
+    return "module$exports$instrument$code.instrumentCodeInstance.instrumentCode(\"" +
+        encodedParam + "\", " + lineNo + ", " + colNo + ")";
   }
 
   @Override


### PR DESCRIPTION
Implemented branch instrumented. This PR is part of a series of PRs to implemented production type code instrumentation. The details of the entire proposal can be found in this [Implementation Doc](https://docs.google.com/document/d/1cdseVYW0x8LWccxYbT6GavrhjL00AA9SoafxAkqyu-8/edit?usp=sharing). 

This PR adds instrumentation to `If` statements, loop structures, `switch` statements,  `||`, `&&` , `??` operations, and ternary operations. It also adds unit tests for all these cases.

Another change was the addition of passing the column number to the `InstrumentCode` function to help distinguish between nested operators. In addition to this, I also created a new type, `Type.BRANCH_DEFAULT` which will help to distinguish if a statement is an `else, default` case. This should make it easier to later determine if code is always executed
and an if statement is not needed. The new type is also used for the line after a loop structure to make it possible to distinguish between the instrumented line in the loop vs outside the loop.

A final modification was to the unit test structure, by adding a function called `getInstrumentCodeLine(...)` which returns the InstrumentCode function call as a string. This helps with maintainability if the function is ever changed, and it also makes it easier to write unit tests and is less prone to human error. 