### PR TITLE
Added window.queueMicrotask() to externs

### DIFF
--- a/externs/browser/window.js
+++ b/externs/browser/window.js
@@ -173,7 +173,7 @@ function setTimeout(callback, opt_delay, callbackParams) {}
  */
 function hasOwnProperty (propertyName) {}
 
-/*
+/**
  * @param {function()} callback
  * @return {undefined}
  * @see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask

--- a/externs/browser/window.js
+++ b/externs/browser/window.js
@@ -172,3 +172,11 @@ function setTimeout(callback, opt_delay, callbackParams) {}
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
  */
 function hasOwnProperty (propertyName) {}
+
+/*
+ * @param {function()} callback
+ * @return {undefined}
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask
+ * @see https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#microtask-queuing
+ */
+function queueMicrotask(callback) {}


### PR DESCRIPTION
The declaration for window.queueMicrotask() is missing in the externs declarations.
