### PR TITLE
Improve unicode escape in regex

### DIFF
--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -4895,6 +4895,14 @@ public final class ParserTest extends BaseJSTypeTestCase {
   }
 
   @Test
+  public void testRegExpUnicode() {
+    assertNodeEquality(parse("/\\u10fA/"), script(expr(regex("\\u10fA"))));
+    assertNodeEquality(parse("/\\u{10fA}/u"), script(expr(regex("\\u{10fA}", "u"))));
+    assertNodeEquality(parse("/\\u{1fA}/u"), script(expr(regex("\\u{1fA}", "u"))));
+    assertNodeEquality(parse("/\\u{10FFFF}/u"), script(expr(regex("\\u{10FFFF}", "u"))));
+  }
+
+  @Test
   public void testRegExpFlags() {
     // Various valid combinations.
     parse("/a/");
@@ -6554,6 +6562,10 @@ public final class ParserTest extends BaseJSTypeTestCase {
 
   private static Node regex(String regex) {
     return new Node(Token.REGEXP, Node.newString(regex));
+  }
+
+  private static Node regex(String regex, String flag) {
+    return new Node(Token.REGEXP, Node.newString(regex), Node.newString(flag));
   }
 
   /**

--- a/test/com/google/javascript/jscomp/regex/RegExpTreeTest.java
+++ b/test/com/google/javascript/jscomp/regex/RegExpTreeTest.java
@@ -193,4 +193,30 @@ public class RegExpTreeTest {
     // (?: ) in expected output serves same purpose as above test
     assertRegexCompilesTo("[(?<foo>)]\\k<foo>", "", "(?:[()<>?fo]k)<foo>");
   }
+
+  @Test
+  public void testValidUnicodeEscape() {
+    assertRegexCompilesTo("\\u0061", "", "a");
+    assertRegexCompilesTo("\\u10b1", "u", "\\u10b1");
+    assertRegexCompilesTo("\\u{61}", "u", "a");
+    assertRegexCompilesTo("\\u{10b1}", "u", "\\u10b1");
+    assertRegexCompilesTo("\\u{1bc}", "u", "\\u01bc");
+    assertRegexCompilesTo("\\u{100A3}", "u", "\\ud800\\udca3");
+  }
+
+  @Test
+  public void testInvalidUnicodeEscape() {
+    assertRegexThrowsExceptionThat("\\u{a012", "u")
+        .hasMessageThat()
+        .isEqualTo("Malformed unicode escape: expected '}' after {a012");
+    assertRegexThrowsExceptionThat("\\u{}", "u")
+        .hasMessageThat()
+        .isEqualTo("Invalid unicode escape: {}");
+    assertRegexThrowsExceptionThat("\\u{10za}", "u")
+        .hasMessageThat()
+        .isEqualTo("Invalid character in unicode escape: z");
+    assertRegexThrowsExceptionThat("\\u{FFFFFF}", "u")
+        .hasMessageThat()
+        .isEqualTo("Unicode must not be greater than 0x10FFFF: {FFFFFF}");
+  }
 }


### PR DESCRIPTION
This PR supports regex Unicode escape in curly brackets format, provided that the 'u' flag presents.

For example:

```javascript
let x = /\u{01ac}/u;
```

Also, it extends Unicode up to 0x10FFFF. For example:

```javascript
let x = /\u{10FFFF}/u;
```

I believe this PR also fixes issue #3563.