### PR TITLE
Update package.json, runtime_tests to use Bazel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "closure-compiler",
   "config": {
-    "runtime_tests_dir": "./test/com/google/javascript/jscomp/runtime_tests"
+    "runtime_tests": "./test/com/google/javascript/jscomp/runtime_tests"
   },
   "version": "1.0.0",
   "repository": "git@github.com:google/closure-compiler.git",
@@ -19,13 +19,14 @@
     "jsdom": "^16.3.0"
   },
   "scripts": {
-    "build": "clean && mvn -DskipTests",
-    "build:fast": "mvn -DskipTests -pl externs/pom.xml,pom-main.xml,pom-main-shaded.xml",
-    "clean": "yarn runtime_tests:clean && mvn clean",
-    "runtime_tests:build": "$npm_package_config_runtime_tests_dir/utils/build.sh",
-    "runtime_tests:clean": "rm -rf $npm_package_config_runtime_tests_dir/**/build/*",
-    "runtime_tests:run": "jest --testRegex $npm_package_config_runtime_tests_dir/utils/test/* --verbose=true",
-    "runtime_tests": "yarn runtime_tests:clean && yarn run --silent runtime_tests:build && yarn run --silent runtime_tests:run",
-    "test": "mvn test"
+    "build": "bazel build //:compiler_unshaded_deploy.jar",
+    "build:all": "bazel build :all",
+    "clean": "yarn runtime_tests:clean && bazel clean",
+    "runtime_tests:clean": "rm -rf $npm_package_config_runtime_tests/**/build/*",
+    "runtime_tests:build": "$npm_package_config_runtime_tests/utils/build.sh",
+    "runtime_tests:run": "jest --testRegex $npm_package_config_runtime_tests/utils/test/* --verbose=true",
+    "runtime_tests": "yarn --silent runtime_tests:clean && yarn --silent runtime_tests:build && yarn run runtime_tests:run",
+    "test": "bazel test //:compiler_unshaded_deploy.jar",
+    "test:all": "bazel test :all"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "bazel build //:compiler_unshaded_deploy.jar",
     "build:all": "bazel build :all",
-    "compiler": "java -jar bazel-bin/compiler_unshaded_deploy.jar",
+    "compile": "java -jar bazel-bin/compiler_unshaded_deploy.jar",
     "clean": "yarn runtime_tests:clean && bazel clean",
     "runtime_tests:clean": "rm -rf $npm_package_config_runtime_tests/**/build/*",
     "runtime_tests:build": "$npm_package_config_runtime_tests/utils/build.sh",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "bazel build //:compiler_unshaded_deploy.jar",
     "build:all": "bazel build :all",
+    "compiler": "java -jar bazel-bin/compiler_unshaded_deploy.jar",
     "clean": "yarn runtime_tests:clean && bazel clean",
     "runtime_tests:clean": "rm -rf $npm_package_config_runtime_tests/**/build/*",
     "runtime_tests:build": "$npm_package_config_runtime_tests/utils/build.sh",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "build": "bazel build //:compiler_unshaded_deploy.jar",
     "build:all": "bazel build :all",
     "compile": "java -jar bazel-bin/compiler_unshaded_deploy.jar",
-    "clean": "yarn runtime_tests:clean && bazel clean",
+    "clean": "npm run runtime_tests:clean && bazel clean",
     "runtime_tests:clean": "rm -rf $npm_package_config_runtime_tests/**/build/*",
     "runtime_tests:build": "$npm_package_config_runtime_tests/utils/build.sh",
     "runtime_tests:run": "jest --testRegex $npm_package_config_runtime_tests/utils/test/* --verbose=true",
-    "runtime_tests": "yarn --silent runtime_tests:clean && yarn --silent runtime_tests:build && yarn run runtime_tests:run",
+    "runtime_tests": "npm run --silent runtime_tests:clean && npm run --silent runtime_tests:build && npm run runtime_tests:run",
     "test": "bazel test //:all",
     "test:all": "npm run test && npm run runtime_tests"
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chalk": "^4.1.0",
     "future-event": "^1.5.0",
     "glob": "^7.1.6",
-    "google-closure-library": "^20200719.0.0",
+    "google-closure-library": "^20201102.0.1",
     "jest": "^26.1.0",
     "jsdom": "^16.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "runtime_tests:build": "$npm_package_config_runtime_tests/utils/build.sh",
     "runtime_tests:run": "jest --testRegex $npm_package_config_runtime_tests/utils/test/* --verbose=true",
     "runtime_tests": "yarn --silent runtime_tests:clean && yarn --silent runtime_tests:build && yarn run runtime_tests:run",
-    "test": "bazel test //:compiler_unshaded_deploy.jar",
-    "test:all": "bazel test :all"
+    "test": "bazel test //:all",
+    "test:all": "npm run test && npm run runtime_tests"
   }
 }

--- a/test/com/google/javascript/jscomp/runtime_tests/module_tests/module_test_resources/+subdir/module_es6.js
+++ b/test/com/google/javascript/jscomp/runtime_tests/module_tests/module_test_resources/+subdir/module_es6.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/com/google/javascript/jscomp/runtime_tests/utils/build.sh
+++ b/test/com/google/javascript/jscomp/runtime_tests/utils/build.sh
@@ -13,11 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Accept a test pattern (PATTERN_test.js) to look for.
 if [ -z $1 ]; then
-  COMPILATION_LEVEL="SIMPLE"
-else
-  COMPILATION_LEVEL=$1
+    TEST_PATTERN="*"
+  else
+    TEST_PATTERN=$1;
 fi
+
+# Use SIMPLE mode for now.
+COMPILATION_LEVEL="SIMPLE"
 
 # This directory.
 THIS_DIR=$(dirname $0)
@@ -27,9 +31,9 @@ PROJECT_ROOT=$(readlink -f $THIS_DIR/../../../../../../..)
 
 # Get the location of the local compiler in this directory, if it exists.
 # If it doesn't, build it, then resume execution.
-LOCAL_COMPILER="$PROJECT_ROOT/target/closure-compiler-1.0-SNAPSHOT.jar"
+LOCAL_COMPILER="$PROJECT_ROOT/bazel-bin/compiler_unshaded_deploy.jar"
 if [ ! -f "$LOCAL_COMPILER" ]; then
-  echo -e "\nCompiler JAR not built. Building...\n" && yarn build:fast
+  echo -e "\nCompiler JAR not built. Building...\n" && npm run build
 fi
 
 # Build tests from the $TEST_DIR directory, where files like
@@ -88,5 +92,5 @@ EOF
 
 # build tests
 time(
-  compileRuntimeTests $(find $ABS_PATH -type f -name '*_test.js')
+  compileRuntimeTests $(find $ABS_PATH -type f -name "${TEST_PATTERN}_test.js")
 )


### PR DESCRIPTION
Please let me know if any changes are needed. This PR mainly just updates the old package.json scripts to use Bazel instead of Maven and closes #3743, but some other small package.json updates are included:

- Upgraded NPM deps
- Added `yarn compiler` script so you can easily run `yarn compiler -O ADVANCED file.js` to call the locally built version of the compiler in `bazel-bin/`

And a few runtime test tweaks:
- Missing runtime test was added
- `runtime_tests:build` can now accept a test pattern as an argument (e.g. `yarn runtime_tests:build module_runtime` to build `module_runtime_test.js` only)

---

I will submit README updates about building the compiler with `yarn build` and building/running the runtime tests as part of a PR dedicated strictly to refreshing the README. 