### PR TITLE
Add EventTarget to TextTrackList

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -2294,6 +2294,7 @@ Text.prototype.getDestinationInsertionPoints = function() {};
 /**
  * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#texttracklist
  * @constructor
+ * @implements {EventTarget}
  * @implements {IArrayLike<!TextTrack>}
  */
 function TextTrackList() {}


### PR DESCRIPTION
According to the second paragraph of [TextTrackList on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/textTracks), `TextTrackList` should implement `EventTarget` so that one can listen for `addtrack` and `removetrack` events on the list.