### PR TITLE
rules.jarjar: shade apache/tools & kohsuke/args4j

### DIFF
--- a/rules.jarjar
+++ b/rules.jarjar
@@ -7,3 +7,5 @@ rule com.google.**         com.google.javascript.jscomp.jarjar.@0
 rule javax.**              com.google.javascript.jscomp.jarjar.@0
 rule jsr305_annotations.** com.google.javascript.jscomp.jarjar.@0
 rule org.json.**           com.google.javascript.jscomp.jarjar.@0
+rule org.kohsuke.args4j.** com.google.javascript.jscomp.jarjar.@0
+rule org.apache.tools.**   com.google.javascript.jscomp.jarjar.@0


### PR DESCRIPTION
These third party dependencies are incorrectly being distributed unshaded in the closure-compiler.jar. This update to the jarjar rules fixes that.

Fixes #3731