### PR TITLE
Refactor ExtractPrototypeMemberDeclarations to use a variable per chunk

### DIFF
--- a/src/com/google/javascript/jscomp/ExtractPrototypeMemberDeclarations.java
+++ b/src/com/google/javascript/jscomp/ExtractPrototypeMemberDeclarations.java
@@ -22,7 +22,9 @@ import com.google.javascript.jscomp.NodeTraversal.AbstractShallowCallback;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -86,7 +88,7 @@ import javax.annotation.Nullable;
 class ExtractPrototypeMemberDeclarations implements CompilerPass {
 
   // The name of variable that will temporary hold the pointer to the prototype
-  // object. Of cause, we assume that it'll be renamed by RenameVars.
+  // object. Of course, we assume that it'll be renamed by RenameVars.
   private static final String PROTOTYPE_ALIAS = "JSCompiler_prototypeAlias";
 
   private final AbstractCompiler compiler;
@@ -138,29 +140,40 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
   public void process(Node externs, Node root) {
     GatherExtractionInfo extractionInfo = new GatherExtractionInfo();
     NodeTraversal.traverse(compiler, root, extractionInfo);
-    if (extractionInfo.shouldExtract()) {
-      doExtraction(extractionInfo);
-    }
+    maybeDoExtraction(extractionInfo);
   }
 
   /**
    * Declares the temp variable to point to prototype objects and iterates
    * through all ExtractInstance and performs extraction there.
    */
-  private void doExtraction(GatherExtractionInfo info) {
-    // Insert a global temp if we are using the USE_GLOBAL_TEMP pattern.
-    if (pattern == Pattern.USE_GLOBAL_TEMP) {
-      Node injectionPoint = compiler.getNodeForCodeInsertion(null);
-
-      Node var = NodeUtil.newVarNode(PROTOTYPE_ALIAS, null)
-          .useSourceInfoIfMissingFromForTree(injectionPoint);
-
-      injectionPoint.addChildToFront(var);
-      compiler.reportChangeToEnclosingScope(var);
+  private void maybeDoExtraction(GatherExtractionInfo info) {
+    if (pattern == Pattern.USE_IIFE && !info.shouldExtractGlobal()) {
+      return;
     }
     // Go through all extraction instances and extract each of them.
-    for (ExtractionInstance instance : info.instances) {
-      extractInstance(instance);
+    for (Map.Entry<JSModule, ExtractionInstanceInfo> entry : info.instancesByModule.entrySet()) {
+      String alias = PROTOTYPE_ALIAS;
+      if (pattern == Pattern.USE_GLOBAL_TEMP) {
+        // Rather than a truly global variable, use a unique variable per output chunk.
+        // This prevents RescopeGlobalSymbolNames from converting these references to
+        // namespace properties which reduces the benefit of the alias.
+        if (info.shouldExtractModule(entry.getKey())) {
+          Node injectionPoint = compiler.getNodeForCodeInsertion(entry.getKey());
+          alias = PROTOTYPE_ALIAS + entry.getKey().getIndex();
+          Node var = NodeUtil.newVarNode(alias, null)
+              .useSourceInfoIfMissingFromForTree(injectionPoint);
+
+          injectionPoint.addChildToFront(var);
+          compiler.reportChangeToEnclosingScope(var);
+        } else {
+          continue;
+        }
+      }
+
+      for (ExtractionInstance instance : entry.getValue().instances) {
+        extractInstance(instance, alias);
+      }
     }
   }
 
@@ -169,7 +182,7 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
    * variable and rewrite each member declaration to assign to the temp variable
    * instead.
    */
-  private void extractInstance(ExtractionInstance instance) {
+  private void extractInstance(ExtractionInstance instance, String alias) {
     PrototypeMemberDeclaration first = instance.declarations.get(0);
     String className = first.qualifiedClassName;
     if (pattern == Pattern.USE_GLOBAL_TEMP) {
@@ -179,7 +192,7 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
       Node stmt =
           IR.exprResult(
               IR.assign(
-                  IR.name(PROTOTYPE_ALIAS),
+                  IR.name(alias),
                   IR.getprop(
                       classNameNode, IR.string("prototype"))))
           .useSourceInfoIfMissingFromForTree(first.node);
@@ -190,7 +203,7 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
       Node block = IR.block();
       Node func = IR.function(
            IR.name(""),
-           IR.paramList(IR.name(PROTOTYPE_ALIAS)),
+           IR.paramList(IR.name(alias)),
            block);
 
       Node call = IR.call(func,
@@ -211,7 +224,7 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
     // Go through each member declaration and replace it with an assignment
     // to the prototype variable.
     for (PrototypeMemberDeclaration declar : instance.declarations) {
-      replacePrototypeMemberDeclaration(declar);
+      replacePrototypeMemberDeclaration(declar, alias);
     }
   }
 
@@ -219,13 +232,13 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
    * Replaces a member declaration to an assignment to the temp prototype
    * object.
    */
-  private void replacePrototypeMemberDeclaration(PrototypeMemberDeclaration declar) {
+  private void replacePrototypeMemberDeclaration(PrototypeMemberDeclaration declar, String alias) {
     // x.prototype.y = ...  ->  t.y = ...
     Node assignment = declar.node.getFirstChild();
     Node lhs = assignment.getFirstChild();
     Node name = NodeUtil.newQName(
         compiler,
-        PROTOTYPE_ALIAS + "." + declar.memberName, declar.node,
+        alias + "." + declar.memberName, declar.node,
         declar.memberName);
 
     // Save the full prototype path on the left hand side of the assignment for debugging purposes.
@@ -241,13 +254,16 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
     compiler.reportChangeToEnclosingScope(name);
   }
 
+  class ExtractionInstanceInfo {
+    final List<ExtractionInstance> instances = new ArrayList<>();
+    int totalDelta = 0;
+  }
+
   /**
    * Collects all the possible extraction instances in a node traversal.
    */
   private class GatherExtractionInfo extends AbstractShallowCallback {
-
-    private final List<ExtractionInstance> instances = new ArrayList<>();
-    private int totalDelta = pattern.globalOverhead;
+    private final Map<JSModule, ExtractionInstanceInfo> instancesByModule = new HashMap<>();
 
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
@@ -270,8 +286,12 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
 
         // Only add it to our work list if the extraction at this instance makes the code smaller.
         if (instance.isFavorable()) {
-          instances.add(instance);
-          totalDelta += instance.delta;
+          if (!instancesByModule.containsKey(t.getModule())) {
+            instancesByModule.put(t.getModule(), new ExtractionInstanceInfo());
+          }
+          ExtractionInstanceInfo instanceInfo = instancesByModule.get(t.getModule());
+          instanceInfo.instances.add(instance);
+          instanceInfo.totalDelta += instance.delta;
         }
       }
     }
@@ -280,8 +300,24 @@ class ExtractPrototypeMemberDeclarations implements CompilerPass {
      * @return {@code true} if the sum of all the extraction instance gain
      * outweighs the overhead of the temp variable declaration.
      */
-    private boolean shouldExtract() {
-      return totalDelta < 0;
+    private boolean shouldExtractGlobal() {
+      int allModulesDelta = 0;
+      for (ExtractionInstanceInfo instanceInfo : instancesByModule.values()) {
+        allModulesDelta += instanceInfo.totalDelta;
+      }
+      return allModulesDelta + pattern.globalOverhead < 0;
+    }
+
+    /**
+     * @return {@code true} if the sum of all the extraction instance gain
+     * outweighs the overhead of the temp variable declaration.
+     */
+    private boolean shouldExtractModule(JSModule module) {
+      ExtractionInstanceInfo instanceInfo = instancesByModule.get(module);
+      if (instanceInfo == null) {
+        return false;
+      }
+      return instanceInfo.totalDelta + pattern.globalOverhead < 0;
     }
   }
 

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -1125,6 +1125,16 @@ public abstract class CompilerTestCase {
   }
 
   /**
+   * Verifies that the compiler pass's JS output matches the expected output.
+   *
+   * @param js Input
+   * @param expected Expected JS output
+   */
+  protected void test(JSModule[] srcs, JSModule[] expected) {
+    test(srcs(srcs), expected(expected));
+  }
+
+  /**
    * Verifies that the compiler generates the given error for the given input.
    *
    * @param js Input

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -1127,8 +1127,8 @@ public abstract class CompilerTestCase {
   /**
    * Verifies that the compiler pass's JS output matches the expected output.
    *
-   * @param js Input
-   * @param expected Expected JS output
+   * @param srcs Input chunks
+   * @param expected Expected chunks
    */
   protected void test(JSModule[] srcs, JSModule[] expected) {
     test(srcs(srcs), expected(expected));

--- a/test/com/google/javascript/jscomp/ExtractPrototypeMemberDeclarationsTest.java
+++ b/test/com/google/javascript/jscomp/ExtractPrototypeMemberDeclarationsTest.java
@@ -19,6 +19,7 @@ package com.google.javascript.jscomp;
 import static com.google.javascript.jscomp.CompilerTestCase.lines;
 
 import com.google.javascript.jscomp.ExtractPrototypeMemberDeclarations.Pattern;
+import com.google.javascript.jscomp.testing.JSChunkGraphBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +56,7 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
   public void testExtractingSingleClassPrototype() {
     extract(
         generatePrototypeDeclarations("x", 7),
-        loadPrototype("x") + generateExtractedDeclarations(7));
+        loadPrototype("x") + generateExtractedDeclarations(0, 7));
   }
 
   @Test
@@ -66,16 +67,17 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
 
   @Test
   public void testClassDefinedInBlock() {
+    String tmp = TMP + "0";
     test(
         lines(
             "{",
             generatePrototypeDeclarations("x", 7),
             "}"),
         lines(
-            "var " + TMP + ";",
+            "var " + tmp + ";",
             "{",
-            TMP + " = x.prototype;",
-            generateExtractedDeclarations(7),
+            tmp + " = x.prototype;",
+            generateExtractedDeclarations(0, 7),
             "}"));
   }
 
@@ -102,9 +104,9 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
     extract(
         generatePrototypeDeclarations("x", 6) + generatePrototypeDeclarations("y", 6),
         loadPrototype("x")
-            + generateExtractedDeclarations(6)
+            + generateExtractedDeclarations(0, 6)
             + loadPrototype("y")
-            + generateExtractedDeclarations(6));
+            + generateExtractedDeclarations(0, 6));
   }
 
   @Test
@@ -115,10 +117,10 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
             + generatePrototypeDeclarations("y", 6)
             + "}",
         loadPrototype("x")
-            + generateExtractedDeclarations(6)
+            + generateExtractedDeclarations(0, 6)
             + "if (foo()) {"
             + loadPrototype("y")
-            + generateExtractedDeclarations(6)
+            + generateExtractedDeclarations(0, 6)
             + "}");
   }
 
@@ -134,7 +136,7 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
   public void testExtractingPrototypeWithQName() {
     extract(
         generatePrototypeDeclarations("com.google.javascript.jscomp.x", 7),
-        loadPrototype("com.google.javascript.jscomp.x") + generateExtractedDeclarations(7));
+        loadPrototype("com.google.javascript.jscomp.x") + generateExtractedDeclarations(0, 7));
   }
 
   @Test
@@ -150,6 +152,7 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
 
   @Test
   public void testExtractingPrototypeWithNestedMembers() {
+    String tmp = TMP + "0";
     extract(
         "x.prototype.y.a = 1;"
             + "x.prototype.y.b = 1;"
@@ -159,17 +162,18 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
             + "x.prototype.y.f = 1;"
             + "x.prototype.y.g = 1;",
         loadPrototype("x")
-            + TMP + ".y.a = 1;"
-            + TMP + ".y.b = 1;"
-            + TMP + ".y.c = 1;"
-            + TMP + ".y.d = 1;"
-            + TMP + ".y.e = 1;"
-            + TMP + ".y.f = 1;"
-            + TMP + ".y.g = 1;");
+            + tmp + ".y.a = 1;"
+            + tmp + ".y.b = 1;"
+            + tmp + ".y.c = 1;"
+            + tmp + ".y.d = 1;"
+            + tmp + ".y.e = 1;"
+            + tmp + ".y.f = 1;"
+            + tmp + ".y.g = 1;");
   }
 
   @Test
   public void testWithDevirtualization() {
+    String tmp = TMP + "0";
     extract(
         "x.prototype.a = 1;"
             + "x.prototype.b = 1;"
@@ -180,14 +184,14 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
             + "x.prototype.f = 1;"
             + "x.prototype.g = 1;",
         loadPrototype("x")
-            + TMP + ".a = 1;"
-            + TMP + ".b = 1;"
+            + tmp + ".a = 1;"
+            + tmp + ".b = 1;"
             + "function devirtualize1() { }"
-            + TMP + ".c = 1;"
-            + TMP + ".d = 1;"
-            + TMP + ".e = 1;"
-            + TMP + ".f = 1;"
-            + TMP + ".g = 1;");
+            + tmp + ".c = 1;"
+            + tmp + ".d = 1;"
+            + tmp + ".e = 1;"
+            + tmp + ".f = 1;"
+            + tmp + ".g = 1;");
 
     extract(
         "x.prototype.a = 1;"
@@ -201,16 +205,16 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
             + "function devirtualize3() { }"
             + "x.prototype.g = 1;",
         loadPrototype("x")
-            + TMP + ".a = 1;"
-            + TMP + ".b = 1;"
+            + tmp + ".a = 1;"
+            + tmp + ".b = 1;"
             + "function devirtualize1() { }"
-            + TMP + ".c = 1;"
-            + TMP + ".d = 1;"
+            + tmp + ".c = 1;"
+            + tmp + ".d = 1;"
             + "function devirtualize2() { }"
-            + TMP + ".e = 1;"
-            + TMP + ".f = 1;"
+            + tmp + ".e = 1;"
+            + tmp + ".f = 1;"
             + "function devirtualize3() { }"
-            + TMP + ".g = 1;");
+            + tmp + ".g = 1;");
   }
 
   @Test
@@ -219,14 +223,14 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
 
     extract(
         generatePrototypeDeclarations("x", 3),
-        generateExtractedDeclarations(3) + loadPrototype("x"));
+        generateExtractedDeclarations(0, 3) + loadPrototype("x"));
 
     testSame(generatePrototypeDeclarations("x", 1));
     testSame(generatePrototypeDeclarations("x", 2));
 
     extract(
         generatePrototypeDeclarations("x", 7),
-        generateExtractedDeclarations(7) + loadPrototype("x"));
+        generateExtractedDeclarations(0, 7) + loadPrototype("x"));
   }
 
   @Test
@@ -283,9 +287,46 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
             + "bar();");
   }
 
+  @Test
+  public void testNotEnoughPrototypeToExtractInChunk() {
+    for (int i = 0; i < 7; i++) {
+      JSModule[] modules = JSChunkGraphBuilder.forStar()
+          .addChunk(generatePrototypeDeclarations("x", i))
+          .addChunk(generatePrototypeDeclarations("y", i))
+          .build();
+      testSame(modules);
+    }
+  }
+
+  @Test
+  public void testExtractingSingleClassPrototypeInChunk() {
+    JSModule[] modules = JSChunkGraphBuilder.forStar()
+        .addChunk(generatePrototypeDeclarations("x", 7))
+        .addChunk(generatePrototypeDeclarations("y", 7))
+        .build();
+
+    StringBuilder builderX = new StringBuilder();
+    StringBuilder builderY = new StringBuilder();
+    String X_TMP = TMP + "0";
+    String Y_TMP = TMP + "1";
+    builderX
+        .append("var " + X_TMP + ";" + X_TMP + " = x.prototype;")
+        .append(generateExtractedDeclarations(0, 7));
+    builderY
+        .append("var " + Y_TMP + ";" + Y_TMP + " = y.prototype;")
+        .append(generateExtractedDeclarations(1, 7));
+
+    JSModule[] expectedModules = JSChunkGraphBuilder.forStar()
+        .addChunk(builderX.toString())
+        .addChunk(builderY.toString())
+        .build();
+
+    test(modules, expectedModules);
+  }
+
   private String loadPrototype(String qName) {
     if (pattern == Pattern.USE_GLOBAL_TEMP) {
-      return TMP + " = " + qName + ".prototype;";
+      return TMP + "0 = " + qName + ".prototype;";
     } else {
       return "})(" + qName + ".prototype);";
     }
@@ -293,7 +334,7 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
 
   private void extract(String src, String expected) {
     if (pattern == Pattern.USE_GLOBAL_TEMP) {
-      test(src, "var " + TMP + ";" + expected);
+      test(src, "var " + TMP + "0;" + expected);
     } else {
       test(src, expected);
     }
@@ -312,21 +353,24 @@ public final class ExtractPrototypeMemberDeclarationsTest extends CompilerTestCa
     return className + ".prototype." + member + " = " + value + ";";
   }
 
-  private String generateExtractedDeclarations(int num) {
+  private String generateExtractedDeclarations(int fileIndex, int num) {
     StringBuilder builder = new StringBuilder();
 
+    String alias = TMP;
     if (pattern == Pattern.USE_IIFE) {
       builder.append("(function(").append(TMP).append("){");
+    } else {
+      alias += fileIndex;
     }
 
     for (int i = 0; i < num; i++) {
       char member = (char) ('a' + i);
-      builder.append(generateExtractedDeclaration("" + member,  "" + member));
+      builder.append(generateExtractedDeclaration(alias, "" + member,  "" + member));
     }
     return builder.toString();
   }
 
-  private String generateExtractedDeclaration(String member, String value) {
-    return TMP + "." + member + " = " + value + ";";
+  private String generateExtractedDeclaration(String alias, String member, String value) {
+    return alias + "." + member + " = " + value + ";";
   }
 }


### PR DESCRIPTION
Switches from a single global variable to a per chunk variable. The prevents RescopeGlobalSymbolNames from adding a global namespace lookup to every variable reference thus undoing some of the benefit of the pass.

Also required for #3367 to prevent attempting to write to a variable in a separate chunk.