### PR TITLE
Add signature for SharedWorker

### DIFF
--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -1501,12 +1501,14 @@ WorkerOptions.prototype.type;
 /**
  * @see http://dev.w3.org/html5/workers/
  * @param {string} scriptURL The URL of the script to run in the SharedWorker.
- * @param {string=} opt_name A name that can later be used to obtain a
- *     reference to the same SharedWorker.
+ * @param {(string|!WorkerOptions)=} opt_options Options can be a name that can
+ *     later be used to obtain a reference to the same SharedWorker or a
+ *     WorkerOptions object which can be be used to specify how scriptURL is
+ *     fetched through the credentials option.
  * @constructor
  * @implements {EventTarget}
  */
-function SharedWorker(scriptURL, opt_name) {}
+function SharedWorker(scriptURL, opt_options) {}
 
 /** @override */
 SharedWorker.prototype.addEventListener = function(


### PR DESCRIPTION
According to the spec:
https://w3c.github.io/workers/#shared-workers-and-sharedworker-interface

SharedWorker should support providing a WorkerOptions as an optional
parameter in its constructor.