### PR TITLE
Add logic for serializing the types on the AST, and deserializing them

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -125,6 +125,7 @@ oss_java_library(
                 "src/com/google/javascript/jscomp/modules/**/*.java",
                 "src/com/google/javascript/jscomp/parsing/**/*.java",
                 "src/com/google/javascript/jscomp/regex/**/*.java",
+                "src/com/google/javascript/jscomp/serialization/**/*.java",
                 "src/com/google/javascript/jscomp/transpile/**/*.java",
                 "src/com/google/javascript/jscomp/type/**/*.java",
                 "src/com/google/javascript/refactoring/**/*.java",
@@ -145,6 +146,7 @@ oss_java_library(
         deps = [
             "//src/com/google/debugging/sourcemap/proto:mapping_java_proto",
             "//src/com/google/javascript/jscomp/conformance:conformance_java_proto",
+            "//src/com/google/javascript/rhino/typed_ast:typed_ast_java_proto",
             "@args4j_args4j",
             "@com_google_code_gson_gson",
             "@com_google_guava_failureaccess//jar",
@@ -207,6 +209,7 @@ gen_java_tests(
         ":compiler_tests_resources",
         "//src/com/google/debugging/sourcemap/proto:mapping_java_proto",
         "//src/com/google/javascript/jscomp/conformance:conformance_java_proto",
+        "//src/com/google/javascript/rhino/typed_ast:typed_ast_java_proto",
         "@args4j_args4j",
         "@com_google_code_gson_gson",
         "@com_google_guava_failureaccess//jar",
@@ -275,6 +278,7 @@ j2cl_library(
             "src/com/google/javascript/jscomp/regex/**/*.java",
             "src/com/google/javascript/jscomp/parsing/**/*.java",
             "src/com/google/javascript/jscomp/modules/**/*.java",
+            # "src/com/google/javascript/jscomp/serialization/**/*.java",
             "src/com/google/javascript/jscomp/type/**/*.java",
             "src/com/google/javascript/jscomp/graph/**/*.java",
             "src/com/google/javascript/jscomp/resources/GwtProperties.*",
@@ -286,6 +290,7 @@ j2cl_library(
             "src/com/google/javascript/jscomp/gwt/super/**/*.js",
         ],
         exclude = [
+            "src/com/google/javascript/rhino/serialization/**/*.java",
             "**/super-gwt/**",
             "**/testing/**",
             "src/com/google/javascript/jscomp/deps/PathUtil.java",
@@ -293,6 +298,7 @@ j2cl_library(
     ),
     js_suppress = ["deprecated"],
     deps = [
+        # "//src/com/google/javascript/rhino/typed_ast:typed_ast_j2cl_proto",
         ":auto_value-j2cl",
         "@com_google_code_findbugs_jsr305-j2cl",
         "@com_google_elemental2//:elemental2-core-j2cl",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -77,6 +77,15 @@ load("@com_google_j2cl//build_defs:rules.bzl", "setup_j2cl_workspace", "j2cl_mav
 
 setup_j2cl_workspace()
 
+git_repository(
+    name = "protobuf_j2cl_rules",
+    commit = "abd9123e04713c9d8243c658970a438b4a4a0bf8",
+    remote = "git://github.com/google/j2cl-protobuf.git",
+)
+
+load("@protobuf_j2cl_rules//:repository.bzl", "load_j2cl_proto_repo_deps")
+load_j2cl_proto_repo_deps()
+
 
 ## Load Elemental2 repo ##
 

--- a/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/serialization/ConvertTypesToColors.java
+++ b/src/com/google/javascript/jscomp/gwt/super/com/google/javascript/jscomp/serialization/ConvertTypesToColors.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.serialization;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.CompilerPass;
+import com.google.javascript.rhino.Node;
+
+/**
+ * Ideally, we wouldn't have this super-source at all, and instead use the real version of this pass
+ * along with the j2cl-compatible proto library at https://github.com/google/j2cl-protobuf
+ */
+public final class ConvertTypesToColors implements CompilerPass {
+  public ConvertTypesToColors(AbstractCompiler compiler) {}
+
+  @Override
+  public void process(Node externs, Node root) {}
+}

--- a/src/com/google/javascript/jscomp/serialization/ColorDeserializer.java
+++ b/src/com/google/javascript/jscomp/serialization/ColorDeserializer.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.serialization;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.javascript.jscomp.colors.Color;
+import com.google.javascript.jscomp.colors.DebugInfo;
+import com.google.javascript.jscomp.colors.ObjectColor;
+import com.google.javascript.jscomp.colors.PrimitiveColor;
+import com.google.javascript.jscomp.colors.UnionColor;
+import com.google.javascript.jscomp.serialization.TypePointer.TypeCase;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+/**
+ * Convert a {@link TypePool} (from a single compilation) into {@link Color}s.
+ *
+ * <p>Future work will be necessary to let this class convert multiple type-pools coming from
+ * different libraries. For now it only handles a single type-pool.
+ */
+public class ColorDeserializer {
+  private final ImmutableList<Color> typeColors; // indexes correspond to the typePool indices
+
+  /** Error emitted when the deserializer sees a serialized type it cannot support deserialize */
+  public static final class InvalidSerializedFormatException extends RuntimeException {
+    public InvalidSerializedFormatException(String msg) {
+      super("Invalid serialized Type format: " + msg);
+    }
+  }
+
+  private ColorDeserializer(ImmutableList<Color> typeColors) {
+    this.typeColors = typeColors;
+  }
+
+  public static ColorDeserializer buildFromTypePool(TypePool typePool) {
+    Deserializer deserializer = new Deserializer(typePool);
+    deserializer.deserializePool();
+
+    return new ColorDeserializer(ImmutableList.copyOf(deserializer.typeColors));
+  }
+
+  // Class to do the actual work of deserialization.
+  private static final class Deserializer {
+    final ArrayList<Color> typeColors; // filled in as we go. initially all null
+
+    // to avoid infinite recursion on types in cycles
+    final Set<Type> currentlyDeserializing = new LinkedHashSet<>();
+    // keys are indices into the type pool and values are pointers to its supertypes
+    final Multimap<Integer, TypePointer> disambiguationEdges = LinkedHashMultimap.create();
+    private final TypePool typePool;
+
+    Deserializer(TypePool typePool) {
+      this.typePool = typePool;
+      this.typeColors = new ArrayList<>();
+      typeColors.addAll(Collections.nCopies(typePool.getTypeCount(), null));
+    }
+
+    private void deserializePool() {
+      for (SubtypingEdge edge : typePool.getDisambiguationEdgesList()) {
+        TypePointer subtype = edge.getSubtype();
+        TypePointer supertype = edge.getSupertype();
+        if (subtype.getTypeCase() != TypeCase.POOL_OFFSET
+            || supertype.getTypeCase() != TypeCase.POOL_OFFSET) {
+          throw new InvalidSerializedFormatException(
+              "Subtyping only supported for pool offsets, found " + subtype + " , " + supertype);
+        }
+        disambiguationEdges.put(subtype.getPoolOffset(), supertype);
+      }
+      for (int i = 0; i < typePool.getTypeCount(); i++) {
+        deserializeTypeFromPoolIfEmpty(i);
+      }
+    }
+
+    /**
+     * Given an index into the type pool, creating its corresponding color if not already
+     * deserialized.
+     */
+    private void deserializeTypeFromPoolIfEmpty(int i) {
+      if (typeColors.get(i) != null) {
+        return;
+      }
+      Color color = deserializeType(i, typePool.getTypeList().get(i));
+      typeColors.set(i, color);
+    }
+
+    /**
+     * Safely deserializes a type after verifying it's not going to cause infinite recursion
+     *
+     * <p>Currently this always initializes a new {@link Color} and we assume there are no duplicate
+     * types in the serialized type pool.
+     */
+    private Color deserializeType(int i, Type serialized) {
+      if (currentlyDeserializing.contains(serialized)) {
+        throw new InvalidSerializedFormatException(
+            "Cannot deserialize type in cycle " + serialized);
+      }
+      currentlyDeserializing.add(serialized);
+
+      Color newColor = deserializeTypeAssumingSafe(i, serialized);
+
+      currentlyDeserializing.remove(serialized);
+      return newColor;
+    }
+
+    /** Creates a color from a Type without checking for any type cycles */
+    private Color deserializeTypeAssumingSafe(int offset, Type serialized) {
+      switch (serialized.getKindCase()) {
+        case OBJECT:
+          return createObjectColor(offset, serialized.getObject());
+        case UNION:
+          return createUnionColor(serialized.getUnion());
+        case KIND_NOT_SET:
+          throw new InvalidSerializedFormatException(
+              "Expected all Types to have a Kind, found " + serialized);
+      }
+      throw new AssertionError();
+    }
+
+    private Color createObjectColor(int offset, ObjectType serialized) {
+      ImmutableList<Color> directSupertypes =
+          this.disambiguationEdges.get(offset).stream()
+              .map(this::dereferenceTypePointer)
+              .collect(toImmutableList());
+      ObjectColor.Builder builder =
+          ObjectColor.builder()
+              .setId(serialized.getUuid())
+              .setInvalidating(serialized.getIsInvalidating())
+              .setDisambiguationSupertypes(directSupertypes)
+              .setDebugInfo(
+                  DebugInfo.builder()
+                      .setFilename(serialized.getFilename())
+                      .setClassName(serialized.getClassName())
+                      .build());
+      if (serialized.hasPrototype()) {
+        builder.setPrototype(dereferenceTypePointer(serialized.getPrototype()));
+      }
+      if (serialized.hasInstanceType()) {
+        builder.setInstanceColor(dereferenceTypePointer(serialized.getInstanceType()));
+      }
+      return builder.build();
+    }
+
+    private Color createUnionColor(UnionType serialized) {
+      if (serialized.getUnionMemberCount() <= 1) {
+        throw new InvalidSerializedFormatException(
+            "Unions must have >= 2 elements, found " + serialized);
+      }
+      ImmutableSet<Color> allAlternates =
+          serialized.getUnionMemberList().stream()
+              .map(this::dereferenceTypePointer)
+              .collect(toImmutableSet());
+      if (allAlternates.size() == 1) {
+        return Iterables.getOnlyElement(allAlternates);
+      } else {
+        return UnionColor.create(allAlternates);
+      }
+    }
+
+    private Color dereferenceTypePointer(TypePointer typePointer) {
+      return ColorDeserializer.dereferenceTypePointer(
+          typePointer, this.typeColors, this::deserializeTypeFromPoolIfEmpty);
+    }
+  }
+
+  @SuppressWarnings("UnnecessaryDefaultInEnumSwitch") // needed for J2CL protos
+  private static PrimitiveColor nativeTypeToPrimitive(NativeType nativeType) {
+    switch (nativeType) {
+      case NUMBER_TYPE:
+        return PrimitiveColor.NUMBER;
+      case NULL_OR_VOID_TYPE:
+        return PrimitiveColor.NULL_OR_VOID;
+      case STRING_TYPE:
+        return PrimitiveColor.STRING;
+      case SYMBOL_TYPE:
+        return PrimitiveColor.SYMBOL;
+      case BIGINT_TYPE:
+        return PrimitiveColor.BIGINT;
+      case UNKNOWN_TYPE:
+        return PrimitiveColor.UNKNOWN;
+      case BOOLEAN_TYPE:
+        return PrimitiveColor.BOOLEAN;
+      case OBJECT_FUNCTION_TYPE:
+      case OBJECT_PROTOTYPE:
+      case OBJECT_TYPE:
+      case FUNCTION_FUNCTION_TYPE:
+      case FUNCTION_PROTOTYPE:
+      case FUNCTION_TYPE:
+      case REGEXP_FUNCTION_TYPE:
+      case REGEXP_TYPE:
+        return null;
+      default:
+        // Switch cannot be exhaustive because Java protos add an additional "UNRECOGNIZED" field
+        // while J2CL protos do not.
+        throw new InvalidSerializedFormatException("unrecognized nativetype " + nativeType);
+    }
+  }
+
+  public Color pointerToColor(TypePointer typePointer) {
+    return dereferenceTypePointer(typePointer, this.typeColors, /* createNewColor= */ null);
+  }
+
+  /**
+   * Converts a type pointer into a corresponding Color
+   *
+   * @param createNewColor given an index into the type pool, creates a new Color and stores it in
+   *     the {@code typePool} parameter obbject. If null, this method will throw an error if it
+   *     finds an index with no existing Color.
+   */
+  private static Color dereferenceTypePointer(
+      TypePointer typePointer, List<Color> typePool, @Nullable Consumer<Integer> createNewColor) {
+    switch (typePointer.getTypeCase()) {
+      case NATIVE_TYPE:
+        return nativeTypeToColor(typePointer.getNativeType());
+      case POOL_OFFSET:
+        int poolOffset = typePointer.getPoolOffset();
+        if (poolOffset < 0 || poolOffset >= typePool.size()) {
+          throw new InvalidSerializedFormatException(
+              "Type pointer has out-of-bounds pool offset: "
+                  + typePointer
+                  + " for pool size "
+                  + typePool.size());
+        }
+        if (typePool.get(typePointer.getPoolOffset()) == null) {
+          if (createNewColor == null) {
+            throw new IllegalStateException(
+                "Failed to deserialize type pool @ index " + poolOffset);
+          }
+          createNewColor.accept(poolOffset);
+        }
+        return typePool.get(poolOffset);
+      case TYPE_NOT_SET:
+        throw new InvalidSerializedFormatException("Cannot dereference TypePointer " + typePointer);
+    }
+    throw new AssertionError();
+  }
+
+  private static Color nativeTypeToColor(NativeType nativeType) {
+    PrimitiveColor primitive = nativeTypeToPrimitive(nativeType);
+    if (primitive != null) {
+      return primitive;
+    }
+    // TODO(b/160342394): add support for other native types
+    return PrimitiveColor.UNKNOWN;
+  }
+}

--- a/src/com/google/javascript/jscomp/serialization/ConvertTypesToColors.java
+++ b/src/com/google/javascript/jscomp/serialization/ConvertTypesToColors.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp.serialization;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.CompilerPass;
+import com.google.javascript.jscomp.NodeTraversal;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.jstype.JSType;
+import java.util.IdentityHashMap;
+
+/**
+ * Pass to convert JSType objects from TypeChecking that are attached to the AST into Color objects
+ * whose sole use is to enable running optimizations.
+ *
+ * <p>Eventually, we anticipate this pass to run at the beginning of optimizations, and leave a
+ * representation of the types as needed for optimizations on the AST.
+ */
+public final class ConvertTypesToColors implements CompilerPass {
+  private final AbstractCompiler compiler;
+
+  public ConvertTypesToColors(AbstractCompiler compiler) {
+    this.compiler = compiler;
+  }
+
+  private static class ColorAst extends AbstractPostOrderCallback {
+    private final ColorDeserializer deserializer;
+    private final IdentityHashMap<JSType, TypePointer> typePointersByJstype;
+
+    ColorAst(
+        ColorDeserializer deserializer, IdentityHashMap<JSType, TypePointer> typePointersByJstype) {
+      this.deserializer = deserializer;
+      this.typePointersByJstype = typePointersByJstype;
+    }
+
+    @Override
+    public void visit(NodeTraversal t, Node n, Node parent) {
+      JSType oldType = n.getJSType();
+      if (oldType != null && typePointersByJstype.containsKey(oldType)) {
+        n.setColor(deserializer.pointerToColor(typePointersByJstype.get(oldType)));
+      }
+    }
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    // Step 1: Serialize types
+    Node externsAndJsRoot = root.getParent();
+    SerializeTypesCallback serializeJstypes = SerializeTypesCallback.create(compiler);
+    NodeTraversal.traverse(compiler, externsAndJsRoot, serializeJstypes);
+
+    // Step 2: Remove types and add colors
+    TypePool typePool = serializeJstypes.generateTypePool();
+    ColorDeserializer deserializer = ColorDeserializer.buildFromTypePool(typePool);
+    NodeTraversal.traverse(
+        compiler,
+        externsAndJsRoot,
+        new ColorAst(deserializer, serializeJstypes.getTypePointersByJstype()));
+  }
+}

--- a/src/com/google/javascript/jscomp/serialization/JSTypeSerializer.java
+++ b/src/com/google/javascript/jscomp/serialization/JSTypeSerializer.java
@@ -1,0 +1,328 @@
+package com.google.javascript.jscomp.serialization;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.javascript.jscomp.IdGenerator;
+import com.google.javascript.jscomp.InvalidatingTypes;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.jstype.EnumType;
+import com.google.javascript.rhino.jstype.FunctionType;
+import com.google.javascript.rhino.jstype.JSType;
+import com.google.javascript.rhino.jstype.JSTypeNative;
+import com.google.javascript.rhino.jstype.JSTypeRegistry;
+import com.google.javascript.rhino.jstype.ObjectType;
+import com.google.javascript.rhino.jstype.UnionType;
+import com.google.javascript.rhino.serialization.TypePoolCreator;
+import java.util.Collection;
+
+final class JSTypeSerializer {
+
+  private final TypePoolCreator<JSType> typePoolCreator;
+  private final ImmutableMap<JSType, TypePointer> nativeTypePointers;
+  private final TypePointer unknownPointer;
+  private final InvalidatingTypes invalidatingTypes;
+  private final IdGenerator idGenerator;
+
+  private JSTypeSerializer(
+      TypePoolCreator<JSType> typePoolCreator,
+      ImmutableMap<JSType, TypePointer> nativeTypePointers,
+      TypePointer unknownPointer,
+      InvalidatingTypes invalidatingTypes,
+      IdGenerator idGenerator) {
+    this.typePoolCreator = typePoolCreator;
+    this.nativeTypePointers = nativeTypePointers;
+    this.unknownPointer = unknownPointer;
+    this.invalidatingTypes = invalidatingTypes;
+    this.idGenerator = idGenerator;
+  }
+
+  public static JSTypeSerializer create(
+      TypePoolCreator<JSType> typePoolCreator,
+      JSTypeRegistry registry,
+      InvalidatingTypes invalidatingTypes) {
+    ImmutableMap<JSType, TypePointer> nativeTypePointers = buildNativeTypeMap(registry);
+    IdGenerator idGenerator = new IdGenerator();
+
+    return new JSTypeSerializer(
+        typePoolCreator,
+        nativeTypePointers,
+        nativeTypePointers.get(registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
+        invalidatingTypes,
+        idGenerator);
+  }
+
+  /** Returns a pointer to the given type. If it is not already serialized, serializes it too */
+  TypePointer serializeType(JSType type) {
+    if (nativeTypePointers.containsKey(type)) {
+      return nativeTypePointers.get(type);
+    }
+
+    if (type.isNamedType()) {
+      return serializeType(type.toMaybeNamedType().getReferencedType());
+    }
+
+    if (type.isEnumElementType()) {
+      // replace with the corresponding primitive
+      return serializeType(type.toMaybeEnumElementType().getPrimitiveType());
+    }
+
+    if (type.isTemplateType()) {
+      // template types are not serialized because optimizations don't seem to care about them.
+      // serialize as the UNKNOWN_TYPE because bounded generics are unsupported
+      return unknownPointer;
+    }
+
+    if (type.isTemplatizedType()) {
+      return serializeType(type.toMaybeTemplatizedType().getReferencedType());
+    }
+
+    if (type.isUnionType()) {
+      return serializeUnionType(type.toMaybeUnionType());
+    }
+
+    if (type.isFunctionType() && type.toMaybeFunctionType().getCanonicalRepresentation() != null) {
+      return serializeType(type.toMaybeFunctionType().getCanonicalRepresentation());
+    }
+
+    if (type.isNoResolvedType()) {
+      // The Closure type system creates separate instances of NoResolvedType per type name. For
+      // optimizations treat them all identically.
+      return unknownPointer;
+    }
+
+    if (type.toObjectType() != null) {
+      TypePointer serialized =
+          typePoolCreator.typeToPointer(
+              type,
+              () ->
+                  com.google.javascript.jscomp.serialization.Type.newBuilder()
+                      .setObject(serializeObjectType(type.toObjectType()).build())
+                      .build());
+      addSupertypeEdges(type.toMaybeObjectType(), serialized);
+      return serialized;
+    }
+
+    throw new IllegalStateException("Unsupported type " + type);
+  }
+
+  private void addSupertypeEdges(ObjectType subtype, TypePointer serializedSubtype) {
+    for (TypePointer ancestor : ownAncestorInterfacesOf(subtype)) {
+      typePoolCreator.addDisambiguationEdge(serializedSubtype, ancestor);
+    }
+    if (subtype.getImplicitPrototype() != null) {
+      typePoolCreator.addDisambiguationEdge(
+          serializedSubtype, serializeType(subtype.getImplicitPrototype()));
+    }
+  }
+
+  private TypePointer serializeUnionType(UnionType type) {
+    ImmutableSet<TypePointer> serializedAlternates =
+        type.getAlternates().stream().map(this::serializeType).collect(toImmutableSet());
+    if (serializedAlternates.size() == 1) {
+      return Iterables.getOnlyElement(serializedAlternates);
+    }
+    return typePoolCreator.typeToPointer(type, () -> serializeUnionType(serializedAlternates));
+  }
+
+  private static Type serializeUnionType(ImmutableSet<TypePointer> serializedAlternates) {
+    return com.google.javascript.jscomp.serialization.Type.newBuilder()
+        .setUnion(
+            com.google.javascript.jscomp.serialization.UnionType.newBuilder()
+                .addAllUnionMember(serializedAlternates)
+                .build())
+        .build();
+  }
+
+  private com.google.javascript.jscomp.serialization.ObjectType.Builder serializeObjectType(
+      ObjectType type) {
+    com.google.javascript.jscomp.serialization.ObjectType.Builder builder =
+        serializePrototypeObjectType(type);
+    if (type.isInstanceType()) {
+      return serializeInstanceObjectType(type, builder);
+    } else if (type.isEnumType()) {
+      return serializeEnumType(type.toMaybeEnumType(), builder);
+    } else if (type.isFunctionType()) {
+      return serializeFunctionType(type.toMaybeFunctionType(), builder);
+    }
+    return builder;
+  }
+
+  private com.google.javascript.jscomp.serialization.ObjectType.Builder
+      serializePrototypeObjectType(ObjectType type) {
+    com.google.javascript.jscomp.serialization.ObjectType.Builder objBuilder =
+        com.google.javascript.jscomp.serialization.ObjectType.newBuilder();
+    Node ownerNode = type.getOwnerFunction() != null ? type.getOwnerFunction().getSource() : null;
+    if (ownerNode != null) {
+      objBuilder.setFilename(ownerNode.getSourceFileName());
+    }
+    String className = type.getReferenceName();
+    if (className != null) {
+      objBuilder.setClassName(className);
+    }
+
+    return objBuilder
+        .setIsInvalidating(invalidatingTypes.isInvalidating(type))
+        // NOTE: We need a better format than sequential integers in order to have an id that
+        // can be consistent across compilation units. For now, using a sequential integers for each
+        // type depends on the invariant that we serialize each distinct type exactly once and from
+        // a single compilation unit.
+        .setUuid(Integer.toHexString(idGenerator.newId()));
+  }
+
+  private static com.google.javascript.jscomp.serialization.ObjectType.Builder
+      serializeInstanceObjectType(
+          ObjectType type,
+          com.google.javascript.jscomp.serialization.ObjectType.Builder objBuilder) {
+    FunctionType constructor = type.getConstructor();
+    String className = constructor.getReferenceName();
+    if (className != null && !className.isEmpty()) {
+      objBuilder.setClassName(className + " instance");
+    }
+    if (objBuilder.getFilename().isEmpty() && constructor.getSource() != null) {
+      String filename = constructor.getSource().getSourceFileName();
+      objBuilder.setFilename(filename);
+    }
+    return objBuilder;
+  }
+
+  private static com.google.javascript.jscomp.serialization.ObjectType.Builder serializeEnumType(
+      EnumType type, com.google.javascript.jscomp.serialization.ObjectType.Builder objBuilder) {
+    if (type.getSource() != null) {
+      objBuilder.setFilename(type.getSource().getSourceFileName());
+    }
+    return objBuilder;
+  }
+
+  private com.google.javascript.jscomp.serialization.ObjectType.Builder serializeFunctionType(
+      FunctionType type, com.google.javascript.jscomp.serialization.ObjectType.Builder objBuilder) {
+    Node source = type.getSource();
+    if (source != null) {
+      String filename = source.getSourceFileName();
+      if (filename != null) {
+        objBuilder.setFilename(filename);
+      }
+    }
+    // Serialize prototypes and instance types for instantiable types. Even if these types never
+    // appear on the AST, optimizations need to know that at runtime these types may be present.
+    if (type.hasInstanceType() && type.getInstanceType() != null) {
+      objBuilder
+          .setPrototype(serializeType(type.getPrototype()))
+          .setInstanceType(serializeType(type.getInstanceType()));
+    }
+
+    return objBuilder;
+  }
+
+  /**
+   * Returns the interfaces directly implemented or extended by {@code type}.
+   *
+   * <p>This is distinct from any of the methods on {@link FunctionType}. Specifically, the result
+   * only contains:
+   *
+   * <ul>
+   *   <li>own/direct supertypes
+   *   <li>supertypes that are actually interfaces
+   * </ul>
+   */
+  private ImmutableList<TypePointer> ownAncestorInterfacesOf(ObjectType type) {
+    FunctionType ctorType = type.getConstructor();
+    if (ctorType == null) {
+      return ImmutableList.of();
+    }
+
+    final Collection<ObjectType> ifaceTypes;
+    if (ctorType.isInterface()) {
+      ifaceTypes = ctorType.getExtendedInterfaces();
+    } else if (ctorType.isConstructor()) {
+      ifaceTypes = ctorType.getOwnImplementedInterfaces();
+    } else {
+      throw new AssertionError();
+    }
+
+    if (ifaceTypes.isEmpty()) {
+      return ImmutableList.of();
+    }
+
+    return ifaceTypes.stream()
+        .filter((t) -> t.getConstructor() != null && t.getConstructor().isInterface())
+        .map(this::serializeType)
+        .collect(toImmutableList());
+  }
+
+  private static ImmutableMap<JSType, TypePointer> buildNativeTypeMap(JSTypeRegistry registry) {
+    ImmutableMap.Builder<JSType, TypePointer> nativeTypes = ImmutableMap.builder();
+    for (JSTypeNative jsNativeType : JSTypeNative.values()) {
+      NativeType serializedNativeType = translateNativeType(jsNativeType);
+      if (serializedNativeType != null) {
+        nativeTypes.put(
+            registry.getNativeType(jsNativeType),
+            TypePointer.newBuilder().setNativeType(serializedNativeType).build());
+      }
+    }
+    return nativeTypes.build();
+  }
+
+  /**
+   * Maps between {@link JSTypeNative} and {@link NativeType}.
+   *
+   * <p>Not one-to-one or onto. Some Closure native types are not natively serialized and multiple
+   * Closure native types correspond go the "UNKNOWN" serialized type.
+   */
+  private static NativeType translateNativeType(JSTypeNative nativeType) {
+    switch (nativeType) {
+      case STRING_TYPE:
+        return NativeType.STRING_TYPE;
+
+      case BOOLEAN_TYPE:
+        return NativeType.BOOLEAN_TYPE;
+
+      case NUMBER_TYPE:
+        return NativeType.NUMBER_TYPE;
+
+      case SYMBOL_TYPE:
+        return NativeType.SYMBOL_TYPE;
+
+      case BIGINT_TYPE:
+        return NativeType.BIGINT_TYPE;
+
+      case NULL_TYPE:
+      case VOID_TYPE:
+        return NativeType.NULL_OR_VOID_TYPE;
+
+      case FUNCTION_PROTOTYPE:
+        return NativeType.FUNCTION_PROTOTYPE;
+      case FUNCTION_TYPE:
+        return NativeType.FUNCTION_TYPE;
+      case FUNCTION_FUNCTION_TYPE:
+        return NativeType.FUNCTION_FUNCTION_TYPE;
+
+      case OBJECT_TYPE:
+        return NativeType.OBJECT_TYPE;
+      case OBJECT_FUNCTION_TYPE:
+        return NativeType.OBJECT_FUNCTION_TYPE;
+      case OBJECT_PROTOTYPE:
+        return NativeType.OBJECT_PROTOTYPE;
+
+      case ALL_TYPE:
+      case UNKNOWN_TYPE:
+      case CHECKED_UNKNOWN_TYPE:
+      case NO_TYPE:
+      case NO_OBJECT_TYPE:
+      case NO_RESOLVED_TYPE:
+        return NativeType.UNKNOWN_TYPE;
+
+      case REGEXP_TYPE:
+        return NativeType.REGEXP_TYPE;
+      case REGEXP_FUNCTION_TYPE:
+        return NativeType.REGEXP_FUNCTION_TYPE;
+
+      default:
+        return null;
+    }
+  }
+}

--- a/src/com/google/javascript/jscomp/serialization/SerializeTypesCallback.java
+++ b/src/com/google/javascript/jscomp/serialization/SerializeTypesCallback.java
@@ -1,0 +1,52 @@
+package com.google.javascript.jscomp.serialization;
+
+import com.google.javascript.jscomp.AbstractCompiler;
+import com.google.javascript.jscomp.InvalidatingTypes;
+import com.google.javascript.jscomp.NodeTraversal;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.jstype.JSType;
+import com.google.javascript.rhino.serialization.TypePoolCreator;
+import java.util.IdentityHashMap;
+
+/** Grab a TypePointer for each JSType on the AST. */
+final class SerializeTypesCallback extends AbstractPostOrderCallback {
+
+  private final TypePoolCreator<JSType> typePoolCreator;
+  private final JSTypeSerializer jstypeSerializer;
+  private final IdentityHashMap<JSType, TypePointer> typePointersByJstype = new IdentityHashMap<>();
+
+  private SerializeTypesCallback(
+      TypePoolCreator<JSType> typePoolCreator, JSTypeSerializer jstypeSerializer) {
+    this.typePoolCreator = typePoolCreator;
+    this.jstypeSerializer = jstypeSerializer;
+  }
+
+  static SerializeTypesCallback create(AbstractCompiler compiler) {
+    TypePoolCreator<JSType> typePoolCreator = TypePoolCreator.create();
+    InvalidatingTypes invalidatingTypes =
+        new InvalidatingTypes.Builder(compiler.getTypeRegistry())
+            .addAllTypeMismatches(compiler.getTypeMismatches())
+            .addAllTypeMismatches(compiler.getImplicitInterfaceUses())
+            .build();
+    JSTypeSerializer jsTypeSerializer =
+        JSTypeSerializer.create(typePoolCreator, compiler.getTypeRegistry(), invalidatingTypes);
+    return new SerializeTypesCallback(typePoolCreator, jsTypeSerializer);
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    JSType type = n.getJSType();
+    if (type != null && !typePointersByJstype.containsKey(type)) {
+      typePointersByJstype.put(type, jstypeSerializer.serializeType(type));
+    }
+  }
+
+  IdentityHashMap<JSType, TypePointer> getTypePointersByJstype() {
+    return typePointersByJstype;
+  }
+
+  TypePool generateTypePool() {
+    return typePoolCreator.generateTypePool();
+  }
+}

--- a/src/com/google/javascript/rhino/serialization/SerializableType.java
+++ b/src/com/google/javascript/rhino/serialization/SerializableType.java
@@ -1,0 +1,57 @@
+package com.google.javascript.rhino.serialization;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.javascript.jscomp.serialization.Type;
+import java.util.function.Supplier;
+
+/**
+ * A wrapper around AST types to aid in serialization.
+ *
+ * The primary features are a more fine-grained notion of equality to make sure that we serialize
+ * all the types we need, and a function to perform serialization.
+ */
+final class SerializableType<T> {
+  private final T wrappedType;
+  private final Supplier<Type> serialize;
+
+  private SerializableType(T wrappedType, Supplier<Type> serialize) {
+    this.wrappedType = checkNotNull(wrappedType);
+    this.serialize = checkNotNull(serialize);
+  }
+
+  static <S> SerializableType<S> create(S wrappedType, Supplier<Type> serialize) {
+    return new SerializableType<>(wrappedType, serialize);
+  }
+
+  /**
+   * Generates the serialized type for this AST type
+   */
+  Type serializeToConcrete() {
+    return serialize.get();
+  }
+
+  /**
+   * Checks for serialization-time equality of the wrapped types.
+   * Since two types may be equal in the type system, but still need to be serialized separately,
+   * we may need more fine-grained equivalence classes, which identity equality gives us.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof SerializableType)) {
+      return false;
+    }
+    SerializableType<?> o = (SerializableType<?>) obj;
+    return wrappedType.equals(o.wrappedType);
+  }
+
+  @Override
+  public int hashCode() {
+    return wrappedType.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return wrappedType.toString();
+  }
+}

--- a/src/com/google/javascript/rhino/serialization/TypePoolCreator.java
+++ b/src/com/google/javascript/rhino/serialization/TypePoolCreator.java
@@ -1,0 +1,174 @@
+package com.google.javascript.rhino.serialization;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.javascript.jscomp.serialization.SubtypingEdge;
+import com.google.javascript.jscomp.serialization.Type;
+import com.google.javascript.jscomp.serialization.TypePointer;
+import com.google.javascript.jscomp.serialization.TypePointer.TypeCase;
+import com.google.javascript.jscomp.serialization.TypePool;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Class that aids in building a pool of serialized types
+ *
+ * <p>This class's purpose is to build the pool of all types and construct pointers into that pool.
+ *
+ * <p>To add a new type to the pool or get a pointer to a type already in the pool, call {@link
+ * #typeToPointer(Object, Supplier)}. Once all types have been registered call {@link
+ * #generateTypePool()}.
+ */
+public class TypePoolCreator<T> {
+  private Map<SerializableType<T>, Integer> seenSerializableTypes = new HashMap<>();
+  private List<SerializableType<T>> toSerialize = new ArrayList<>();
+  private final Multimap<TypePointer, TypePointer> disambiguateEdges = LinkedHashMultimap.create();
+  private State state = State.COLLECTING_TYPES;
+  private final boolean doExpensiveValidityChecks;
+
+  enum State {
+    COLLECTING_TYPES,
+    GENERATING_POOL,
+    FINISHED,
+  }
+
+  private TypePoolCreator(boolean doExpensiveValidityChecks) {
+    this.doExpensiveValidityChecks = doExpensiveValidityChecks;
+  }
+
+  /** Creates a new TypePoolCreator */
+  public static <T> TypePoolCreator<T> create() {
+    return new TypePoolCreator<>(false);
+  }
+
+  /** Creates a new TypePoolCreator that runs expensive validity checks. */
+  public static <T> TypePoolCreator<T> createWithExpensiveValidityChecks() {
+    TypePoolCreator<T> serializer = new TypePoolCreator<>(true);
+    serializer.checkValid();
+    return serializer;
+  }
+
+  /** Checks that this instance is in a valid state. */
+  private void checkValid() {
+    if (!doExpensiveValidityChecks) {
+      return;
+    }
+    final int totalTypeCount = seenSerializableTypes.size();
+    for (Integer pointer : seenSerializableTypes.values()) {
+      checkState(pointer >= 0);
+      checkState(
+          pointer <= totalTypeCount,
+          "Found invalid pointer %s, out of a total of %s user-defined types",
+          pointer,
+          totalTypeCount);
+    }
+    switch (state) {
+      case COLLECTING_TYPES:
+        checkState(seenSerializableTypes.size() == toSerialize.size());
+        for (SerializableType<T> astType : toSerialize) {
+          checkState(seenSerializableTypes.containsKey(astType));
+        }
+        for (SerializableType<T> astType : seenSerializableTypes.keySet()) {
+          checkState(
+              toSerialize.contains(astType),
+              "Type %s not present in toSerialize, whose contents are: %s",
+              astType,
+              toSerialize);
+          int serializeOrder = toSerialize.indexOf(astType);
+          int seenPointer = seenSerializableTypes.get(astType);
+          checkState(
+              serializeOrder == seenPointer,
+              "For type %s, serializeOrder (%s) != pointer (%s)",
+              astType,
+              serializeOrder,
+              seenPointer);
+        }
+        break;
+      case GENERATING_POOL:
+        for (SerializableType<T> astType : toSerialize) {
+          checkState(seenSerializableTypes.containsKey(astType));
+        }
+        break;
+      case FINISHED:
+        checkState(toSerialize.isEmpty());
+        break;
+    }
+  }
+
+  /**
+   * Generates a "type-pool" representing all the types that this class has encountered through
+   * calls to {@link #typeToPointer(Object, Supplier)}. After generation, no new types can be added,
+   * so subsequent calls to {@link #typeToPointer(Object, Supplier)} can only be used to retrieve
+   * pointers to existing types in the type pool.
+   */
+  public TypePool generateTypePool() {
+    checkState(state == State.COLLECTING_TYPES);
+    checkValid();
+    state = State.GENERATING_POOL;
+    TypePool.Builder builder = TypePool.newBuilder();
+    for (int i = 0; !toSerialize.isEmpty(); i++) {
+      SerializableType<T> astType = toSerialize.remove(0);
+      checkState(seenSerializableTypes.get(astType) == i);
+      Type serializedType = astType.serializeToConcrete();
+      builder.addType(serializedType);
+    }
+    for (TypePointer subtype : disambiguateEdges.keySet()) {
+      for (TypePointer supertype : disambiguateEdges.get(subtype)) {
+        builder.addDisambiguationEdges(
+            SubtypingEdge.newBuilder().setSubtype(subtype).setSupertype(supertype));
+      }
+    }
+    TypePool pool = builder.build();
+    state = State.FINISHED;
+    checkValid();
+    seenSerializableTypes = ImmutableMap.copyOf(seenSerializableTypes);
+    toSerialize = ImmutableList.of();
+    return pool;
+  }
+
+  /**
+   * Returns the type-pointer for the given AST-type, adding it to the type-pool if not present.
+   *
+   * <p>The type-pointer is a reference that can be later used to look up the given type in the
+   * type-pool. This function memoizes type-pointers and can be safely called multiple times for a
+   * given type.
+   *
+   * <p>The given serializer will be called only once per type during type pool generation.
+   */
+  public TypePointer typeToPointer(T t, Supplier<Type> serialize) {
+    checkValid();
+    SerializableType<T> idType = SerializableType.create(t, serialize);
+    final int poolOffset;
+    if (seenSerializableTypes.containsKey(idType)) {
+      poolOffset = seenSerializableTypes.get(idType);
+    } else {
+      checkState(State.COLLECTING_TYPES == state || State.GENERATING_POOL == state);
+      poolOffset = seenSerializableTypes.size();
+      checkState(null == seenSerializableTypes.put(idType, poolOffset));
+      toSerialize.add(idType);
+      checkValid();
+    }
+    return TypePointer.newBuilder()
+        .setPoolOffset(poolOffset)
+        .setDescriptionForDebug(t.toString())
+        .build();
+  }
+
+  /**
+   * Adds an edge from the given subtype to the given supertype if both are user-defined types and
+   * not native.
+   */
+  public void addDisambiguationEdge(TypePointer subtype, TypePointer supertype) {
+    if (subtype.getTypeCase().equals(TypeCase.POOL_OFFSET)
+        && supertype.getTypeCase().equals(TypeCase.POOL_OFFSET)) {
+      this.disambiguateEdges.put(subtype, supertype);
+    }
+  }
+}

--- a/src/com/google/javascript/rhino/typed_ast/BUILD.bazel
+++ b/src/com/google/javascript/rhino/typed_ast/BUILD.bazel
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@protobuf_java_rules//java:defs.bzl", "java_proto_library")
+load("@protobuf_proto_rules//proto:defs.bzl", "proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "typed_ast_proto",
+    srcs = glob([
+        "*.proto",
+    ]),
+)
+
+java_proto_library(
+    name = "typed_ast_java_proto",
+    deps = [":typed_ast_proto"],
+)
+
+# TODO: Reenable once j2cl_proto_library is working again.
+# j2cl_proto_library(
+#     name = "typed_ast_j2cl_proto",
+#     deps = [":typed_ast_proto"],
+# )

--- a/src/com/google/javascript/rhino/typed_ast/types.proto
+++ b/src/com/google/javascript/rhino/typed_ast/types.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package jscomp;
+
+option java_package = "com.google.javascript.jscomp.serialization";
+option java_multiple_files = true;
+
+// All of these proto definitions are in flux.  Please don't depend on them.
+
+message TypePool {
+  repeated Type type = 1;
+  // edges used for Closure Compiler property disambiguation/ambiguation
+  repeated SubtypingEdge disambiguation_edges = 2;
+}
+
+message TypePointer {
+  // required
+  oneof type {
+    int32 pool_offset = 1;
+    NativeType native_type = 2;
+  }
+  // for debugging only -- may not be present
+  string description_for_debug = 3;
+}
+
+message SubtypingEdge {
+  TypePointer subtype = 1;
+  TypePointer supertype = 2;
+}
+
+message UnionType {
+  repeated TypePointer union_member = 1;
+}
+
+message ObjectType {
+  // If true, type-based property optimizations will back off optimizations on
+  // properties related to this type.
+  bool is_invalidating = 2;
+  TypePointer instance_type = 3;
+  TypePointer prototype = 4;
+  string uuid = 5;
+
+  // TODO: move these into a separate message
+  string class_name = 1;
+  string filename = 9;
+}
+
+message Type {
+  oneof kind {
+    ObjectType object = 2;
+    UnionType union = 4;
+  }
+}
+
+/*
+ * Types that are built-in to a JavaScript engine and other types that occur
+ * very commonly in a JS program.
+ */
+enum NativeType {
+  // Type-system only type: The Closure '*' and '?', or TS 'any' and 'unknown'
+  // or the bottom type. (For the purposes of optimization we believe all these
+  // types may be treated identically)
+  UNKNOWN_TYPE = 0;
+
+  // JS primitive types
+  BOOLEAN_TYPE = 1;
+  STRING_TYPE = 2;
+  NUMBER_TYPE = 3;
+  // Optimizations treat null and void identically
+  NULL_OR_VOID_TYPE = 4;
+  SYMBOL_TYPE = 6;
+  BIGINT_TYPE = 7;
+
+  // Common object types
+  OBJECT_TYPE = 8;
+  OBJECT_FUNCTION_TYPE = 9;
+  OBJECT_PROTOTYPE = 10;
+
+  FUNCTION_TYPE = 11;
+  FUNCTION_FUNCTION_TYPE = 12;
+  FUNCTION_PROTOTYPE = 13;
+
+  REGEXP_TYPE = 14;
+  REGEXP_FUNCTION_TYPE = 15;
+}


### PR DESCRIPTION
Add logic for serializing the types on the AST, and deserializing them
as optimization "colors". This allows a cleaner separation between the
capabilities needed for checking, and those needed at optimization time for
type-based optimization.
