### PR TITLE
Add support for Screen Wake Lock API

### DIFF
--- a/externs/browser/w3c_screen_wake_lock.js
+++ b/externs/browser/w3c_screen_wake_lock.js
@@ -1,0 +1,43 @@
+/**
+ * Screen Wake Lock API
+ * W3C Editor's Draft 01 September 2020
+ * @externs
+ * @see https://w3c.github.io/screen-wake-lock/
+ */
+
+
+/** @type {!WakeLock} */
+Navigator.prototype.wakeLock;
+
+
+/**
+ * @interface
+ * @see https://w3c.github.io/screen-wake-lock/#the-wakelock-interface
+ */
+function WakeLock() {};
+
+/**
+ * @param {string} type
+ * @return {!Promise<!WakeLockSentinel>}
+ */
+WakeLock.prototype.request = function(type) {};
+
+
+/**
+ * @interface
+ * @extends {EventTarget}
+ * @see https://w3c.github.io/screen-wake-lock/#the-wakelocksentinel-interface
+ */
+function WakeLockSentinel() {};
+
+/** @type {?function(!Event)} */
+WakeLockSentinel.prototype.onrelease;
+
+/** @return {!Promise<void>} */
+WakeLockSentinel.prototype.release = function() {};
+
+/** @type {boolean} @const */
+WakeLockSentinel.prototype.released;
+
+/** @type {string} @const */
+WakeLockSentinel.prototype.type;


### PR DESCRIPTION
This API is now enabled by default in Chrome.

See https://www.chromestatus.com/feature/4636879949398016
See https://w3c.github.io/screen-wake-lock/