### PR TITLE
Feature: Enable cross chunk code motion for pure function values

### DIFF
--- a/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
+++ b/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
@@ -350,6 +350,10 @@ public final class CrossChunkReferenceCollector implements ScopedCallback, Compi
         return true;
 
       case CALL:
+        if (valueNode.getSideEffectFlags() == 0) {
+          return true;
+        }
+
         // In general it is not safe to move function calls, but we carve out an exception
         // for the special stub method calls used for CrossChunkMethodMotion.
         // Case: `JSCompiler_stubMethod(x)`

--- a/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
+++ b/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
@@ -351,7 +351,7 @@ public final class CrossChunkReferenceCollector implements ScopedCallback, Compi
 
       case CALL:
         // If the function has been marked as having no side effects then it is safe to move to another module.
-        if (valueNode.getSideEffectFlags() == 0) {
+        if (valueNode.isNoSideEffectsCall()) {
           return true;
         }
 

--- a/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
+++ b/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
@@ -16,16 +16,21 @@
 
 package com.google.javascript.jscomp;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.javascript.jscomp.NodeTraversal.ScopedCallback;
 import com.google.javascript.rhino.Node;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
-import java.util.*;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 /** Collects global variable references for use by {@link CrossChunkCodeMotion}. */
 public final class CrossChunkReferenceCollector implements ScopedCallback, CompilerPass {

--- a/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
+++ b/src/com/google/javascript/jscomp/CrossChunkReferenceCollector.java
@@ -16,21 +16,16 @@
 
 package com.google.javascript.jscomp;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.javascript.jscomp.NodeTraversal.ScopedCallback;
 import com.google.javascript.rhino.Node;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
 import javax.annotation.Nullable;
+import java.util.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 /** Collects global variable references for use by {@link CrossChunkCodeMotion}. */
 public final class CrossChunkReferenceCollector implements ScopedCallback, CompilerPass {
@@ -350,11 +345,12 @@ public final class CrossChunkReferenceCollector implements ScopedCallback, Compi
         return true;
 
       case CALL:
+        // If the function has been marked as having no side effects then it is safe to move to another module.
         if (valueNode.getSideEffectFlags() == 0) {
           return true;
         }
 
-        // In general it is not safe to move function calls, but we carve out an exception
+        // In general it is not safe to move function calls with side effects, but we carve out an exception
         // for the special stub method calls used for CrossChunkMethodMotion.
         // Case: `JSCompiler_stubMethod(x)`
         Node functionName = checkNotNull(valueNode.getFirstChild());


### PR DESCRIPTION
This PR enables calls to pure function to be moved to deeper chunks.

For example,

if the root chunk contains:

```
function pure(a) {
   return a + 1;
}

var b = pure(1);
```

and a child chunk with a dependency on the root contains:

```
var c = b;
```

Then the `pure` and `b` globals are moved to the child chunk.

This has a significant impact on large code bases that make use of factories to create globals. One of our builds is 10mb in size, with a root chunk of 1.8mb, this change reduces the root chunk to 1.6mb, or a 11% reduction.

Related feature request from a few years ago:
https://github.com/google/closure-compiler/issues/2316
