### PR TITLE
Try reducing bazel memory to fix travis build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,1 @@
-# Recommended bazel settings for working with J2CL.
-#
-# Copied from https://github.com/google/j2cl/blob/master/.bazelrc since Bazel
-# doesn't support referring to .bazelrc from different workspaces.
-
-build --watchfs
-
-build --spawn_strategy=local
-build --strategy=J2cl=worker
-build --strategy=Closure=worker
-build --experimental_persistent_javac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_script:
   - echo "common --noshow_progress" >> .bazelrc
   - echo "build --noshow_loading_progress" >> .bazelrc
   - echo "build --verbose_failures" >> .bazelrc
+  - echo "build --discard_analysis_cache" >> .bazelrc
+  - echo "build --nokeep_state_after_build" >> .bazelrc
+  - echo "build --notrack_incremental_state" >> .bazelrc
 
 script:
   # Builds the compiler and runs tests


### PR DESCRIPTION
Adds three flags to the bazel build:
--discard_analysis_cache
--nokeep_state_after_build
--notrack_incremental_state

They're defined here - https://docs.bazel.build/versions/master/memory-saving-mode.html