### PR TITLE
Add support for rewriting dynamic import expressions

### DIFF
--- a/src/com/google/javascript/jscomp/AstFactory.java
+++ b/src/com/google/javascript/jscomp/AstFactory.java
@@ -455,6 +455,10 @@ final class AstFactory {
     return createQName(scope, DOT_SPLITTER.split(qname));
   }
 
+  Node createQNameWithUnknownType(String qname) {
+    return createQNameWithUnknownType(DOT_SPLITTER.split(qname));
+  }
+
   /**
    * Looks up the type of a name from a {@link TypedScope} created from typechecking
    *
@@ -482,6 +486,12 @@ final class AstFactory {
     return createQName(scope, baseName, propertyNames);
   }
 
+  private Node createQNameWithUnknownType(Iterable<String> names) {
+    String baseName = checkNotNull(Iterables.getFirst(names, null));
+    Iterable<String> propertyNames = Iterables.skip(names, 1);
+    return createQNameWithUnknownType(baseName, propertyNames);
+  }
+
   Node createQName(Scope scope, String baseName, String... propertyNames) {
     checkNotNull(baseName);
     return createQName(scope, baseName, Arrays.asList(propertyNames));
@@ -489,6 +499,11 @@ final class AstFactory {
 
   Node createQName(Scope scope, String baseName, Iterable<String> propertyNames) {
     Node baseNameNode = createName(scope, baseName);
+    return createGetProps(baseNameNode, propertyNames);
+  }
+
+  Node createQNameWithUnknownType(String baseName, Iterable<String> propertyNames) {
+    Node baseNameNode = createNameWithUnknownType(baseName);
     return createGetProps(baseNameNode, propertyNames);
   }
 
@@ -840,6 +855,14 @@ final class AstFactory {
       result.setJSType(type);
     }
     return result;
+  }
+
+  Node createParamList(String... parameterNames) {
+    final Node paramList = IR.paramList();
+    for (String parameterName : parameterNames) {
+      paramList.addChildToBack(createNameWithUnknownType(parameterName));
+    }
+    return paramList;
   }
 
   Node createZeroArgFunction(String name, Node body, @Nullable JSType returnType) {

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -947,6 +947,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 + "expressions are not yet fully supported and may lead to broken output code.")
     private boolean allowDynamicImport = false;
 
+    @Option(
+        name = "--dynamic_import_alias",
+        usage =
+            "Instructs the compiler to replace dynamic imports expressions with a function call "
+                + "using the specified name. Allows dynamic import expressions to be externally "
+                + "polyfilled when the output language level does not natively support them.")
+    private String dynamicImportAlias = null;
+
     @Argument private List<String> arguments = new ArrayList<>();
     private final CmdLineParser parser;
 
@@ -1033,6 +1041,8 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
             .putAll(
                 "JS Modules",
                 ImmutableList.of(
+                    "allow_dynamic_import",
+                    "dynamic_import_alias",
                     "js_module_root",
                     "module_resolution",
                     "process_common_js_modules",
@@ -2002,6 +2012,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     options.setInstrumentForCoverageOption(flags.instrumentCodeParsed);
     options.setProductionInstrumentationArrayName(flags.productionInstrumentationArrayName);
     options.setAllowDynamicImport(flags.allowDynamicImport);
+    options.setDynamicImportAlias(flags.dynamicImportAlias);
 
     if (flags.chunkOutputType == ChunkOutputType.ES_MODULES
         && flags.renamePrefixNamespace != null) {

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1207,8 +1207,6 @@ public class CompilerOptions implements Serializable {
     return this.allowDynamicImport;
   }
 
-  ChunkOutputType chunkOutputType;
-
   private String dynamicImportAlias = null;
 
   /** Set the alias name for dynamic import expressions */
@@ -1224,6 +1222,8 @@ public class CompilerOptions implements Serializable {
   boolean shouldAliasDynamicImport() {
     return this.dynamicImportAlias != null;
   }
+
+  ChunkOutputType chunkOutputType;
 
   /**
    * Initializes compiler options. All options are disabled by default.

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1209,6 +1209,22 @@ public class CompilerOptions implements Serializable {
 
   ChunkOutputType chunkOutputType;
 
+  private String dynamicImportAlias = null;
+
+  /** Set the alias name for dynamic import expressions */
+  public String getDynamicImportAlias() {
+    return this.dynamicImportAlias;
+  }
+
+  /** Set the alias name for dynamic import expressions */
+  public void setDynamicImportAlias(String value) {
+    this.dynamicImportAlias = value;
+  }
+
+  boolean shouldAliasDynamicImport() {
+    return this.dynamicImportAlias != null;
+  }
+
   /**
    * Initializes compiler options. All options are disabled by default.
    *

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -394,8 +394,8 @@ public final class DefaultPassConfig extends PassConfig {
     }
 
     // Dynamic import rewriting must always occur after type checking
-    if (options.shouldAllowDynamicImport() &&
-        options.getLanguageIn().toFeatureSet().has(Feature.DYNAMIC_IMPORT)) {
+    if (options.shouldAllowDynamicImport()
+        && options.getLanguageIn().toFeatureSet().has(Feature.DYNAMIC_IMPORT)) {
       checks.add(rewriteDynamicImports);
     }
 
@@ -2919,7 +2919,9 @@ public final class DefaultPassConfig extends PassConfig {
       PassFactory.builder()
           .setName("REWRITE_DYNAMIC_IMPORT")
           .setFeatureSet(FeatureSet.all())
-          .setInternalFactory((compiler) ->
-              new RewriteDynamicImports(compiler, compiler.getOptions().getDynamicImportAlias()))
+          .setInternalFactory(
+              (compiler) ->
+                  new RewriteDynamicImports(
+                      compiler, compiler.getOptions().getDynamicImportAlias()))
           .build();
 }

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -393,6 +393,12 @@ public final class DefaultPassConfig extends PassConfig {
       }
     }
 
+    // Dynamic import rewriting must always occur after type checking
+    if (options.shouldAllowDynamicImport() &&
+        options.getLanguageIn().toFeatureSet().has(Feature.DYNAMIC_IMPORT)) {
+      checks.add(rewriteDynamicImports);
+    }
+
     // We assume that only clients who are going to re-compile, or do in-depth static analysis,
     // will need the typed scope creator after the compile job.
     if (!options.preservesDetailedSourceInfo() && !options.allowsHotswapReplaceScript()) {
@@ -2906,5 +2912,14 @@ public final class DefaultPassConfig extends PassConfig {
           .setName("FORBID_DYNAMIC_IMPORT")
           .setFeatureSet(FeatureSet.all())
           .setInternalFactory(ForbidDynamicImportUsage::new)
+          .build();
+
+  /** Rewrites Dynamic Import Expressions */
+  private static final PassFactory rewriteDynamicImports =
+      PassFactory.builder()
+          .setName("REWRITE_DYNAMIC_IMPORT")
+          .setFeatureSet(FeatureSet.all())
+          .setInternalFactory((compiler) ->
+              new RewriteDynamicImports(compiler, compiler.getOptions().getDynamicImportAlias()))
           .build();
 }

--- a/src/com/google/javascript/jscomp/FindModuleDependencies.java
+++ b/src/com/google/javascript/jscomp/FindModuleDependencies.java
@@ -165,7 +165,9 @@ public class FindModuleDependencies implements NodeTraversal.ScopedCallback {
     } else if (supportsEs6Modules && n.isImport()) {
       moduleType = ModuleType.ES6;
       addEs6ModuleImportToGraph(t, n);
-    } else if (supportsEs6Modules && n.getToken() == Token.DYNAMIC_IMPORT && n.getFirstChild().isString()) {
+    } else if (supportsEs6Modules
+        && n.getToken() == Token.DYNAMIC_IMPORT
+        && n.getFirstChild().isString()) {
       String path = n.getFirstChild().getString();
       ModuleLoader.ModulePath modulePath =
           t.getInput()

--- a/src/com/google/javascript/jscomp/FindModuleDependencies.java
+++ b/src/com/google/javascript/jscomp/FindModuleDependencies.java
@@ -165,6 +165,15 @@ public class FindModuleDependencies implements NodeTraversal.ScopedCallback {
     } else if (supportsEs6Modules && n.isImport()) {
       moduleType = ModuleType.ES6;
       addEs6ModuleImportToGraph(t, n);
+    } else if (supportsEs6Modules && n.getToken() == Token.DYNAMIC_IMPORT && n.getFirstChild().isString()) {
+      String path = n.getFirstChild().getString();
+      ModuleLoader.ModulePath modulePath =
+          t.getInput()
+              .getPath()
+              .resolveJsModule(path, n.getSourceFileName(), n.getLineno(), n.getCharno());
+      if (modulePath != null) {
+        t.getInput().addDynamicRequire(modulePath.toModuleName());
+      }
     } else if (supportsCommonJsModules) {
       if (moduleType != ModuleType.GOOG
           && ProcessCommonJSModules.isCommonJsExport(t, n, resolutionMode)) {

--- a/src/com/google/javascript/jscomp/RewriteDynamicImports.java
+++ b/src/com/google/javascript/jscomp/RewriteDynamicImports.java
@@ -31,6 +31,7 @@ import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.JSTypeExpression;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
+import com.google.javascript.rhino.jstype.FunctionType;
 import com.google.javascript.rhino.jstype.JSType;
 import com.google.javascript.rhino.jstype.JSTypeNative;
 import com.google.javascript.rhino.jstype.JSTypeRegistry;
@@ -38,19 +39,21 @@ import com.google.javascript.rhino.jstype.TemplatizedType;
 import javax.annotation.Nullable;
 
 /**
- * Rewrite dynamic import expressions to account for bundling and module rewriting.
- * Since dynamic imports cannot be fully polyfilled, optionally support replacing the expression
- * with a function call which indicates an external polyfill is utilized.
+ * Rewrite dynamic import expressions to account for bundling and module rewriting. Since dynamic
+ * imports cannot be fully polyfilled, optionally support replacing the expression with a function
+ * call which indicates an external polyfill is utilized.
  *
- * If the import specifier is a string literal and the module resolver recognizes the target,
- * the pass retargets the specifier to the correct output chunk.
+ * <p>If the import specifier is a string literal and the module resolver recognizes the target, the
+ * pass retargets the specifier to the correct output chunk.
  *
- * Example from:
+ * <p>Example from:
+ *
  * <pre>
  *   import('./input-module1.js');
  * </pre>
  *
  * To:
+ *
  * <pre>
  *   imprt_('./output-chunk0.js').then(function() { return module$output$chunk0; });
  * </pre>
@@ -58,27 +61,27 @@ import javax.annotation.Nullable;
 public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallback
     implements CompilerPass {
 
-  static final DiagnosticType UNABLE_TO_COMPUTE_RELATIVE_PATH = DiagnosticType.error(
-      "JSC_UNABLE_TO_COMPUTE_RELATIVE_PATH",
-      "Unable to compute relative import path from \"{0}\" to \"{1}\"");
+  static final DiagnosticType UNABLE_TO_COMPUTE_RELATIVE_PATH =
+      DiagnosticType.error(
+          "JSC_UNABLE_TO_COMPUTE_RELATIVE_PATH",
+          "Unable to compute relative import path from \"{0}\" to \"{1}\"");
 
-  static final DiagnosticType DYNAMIC_IMPORT_ALIAS_MISSING = DiagnosticType.warning(
-      "JSC_DYNAMIC_IMPORT_ALIAS_MISSING",
-      "A dynamic import alias is specified as a qualified name but the definition " +
-          "is missing: \"{0}\"");
+  static final DiagnosticType DYNAMIC_IMPORT_ALIAS_MISSING =
+      DiagnosticType.warning(
+          "JSC_DYNAMIC_IMPORT_ALIAS_MISSING",
+          "A dynamic import alias is specified as a qualified name but the definition "
+              + "is missing: \"{0}\"");
 
   private final AbstractCompiler compiler;
+  private final AstFactory astFactory;
   private final String alias;
   private boolean dynamicImportsRemoved = false;
   private boolean shouldInjectAliasExtern = false;
 
-  /**
-   *
-   *
-   * @param compiler The compiler
-   */
-  public RewriteDynamicImports(AbstractCompiler compiler, @Nullable  String alias) {
+  /** @param compiler The compiler */
+  public RewriteDynamicImports(AbstractCompiler compiler, @Nullable String alias) {
     this.compiler = compiler;
+    this.astFactory = compiler.createAstFactory();
     this.alias = alias;
   }
 
@@ -88,11 +91,11 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     shouldInjectAliasExtern = false;
     checkArgument(externs.isRoot(), externs);
     checkArgument(root.isRoot(), root);
-    ScopeCreator scopeCreator = new TypedScopeCreator(compiler);
-    NodeTraversal nodeTraversal = new NodeTraversal(compiler, this, scopeCreator);
-    nodeTraversal.traverse(root.getParent());
+    NodeTraversal.traverse(compiler, root, this);
     if (dynamicImportsRemoved) {
-      compiler.setFeatureSet(compiler.getFeatureSet().without(Feature.DYNAMIC_IMPORT));
+      // This pass removes dynamic import, but adds arrow functions.
+      compiler.setFeatureSet(
+          compiler.getFeatureSet().without(Feature.DYNAMIC_IMPORT).with(Feature.ARROW_FUNCTIONS));
     }
     if (shouldInjectAliasExtern) {
       injectAliasAsExtern(externs);
@@ -106,17 +109,24 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     }
 
     // If the module specifier is a string, attempt to resolve the module
-    ModuleMap moduleMap = compiler.getModuleMap();
-    Node importSpecifier = n.getFirstChild();
+    final ModuleMap moduleMap = compiler.getModuleMap();
+    final Node importSpecifier = n.getFirstChild();
     if (importSpecifier.isString() && moduleMap != null) {
-      ModulePath targetPath = compiler.getModuleLoader().resolve(importSpecifier.getString());
-      TypedVar targetModuleNS = getModuleNamespaceVar(t, compiler.getModuleMap().getModule(targetPath));
+      final ModulePath targetPath = compiler.getModuleLoader().resolve(importSpecifier.getString());
+      final Module module = compiler.getModuleMap().getModule(targetPath);
+      final String targetModuleVarName =
+          (module == null)
+              ? null
+              : GlobalizedModuleName.create(module.metadata(), null, null).aliasName().join();
+      final Var targetModuleNS =
+          (targetModuleVarName == null) ? null : t.getScope().getVar(targetModuleVarName);
+
       if (targetModuleNS != null) {
-        JSModule targetModule = targetModuleNS.getInput().getModule();
+        final JSModule targetModule = targetModuleNS.getInput().getModule();
         // If the target module is bundled into the same output chunk, replace the import statement
         // with a promise that resolves to the module namespace.
         // No further rewriting occurs for this case.
-        if (t.getModule() == targetModuleNS.getInput().getModule()) {
+        if (t.getModule() == targetModule) {
           replaceDynamicImportWithPromise(t, n, targetModuleNS);
           return;
         } else {
@@ -138,27 +148,26 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
   /**
    * Replace a dynamic import expression with a promise resolving to the rewritten module namespace.
    *
-   * Before
+   * <p>Before
+   *
    * <pre>
    *   import('./foo.js');
    * </pre>
    *
    * After
+   *
    * <pre>
    *   Promise.resolve(module$foo);
    * </pre>
    */
-  private void replaceDynamicImportWithPromise(NodeTraversal t, Node dynamicImport, TypedVar targetModuleNS) {
-    JSTypeRegistry registry = compiler.getTypeRegistry();
-    Node promise = IR.name("Promise");
-    promise.setJSType(registry.getGlobalType("Promise"));
-
-    Node resolve = IR.string("resolve");
-    resolve.setJSType(registry.getNativeType(JSTypeNative.STRING_TYPE));
-
-    Node promiseResolve = IR.getprop(promise, resolve);
-    Node promiseResolveCall = IR.call(promiseResolve);
-    boolean isExpressionUsed = NodeUtil.isExpressionResultUsed(dynamicImport);
+  private void replaceDynamicImportWithPromise(
+      NodeTraversal t, Node dynamicImport, Var targetModuleNS) {
+    final Scope scope = t.getScope();
+    final JSTypeRegistry registry = compiler.getTypeRegistry();
+    final Node promiseDotResolve =
+        astFactory.createQName(scope.getGlobalScope(), "Promise.resolve");
+    final Node promiseResolveCall = astFactory.createCall(promiseDotResolve);
+    final boolean isExpressionUsed = NodeUtil.isExpressionResultUsed(dynamicImport);
     if (isExpressionUsed) {
       JSType moduleNamespaceType;
       if (dynamicImport.getJSType() != null && dynamicImport.getJSType().isTemplatizedType()) {
@@ -167,22 +176,24 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
       } else {
         moduleNamespaceType = registry.getNativeType(JSTypeNative.UNKNOWN_TYPE);
       }
-      promiseResolve.setJSType(registry.createFunctionType(
-          registry.createTemplatizedType(
-              registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
-              moduleNamespaceType),
-          registry.getNativeType(JSTypeNative.ALL_TYPE)));
-      promiseResolveCall.addChildToBack(getModuleNamespaceNode(targetModuleNS));
+      promiseDotResolve.setJSType(
+          registry.createFunctionType(
+              registry.createTemplatizedType(
+                  registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE), moduleNamespaceType),
+              registry.getNativeType(JSTypeNative.ALL_TYPE)));
+      promiseResolveCall.addChildToBack(createModuleNamespaceNode(targetModuleNS));
       promiseResolveCall.setJSType(dynamicImport.getJSType());
     } else {
-      promiseResolve.setJSType(registry.createFunctionType(
+      promiseDotResolve.setJSType(
+          registry.createFunctionType(
+              registry.createTemplatizedType(
+                  registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+                  registry.getNativeType(JSTypeNative.VOID_TYPE)),
+              registry.getNativeType(JSTypeNative.ALL_TYPE)));
+      promiseResolveCall.setJSType(
           registry.createTemplatizedType(
               registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
-              registry.getNativeType(JSTypeNative.VOID_TYPE)),
-          registry.getNativeType(JSTypeNative.ALL_TYPE)));
-      promiseResolveCall.setJSType(registry.createTemplatizedType(
-          registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
-          registry.getNativeType(JSTypeNative.VOID_TYPE)));
+              registry.getNativeType(JSTypeNative.VOID_TYPE)));
     }
     promiseResolveCall.useSourceInfoFromForTree(dynamicImport);
     Node parent = dynamicImport.getParent();
@@ -198,12 +209,14 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
   /**
    * Rewrite the dynamic import specifier to the output chunk path
    *
-   * Before
+   * <p>Before
+   *
    * <pre>
    *   import('./foo.js');
    * </pre>
    *
    * After
+   *
    * <pre>
    *   import('./chunk0.js');
    * </pre>
@@ -224,144 +237,126 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
               targetChunkFilename));
       return;
     }
-    Node newSpecifier = IR.string(retargetedSpecifier)
-        .useSourceInfoFrom(dynamicImport.getFirstChild());
-    newSpecifier.setJSType(dynamicImport.getFirstChild().getJSType());
-    dynamicImport.getFirstChild().replaceWith(newSpecifier);
-    t.reportCodeChange(dynamicImport.getFirstChild());
+    final Node originalSpecifierNode = dynamicImport.getFirstChild();
+    Node newSpecifier =
+        astFactory.createString(retargetedSpecifier).useSourceInfoFrom(originalSpecifierNode);
+    originalSpecifierNode.replaceWith(newSpecifier);
+    t.reportCodeChange(newSpecifier);
   }
 
   /**
-   * Since a dynamic import expression is a promise resolving to the namespace export type,
-   * add a ".then()" call after it and resolve to the rewritten module namespace.
+   * Since a dynamic import expression is a promise resolving to the namespace export type, add a
+   * ".then()" call after it and resolve to the rewritten module namespace.
    *
-   * Before
+   * <p>Before
+   *
    * <pre>
    *   import('./foo.js');
    * </pre>
    *
    * After
+   *
    * <pre>
    *   import('./foo.js').then(function() { return module$foo; });
    * </pre>
    */
-  private void addChainedThen(NodeTraversal t, Node dynamicImport, TypedVar targetModuleNs) {
+  private void addChainedThen(NodeTraversal t, Node dynamicImport, Var targetModuleNs) {
     JSTypeRegistry registry = compiler.getTypeRegistry();
-    Node importParent = dynamicImport.getParent();
-    Node placeholder = IR.string("");
+    final Node importParent = dynamicImport.getParent();
+    final Node placeholder = IR.empty();
     importParent.replaceChild(dynamicImport, placeholder);
-    Node thenCallback = IR.function(
-        IR.name(""),
-        IR.paramList(),
-        IR.block(
-            IR.returnNode(
-                getModuleNamespaceNode(targetModuleNs))));
-    thenCallback.setJSType(registry.createFunctionType(dynamicImport.getJSType()));
-
-    Node importThenCall = IR.call(
-        IR.getprop(
-            dynamicImport,
-            IR.string("then")),
-        thenCallback);
-    importThenCall.getFirstChild().setJSType(registry.createFunctionType(
-        registry.createTemplatizedType(
-            registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
-            registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
-        registry.createFunctionType(registry.getNativeType(JSTypeNative.ALL_TYPE))
-    ));
+    final Node moduleNamespaceNode = createModuleNamespaceNode(targetModuleNs);
+    final Node callbackFn = astFactory.createZeroArgArrowFunctionForExpression(moduleNamespaceNode);
+    final Node importThenCall =
+        astFactory.createCall(astFactory.createGetProp(dynamicImport, "then"), callbackFn);
+    importThenCall
+        .getFirstChild()
+        .setJSType(
+            registry.createFunctionType(
+                registry.createTemplatizedType(
+                    registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+                    registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
+                registry.createFunctionType(registry.getNativeType(JSTypeNative.ALL_TYPE))));
     importThenCall.useSourceInfoIfMissingFromForTree(dynamicImport);
     if (dynamicImport.getJSType() != null) {
       importThenCall.setJSType(dynamicImport.getJSType());
     }
     importParent.replaceChild(placeholder, importThenCall);
-    t.reportCodeChange(NodeUtil.getFunctionBody(thenCallback));
-    t.reportCodeChange(importThenCall);
+    compiler.reportChangeToChangeScope(callbackFn);
+    compiler.reportChangeToEnclosingScope(importParent);
   }
 
   /**
    * Replace a dynamic import expression with a function call to the specified alias.
    *
-   * Before
+   * <p>Before
+   *
    * <pre>
    *   import('./foo.js');
    * </pre>
    *
    * After
+   *
    * <pre>
    *   aliasedName('./foo.js');
    * </pre>
    */
   private void aliasDynamicImport(NodeTraversal t, Node dynamicImport) {
     checkNotNull(this.alias);
-    if (NodeUtil.isValidSimpleName(this.alias) && t.getTypedScope().getVar(this.alias) == null) {
+    if (NodeUtil.isValidSimpleName(this.alias) && t.getScope().getVar(this.alias) == null) {
       shouldInjectAliasExtern = true;
-    } else if (t.getTypedScope().getVar(this.alias) == null) {
-      compiler.report(
-          JSError.make(
-              dynamicImport,
-              DYNAMIC_IMPORT_ALIAS_MISSING,
-              this.alias));
+    } else if (t.getScope().getVar(this.alias) == null) {
+      compiler.report(JSError.make(dynamicImport, DYNAMIC_IMPORT_ALIAS_MISSING, this.alias));
     }
 
-    Node importAliasCall = IR.call(
-        NodeUtil.newQName(compiler, this.alias, dynamicImport, "import"),
-        dynamicImport.getFirstChild().detach());
-    if (NodeUtil.isValidSimpleName(this.alias)) {
-      importAliasCall.putBooleanProp(Node.FREE_CALL, true);
-    }
-    importAliasCall.useSourceInfoIfMissingFromForTree(dynamicImport);
+    final Node aliasNode = astFactory.createQNameWithUnknownType(this.alias);
+    aliasNode.setOriginalName("import");
+    final Node moduleSpecifier = dynamicImport.getFirstChild().detach();
+    Node importAliasCall =
+        astFactory
+            .createCall(aliasNode, moduleSpecifier)
+            .useSourceInfoIfMissingFromForTree(dynamicImport);
     if (dynamicImport.getJSType() != null) {
-      importAliasCall.getFirstChild().setJSType(dynamicImport.getJSType());
+      importAliasCall.setJSType(dynamicImport.getJSType());
     }
-    dynamicImport.getParent().replaceChild(dynamicImport, importAliasCall);
+    dynamicImport.replaceWith(importAliasCall);
     t.reportCodeChange(importAliasCall);
     dynamicImportsRemoved = true;
   }
 
-  /**
-   * For a given module, return a reference to the module namespace export
-   */
-  private Node getModuleNamespaceNode(TypedVar moduleVar) {
-    Node moduleNamespace = moduleVar.getNode().cloneNode();
-    moduleNamespace.setJSType(moduleVar.getNode().getJSType());
+  /** For a given module, return a reference to the module namespace export */
+  private Node createModuleNamespaceNode(Var moduleVar) {
+    final Node moduleVarNode = moduleVar.getNode();
+    Node moduleNamespace = moduleVarNode.cloneNode();
+    moduleNamespace.setJSType(moduleVarNode.getJSType());
     return moduleNamespace;
   }
 
-  /**
-   * For a given module, return a reference to the module namespace export
-   */
-  private TypedVar getModuleNamespaceVar(NodeTraversal t, @Nullable Module module) {
-    if (module == null) {
-      return null;
-    }
-    GlobalizedModuleName globalModuleName =
-        ModuleRenaming.GlobalizedModuleName.create(module.metadata(), null, null);
-
-    return t.getTypedScope().getVar(globalModuleName.aliasName().join());
-  }
-
-  /**
-   * Inject the alias definition for dynamic import expressions into the externs.
-   */
+  /** Inject the alias definition for dynamic import expressions into the externs. */
   private void injectAliasAsExtern(Node externs) {
     checkState(alias != null && NodeUtil.isValidSimpleName(alias));
 
-    Node importAliasFunction = IR.function(
-        IR.name(alias), IR.paramList(IR.name("specifier")), IR.block());
     JSTypeRegistry registry = compiler.getTypeRegistry();
-    importAliasFunction.setJSType(
+    final JSType unknownType = registry.getNativeType(JSTypeNative.UNKNOWN_TYPE);
+    final FunctionType importFunctionType =
         registry.createFunctionType(
             registry.createTemplatizedType(
-                registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
-                registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
-            registry.getNativeType(JSTypeNative.STRING_TYPE)));
+                registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE), unknownType),
+            registry.getNativeType(JSTypeNative.STRING_TYPE));
+    Node importAliasFunction =
+        astFactory.createFunction(
+            alias,
+            astFactory.createParamList("specifier"),
+            astFactory.createBlock(),
+            importFunctionType);
     importAliasFunction.useSourceInfoFromForTree(externs);
 
-    String externsSourceFile = compiler.getInput(externs.getFirstChild().getInputId()).getSourceFile().getName();
+    String externsSourceFile =
+        compiler.getInput(externs.getFirstChild().getInputId()).getSourceFile().getName();
     JSDocInfo.Builder info = JSDocInfo.builder();
     info.recordParameter(
-            "specifier",
-            new JSTypeExpression(JsDocInfoParser.parseTypeString("string"), externsSourceFile));
+        "specifier",
+        new JSTypeExpression(JsDocInfoParser.parseTypeString("string"), externsSourceFile));
     info.recordReturnType(
         new JSTypeExpression(JsDocInfoParser.parseTypeString("Promise<?>"), externsSourceFile));
     importAliasFunction.setJSDocInfo(info.build());

--- a/src/com/google/javascript/jscomp/RewriteDynamicImports.java
+++ b/src/com/google/javascript/jscomp/RewriteDynamicImports.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2021 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.javascript.jscomp.ModuleRenaming.GlobalizedModuleName;
+import com.google.javascript.jscomp.deps.ModuleLoader;
+import com.google.javascript.jscomp.deps.ModuleLoader.ModulePath;
+import com.google.javascript.jscomp.modules.Module;
+import com.google.javascript.jscomp.modules.ModuleMap;
+import com.google.javascript.jscomp.parsing.JsDocInfoParser;
+import com.google.javascript.jscomp.parsing.parser.FeatureSet.Feature;
+import com.google.javascript.rhino.IR;
+import com.google.javascript.rhino.JSDocInfo;
+import com.google.javascript.rhino.JSTypeExpression;
+import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.Token;
+import com.google.javascript.rhino.jstype.JSType;
+import com.google.javascript.rhino.jstype.JSTypeNative;
+import com.google.javascript.rhino.jstype.JSTypeRegistry;
+import com.google.javascript.rhino.jstype.TemplatizedType;
+import javax.annotation.Nullable;
+
+/**
+ * Rewrite dynamic import expressions to account for bundling and module rewriting.
+ * Since dynamic imports cannot be fully polyfilled, optionally support replacing the expression
+ * with a function call which indicates an external polyfill is utilized.
+ *
+ * If the import specifier is a string literal and the module resolver recognizes the target,
+ * the pass retargets the specifier to the correct output chunk.
+ *
+ * Example from:
+ * <pre>
+ *   import('./input-module1.js');
+ * </pre>
+ *
+ * To:
+ * <pre>
+ *   imprt_('./output-chunk0.js').then(function() { return module$output$chunk0; });
+ * </pre>
+ */
+public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallback
+    implements CompilerPass {
+
+  static final DiagnosticType UNABLE_TO_COMPUTE_RELATIVE_PATH = DiagnosticType.error(
+      "JSC_UNABLE_TO_COMPUTE_RELATIVE_PATH",
+      "Unable to compute relative import path from \"{0}\" to \"{1}\"");
+
+  static final DiagnosticType DYNAMIC_IMPORT_ALIAS_MISSING = DiagnosticType.warning(
+      "JSC_DYNAMIC_IMPORT_ALIAS_MISSING",
+      "A dynamic import alias is specified as a qualified name but the definition " +
+          "is missing: \"{0}\"");
+
+  private final AbstractCompiler compiler;
+  private final String alias;
+  private boolean dynamicImportsRemoved = false;
+  private boolean shouldInjectAliasExtern = false;
+
+  /**
+   *
+   *
+   * @param compiler The compiler
+   */
+  public RewriteDynamicImports(AbstractCompiler compiler, @Nullable  String alias) {
+    this.compiler = compiler;
+    this.alias = alias;
+  }
+
+  @Override
+  public void process(Node externs, Node root) {
+    dynamicImportsRemoved = false;
+    shouldInjectAliasExtern = false;
+    checkArgument(externs.isRoot(), externs);
+    checkArgument(root.isRoot(), root);
+    ScopeCreator scopeCreator = new TypedScopeCreator(compiler);
+    NodeTraversal nodeTraversal = new NodeTraversal(compiler, this, scopeCreator);
+    nodeTraversal.traverse(root.getParent());
+    if (dynamicImportsRemoved) {
+      compiler.setFeatureSet(compiler.getFeatureSet().without(Feature.DYNAMIC_IMPORT));
+    }
+    if (shouldInjectAliasExtern) {
+      injectAliasAsExtern(externs);
+    }
+  }
+
+  @Override
+  public void visit(NodeTraversal t, Node n, Node parent) {
+    if (n.getToken() != Token.DYNAMIC_IMPORT) {
+      return;
+    }
+
+    // If the module specifier is a string, attempt to resolve the module
+    ModuleMap moduleMap = compiler.getModuleMap();
+    Node importSpecifier = n.getFirstChild();
+    if (importSpecifier.isString() && moduleMap != null) {
+      ModulePath targetPath = compiler.getModuleLoader().resolve(importSpecifier.getString());
+      TypedVar targetModuleNS = getModuleNamespaceVar(t, compiler.getModuleMap().getModule(targetPath));
+      if (targetModuleNS != null) {
+        JSModule targetModule = targetModuleNS.getInput().getModule();
+        // If the target module is bundled into the same output chunk, replace the import statement
+        // with a promise that resolves to the module namespace.
+        // No further rewriting occurs for this case.
+        if (t.getModule() == targetModuleNS.getInput().getModule()) {
+          replaceDynamicImportWithPromise(t, n, targetModuleNS);
+          return;
+        } else {
+          // The target output chunk is recognized and different from the current chunk.
+          // Retarget the import specifier path to the output chunk path and rewrite
+          // the import to reference the rewritten global module namespace variable.
+          retargetImportSpecifier(t, n, targetModule);
+          if (NodeUtil.isExpressionResultUsed(n)) {
+            addChainedThen(t, n, targetModuleNS);
+          }
+        }
+      }
+    }
+    if (this.alias != null) {
+      aliasDynamicImport(t, n);
+    }
+  }
+
+  /**
+   * Replace a dynamic import expression with a promise resolving to the rewritten module namespace.
+   *
+   * Before
+   * <pre>
+   *   import('./foo.js');
+   * </pre>
+   *
+   * After
+   * <pre>
+   *   Promise.resolve(module$foo);
+   * </pre>
+   */
+  private void replaceDynamicImportWithPromise(NodeTraversal t, Node dynamicImport, TypedVar targetModuleNS) {
+    JSTypeRegistry registry = compiler.getTypeRegistry();
+    Node promise = IR.name("Promise");
+    promise.setJSType(registry.getGlobalType("Promise"));
+
+    Node resolve = IR.string("resolve");
+    resolve.setJSType(registry.getNativeType(JSTypeNative.STRING_TYPE));
+
+    Node promiseResolve = IR.getprop(promise, resolve);
+    Node promiseResolveCall = IR.call(promiseResolve);
+    boolean isExpressionUsed = NodeUtil.isExpressionResultUsed(dynamicImport);
+    if (isExpressionUsed) {
+      JSType moduleNamespaceType;
+      if (dynamicImport.getJSType() != null && dynamicImport.getJSType().isTemplatizedType()) {
+        TemplatizedType templatizedType = (TemplatizedType) dynamicImport.getJSType();
+        moduleNamespaceType = templatizedType.getTemplateTypes().asList().get(0);
+      } else {
+        moduleNamespaceType = registry.getNativeType(JSTypeNative.UNKNOWN_TYPE);
+      }
+      promiseResolve.setJSType(registry.createFunctionType(
+          registry.createTemplatizedType(
+              registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+              moduleNamespaceType),
+          registry.getNativeType(JSTypeNative.ALL_TYPE)));
+      promiseResolveCall.addChildToBack(getModuleNamespaceNode(targetModuleNS));
+      promiseResolveCall.setJSType(dynamicImport.getJSType());
+    } else {
+      promiseResolve.setJSType(registry.createFunctionType(
+          registry.createTemplatizedType(
+              registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+              registry.getNativeType(JSTypeNative.VOID_TYPE)),
+          registry.getNativeType(JSTypeNative.ALL_TYPE)));
+      promiseResolveCall.setJSType(registry.createTemplatizedType(
+          registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+          registry.getNativeType(JSTypeNative.VOID_TYPE)));
+    }
+    promiseResolveCall.useSourceInfoFromForTree(dynamicImport);
+    Node parent = dynamicImport.getParent();
+    parent.replaceChild(dynamicImport, promiseResolveCall);
+    t.reportCodeChange(parent);
+    dynamicImportsRemoved = true;
+  }
+
+  private static String getChunkFileName(JSModule chunk) {
+    return chunk.getName() + ".js";
+  }
+
+  /**
+   * Rewrite the dynamic import specifier to the output chunk path
+   *
+   * Before
+   * <pre>
+   *   import('./foo.js');
+   * </pre>
+   *
+   * After
+   * <pre>
+   *   import('./chunk0.js');
+   * </pre>
+   */
+  private void retargetImportSpecifier(NodeTraversal t, Node dynamicImport, JSModule targetModule) {
+    String retargetedSpecifier;
+    String importingChunkFilename = getChunkFileName(t.getInput().getModule());
+    String targetChunkFilename = getChunkFileName(targetModule);
+    try {
+      retargetedSpecifier =
+          ModuleLoader.relativePathFrom(importingChunkFilename, targetChunkFilename);
+    } catch (IllegalArgumentException e) {
+      compiler.report(
+          JSError.make(
+              dynamicImport,
+              UNABLE_TO_COMPUTE_RELATIVE_PATH,
+              importingChunkFilename,
+              targetChunkFilename));
+      return;
+    }
+    Node newSpecifier = IR.string(retargetedSpecifier)
+        .useSourceInfoFrom(dynamicImport.getFirstChild());
+    newSpecifier.setJSType(dynamicImport.getFirstChild().getJSType());
+    dynamicImport.getFirstChild().replaceWith(newSpecifier);
+    t.reportCodeChange(dynamicImport.getFirstChild());
+  }
+
+  /**
+   * Since a dynamic import expression is a promise resolving to the namespace export type,
+   * add a ".then()" call after it and resolve to the rewritten module namespace.
+   *
+   * Before
+   * <pre>
+   *   import('./foo.js');
+   * </pre>
+   *
+   * After
+   * <pre>
+   *   import('./foo.js').then(function() { return module$foo; });
+   * </pre>
+   */
+  private void addChainedThen(NodeTraversal t, Node dynamicImport, TypedVar targetModuleNs) {
+    JSTypeRegistry registry = compiler.getTypeRegistry();
+    Node importParent = dynamicImport.getParent();
+    Node placeholder = IR.string("");
+    importParent.replaceChild(dynamicImport, placeholder);
+    Node thenCallback = IR.function(
+        IR.name(""),
+        IR.paramList(),
+        IR.block(
+            IR.returnNode(
+                getModuleNamespaceNode(targetModuleNs))));
+    thenCallback.setJSType(registry.createFunctionType(dynamicImport.getJSType()));
+
+    Node importThenCall = IR.call(
+        IR.getprop(
+            dynamicImport,
+            IR.string("then")),
+        thenCallback);
+    importThenCall.getFirstChild().setJSType(registry.createFunctionType(
+        registry.createTemplatizedType(
+            registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+            registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
+        registry.createFunctionType(registry.getNativeType(JSTypeNative.ALL_TYPE))
+    ));
+    importThenCall.useSourceInfoIfMissingFromForTree(dynamicImport);
+    if (dynamicImport.getJSType() != null) {
+      importThenCall.setJSType(dynamicImport.getJSType());
+    }
+    importParent.replaceChild(placeholder, importThenCall);
+    t.reportCodeChange(NodeUtil.getFunctionBody(thenCallback));
+    t.reportCodeChange(importThenCall);
+  }
+
+  /**
+   * Replace a dynamic import expression with a function call to the specified alias.
+   *
+   * Before
+   * <pre>
+   *   import('./foo.js');
+   * </pre>
+   *
+   * After
+   * <pre>
+   *   aliasedName('./foo.js');
+   * </pre>
+   */
+  private void aliasDynamicImport(NodeTraversal t, Node dynamicImport) {
+    checkNotNull(this.alias);
+    if (NodeUtil.isValidSimpleName(this.alias) && t.getTypedScope().getVar(this.alias) == null) {
+      shouldInjectAliasExtern = true;
+    } else if (t.getTypedScope().getVar(this.alias) == null) {
+      compiler.report(
+          JSError.make(
+              dynamicImport,
+              DYNAMIC_IMPORT_ALIAS_MISSING,
+              this.alias));
+    }
+
+    Node importAliasCall = IR.call(
+        NodeUtil.newQName(compiler, this.alias, dynamicImport, "import"),
+        dynamicImport.getFirstChild().detach());
+    if (NodeUtil.isValidSimpleName(this.alias)) {
+      importAliasCall.putBooleanProp(Node.FREE_CALL, true);
+    }
+    importAliasCall.useSourceInfoIfMissingFromForTree(dynamicImport);
+    if (dynamicImport.getJSType() != null) {
+      importAliasCall.getFirstChild().setJSType(dynamicImport.getJSType());
+    }
+    dynamicImport.getParent().replaceChild(dynamicImport, importAliasCall);
+    t.reportCodeChange(importAliasCall);
+    dynamicImportsRemoved = true;
+  }
+
+  /**
+   * For a given module, return a reference to the module namespace export
+   */
+  private Node getModuleNamespaceNode(TypedVar moduleVar) {
+    Node moduleNamespace = moduleVar.getNode().cloneNode();
+    moduleNamespace.setJSType(moduleVar.getNode().getJSType());
+    return moduleNamespace;
+  }
+
+  /**
+   * For a given module, return a reference to the module namespace export
+   */
+  private TypedVar getModuleNamespaceVar(NodeTraversal t, @Nullable Module module) {
+    if (module == null) {
+      return null;
+    }
+    GlobalizedModuleName globalModuleName =
+        ModuleRenaming.GlobalizedModuleName.create(module.metadata(), null, null);
+
+    return t.getTypedScope().getVar(globalModuleName.aliasName().join());
+  }
+
+  /**
+   * Inject the alias definition for dynamic import expressions into the externs.
+   */
+  private void injectAliasAsExtern(Node externs) {
+    checkState(alias != null && NodeUtil.isValidSimpleName(alias));
+
+    Node importAliasFunction = IR.function(
+        IR.name(alias), IR.paramList(IR.name("specifier")), IR.block());
+    JSTypeRegistry registry = compiler.getTypeRegistry();
+    importAliasFunction.setJSType(
+        registry.createFunctionType(
+            registry.createTemplatizedType(
+                registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
+                registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
+            registry.getNativeType(JSTypeNative.STRING_TYPE)));
+    importAliasFunction.useSourceInfoFromForTree(externs);
+
+    String externsSourceFile = compiler.getInput(externs.getFirstChild().getInputId()).getSourceFile().getName();
+    JSDocInfo.Builder info = JSDocInfo.builder();
+    info.recordParameter(
+            "specifier",
+            new JSTypeExpression(JsDocInfoParser.parseTypeString("string"), externsSourceFile));
+    info.recordReturnType(
+        new JSTypeExpression(JsDocInfoParser.parseTypeString("Promise<?>"), externsSourceFile));
+    importAliasFunction.setJSDocInfo(info.build());
+
+    externs.getFirstChild().addChildToFront(importAliasFunction);
+    compiler.reportChangeToEnclosingScope(importAliasFunction);
+  }
+}

--- a/src/com/google/javascript/jscomp/RewriteDynamicImports.java
+++ b/src/com/google/javascript/jscomp/RewriteDynamicImports.java
@@ -181,7 +181,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     }
     promiseResolveCall.srcrefTree(dynamicImport);
     Node parent = dynamicImport.getParent();
-    parent.replaceChild(dynamicImport, promiseResolveCall);
+    dynamicImport.replaceWith(promiseResolveCall);
     t.reportCodeChange(parent);
     dynamicImportsRemoved = true;
   }
@@ -248,7 +248,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     JSTypeRegistry registry = compiler.getTypeRegistry();
     final Node importParent = dynamicImport.getParent();
     final Node placeholder = IR.empty();
-    importParent.replaceChild(dynamicImport, placeholder);
+    dynamicImport.replaceWith(placeholder);
     final Node moduleNamespaceNode = createModuleNamespaceNode(targetModuleNs);
     final Node callbackFn = astFactory.createZeroArgArrowFunctionForExpression(moduleNamespaceNode);
     final Node importThenCall =
@@ -265,7 +265,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     if (dynamicImport.getJSType() != null) {
       importThenCall.setJSType(dynamicImport.getJSType());
     }
-    importParent.replaceChild(placeholder, importThenCall);
+    placeholder.replaceWith(importThenCall);
     compiler.reportChangeToChangeScope(callbackFn);
     compiler.reportChangeToEnclosingScope(importParent);
   }

--- a/src/com/google/javascript/jscomp/RewriteDynamicImports.java
+++ b/src/com/google/javascript/jscomp/RewriteDynamicImports.java
@@ -179,7 +179,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
               registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
               registry.getNativeType(JSTypeNative.VOID_TYPE)));
     }
-    promiseResolveCall.useSourceInfoFromForTree(dynamicImport);
+    promiseResolveCall.srcrefTree(dynamicImport);
     Node parent = dynamicImport.getParent();
     parent.replaceChild(dynamicImport, promiseResolveCall);
     t.reportCodeChange(parent);
@@ -223,7 +223,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     }
     final Node originalSpecifierNode = dynamicImport.getFirstChild();
     Node newSpecifier =
-        astFactory.createString(retargetedSpecifier).useSourceInfoFrom(originalSpecifierNode);
+        astFactory.createString(retargetedSpecifier).srcref(originalSpecifierNode);
     originalSpecifierNode.replaceWith(newSpecifier);
     t.reportCodeChange(newSpecifier);
   }
@@ -261,7 +261,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
                     registry.getNativeObjectType(JSTypeNative.PROMISE_TYPE),
                     registry.getNativeType(JSTypeNative.UNKNOWN_TYPE)),
                 registry.createFunctionType(registry.getNativeType(JSTypeNative.ALL_TYPE))));
-    importThenCall.useSourceInfoIfMissingFromForTree(dynamicImport);
+    importThenCall.srcrefTreeIfMissing(dynamicImport);
     if (dynamicImport.getJSType() != null) {
       importThenCall.setJSType(dynamicImport.getJSType());
     }
@@ -293,7 +293,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     Node importAliasCall =
         astFactory
             .createCall(aliasNode, moduleSpecifier)
-            .useSourceInfoIfMissingFromForTree(dynamicImport);
+            .srcrefTreeIfMissing(dynamicImport);
     if (dynamicImport.getJSType() != null) {
       importAliasCall.setJSType(dynamicImport.getJSType());
     }

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -2618,10 +2618,12 @@ class TypeInference extends DataFlowAnalysis.BranchedForwardDataFlowAnalysis<Nod
       if (targetModule != null) {
         // TypedScopeCreator ensures that the MODULE_BODY type is the export namespace type
         Node scriptNode = targetModule.metadata().rootNode();
-        JSType exportNamespaceType =
-            scriptNode != null ? scriptNode.getOnlyChild().getJSType() : null;
-        if (exportNamespaceType != null) {
-          templateType = exportNamespaceType;
+        if (scriptNode.hasOneChild() && scriptNode.getFirstChild().isModuleBody()) {
+          JSType exportNamespaceType =
+              scriptNode != null ? scriptNode.getOnlyChild().getJSType() : null;
+          if (exportNamespaceType != null) {
+            templateType = exportNamespaceType;
+          }
         }
       }
     }

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -29,6 +29,7 @@ import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.DiagnosticType;
 import com.google.javascript.jscomp.ErrorHandler;
 import com.google.javascript.jscomp.JSError;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -296,6 +297,28 @@ public final class ModuleLoader {
     }
     // Not underneath any of the roots.
     return path;
+  }
+
+  public static String relativePathFrom(String fromUriPath, String toUriPath) {
+    Path fromPath = Paths.get(fromUriPath);
+    Path toPath = Paths.get(toUriPath);
+    Path fromFolder = fromPath.getParent();
+
+    // if the from URIs are simple names without paths, they are in the same folder
+    // example: m0.js
+    if (fromFolder == null && toPath.getParent() == null) {
+      return "./" + toUriPath;
+    } else if (fromFolder == null && toUriPath.startsWith(".") || toPath.startsWith("/")) {
+      return toUriPath;
+    } else if (fromFolder == null) {
+      throw new IllegalArgumentException("Relative path between URIs cannot be calculated");
+    }
+
+    String calculatedPath = fromFolder.relativize(toPath).toString();
+    if (calculatedPath.startsWith(".") || calculatedPath.startsWith("/")) {
+      return calculatedPath;
+    }
+    return "./" + calculatedPath;
   }
 
   public void setErrorHandler(ErrorHandler errorHandler) {

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -308,7 +308,7 @@ public final class ModuleLoader {
     // example: m0.js
     if (fromFolder == null && toPath.getParent() == null) {
       return "./" + toUriPath;
-    } else if (fromFolder == null && toUriPath.startsWith(".") || toPath.startsWith("/")) {
+    } else if (fromFolder == null && (toUriPath.startsWith(".") || toPath.startsWith("/"))) {
       return toUriPath;
     } else if (fromFolder == null) {
       throw new IllegalArgumentException("Relative path between URIs cannot be calculated");

--- a/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
+++ b/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2021 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.javascript.jscomp;
+
+import static com.google.javascript.jscomp.RewriteDynamicImports.DYNAMIC_IMPORT_ALIAS_MISSING;
+import static com.google.javascript.jscomp.RewriteDynamicImports.UNABLE_TO_COMPUTE_RELATIVE_PATH;
+
+import com.google.common.collect.ImmutableList;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+import com.google.javascript.jscomp.type.ReverseAbstractInterpreter;
+import com.google.javascript.jscomp.type.SemanticReverseAbstractInterpreter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link RewriteDynamicImports} */
+@RunWith(JUnit4.class)
+public class RewriteDynamicImportsTest extends CompilerTestCase {
+  private String dynamicImportAlias = "imprt_";
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    setLanguage(LanguageMode.ECMASCRIPT_2020, LanguageMode.ECMASCRIPT_2020);
+    enableCreateModuleMap();
+    enableTypeInfoValidation();
+    disableScriptFeatureValidation();
+    enableTranspile();
+  }
+
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    options.setLanguageOut(LanguageMode.ECMASCRIPT_2020);
+    options.setPrettyPrint(true);
+
+    return options;
+  }
+
+  @Override
+  protected CompilerPass getProcessor(Compiler compiler) {
+    return (externs, root) -> {
+      ReverseAbstractInterpreter rai =
+          new SemanticReverseAbstractInterpreter(compiler.getTypeRegistry());
+      compiler.setTypeCheckingHasRun(true);
+      new TypeCheck(compiler, rai, compiler.getTypeRegistry())
+          .processForTesting(externs, root);
+      new RewriteDynamicImports(compiler, dynamicImportAlias).process(externs, root);
+    };
+  }
+
+  @Test
+  public void externalImportWithoutAlias() {
+    this.dynamicImportAlias = null;
+    testSame("import('./external.js')");
+  }
+
+  @Test
+  public void externalImportWithAlias() {
+    testExternChanges(
+        "import('./external.js')",
+        "/** @param {string} specifier @return {Promise<?>} */ function imprt_(specifier) {}");
+
+    this.allowExternsChanges();
+    test("import('./external.js')", "imprt_('./external.js')");
+  }
+
+  @Test
+  public void internalImportSameChuckWithoutAlias_unused() {
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+    actualChunk0.add(SourceFile.fromCode("i1.js", "import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js", "Promise.resolve();")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void internalImportSameChuckWithoutAlias_used() {
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+    actualChunk0.add(SourceFile.fromCode("i1.js", "const ns = import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js", "const ns = Promise.resolve(module$i0);")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void internalImportSameChuckWithAlias() {
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+    actualChunk0.add(SourceFile.fromCode("i1.js", "const ns = import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js", "const ns = Promise.resolve(module$i0);")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void internalImportDifferentChucksWithoutAlias_unused() {
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js", "import('./chunk0.js');")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0, actualChunk1 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void internalImportDifferentChucksWithAlias_unused() {
+    allowExternsChanges();
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js", "imprt_('./chunk0.js');")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0, actualChunk1 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void internalImportDifferentChucksWithoutAlias_used() {
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "const nsPromise = import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js",
+            "const nsPromise = import('./chunk0.js').then(function() { return module$i0; });")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0, actualChunk1 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void internalImportDifferentChucksWithAlias_used() {
+    allowExternsChanges();
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "const nsPromise = import('./i0.js');"));
+
+    Expected expectedSrcs = new Expected(ImmutableList.of(
+        SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+        SourceFile.fromCode("i1.js",
+            "const nsPromise = imprt_('./chunk0.js').then(function() { return module$i0; });")
+    ));
+
+    test(
+        srcs(new JSModule[] { actualChunk0, actualChunk1 }),
+        expectedSrcs);
+  }
+
+  @Test
+  public void qualifiedNameAlias() {
+    this.dynamicImportAlias = "ns.imprt_";
+    test(
+        "/** @const */ const ns = {}; /**@const */ ns.imprt_ = function(path) {}; import('./other.js');",
+        "const ns = {};  /** @const */ ns.imprt_ = function(path) {}; ns.imprt_('./other.js');");
+  }
+
+  @Test
+  public void qualifiedNameAliasExtern() {
+    this.dynamicImportAlias = "ns.imprt_";
+    test(
+        externs("const ns = {}; /** @const */ ns.imprt_ = function(path) {};"),
+        srcs("import('./other.js');"),
+        expected("ns.imprt_('./other.js');"));
+  }
+
+  @Test
+  public void qualifiedNameAliasError() {
+    this.dynamicImportAlias = "ns.imprt_";
+    testWarning(
+        "const ns = {}; import('./other.js');",
+        DYNAMIC_IMPORT_ALIAS_MISSING);
+  }
+
+  @Test
+  public void internalImportPathError() {
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("folder1/chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("../folder2/chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "import('./i0.js');"));
+
+    testError(
+        srcs(new JSModule[] { actualChunk0, actualChunk1 }),
+        UNABLE_TO_COMPUTE_RELATIVE_PATH);
+  }
+}

--- a/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
+++ b/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
@@ -16,7 +16,6 @@
 package com.google.javascript.jscomp;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.javascript.jscomp.RewriteDynamicImports.DYNAMIC_IMPORT_ALIAS_MISSING;
 import static com.google.javascript.jscomp.RewriteDynamicImports.UNABLE_TO_COMPUTE_RELATIVE_PATH;
 
 import com.google.common.collect.ImmutableList;
@@ -86,12 +85,10 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
 
   @Test
   public void externalImportWithAlias() {
-    testExternChanges(
-        "import('./external.js')",
-        "/** @param {string} specifier @return {Promise<?>} */ function imprt_(specifier) {}");
-
-    this.allowExternsChanges();
-    test("import('./external.js')", "imprt_('./external.js')");
+    test(
+        externs("/** @param {string} a @return {!Promise<?>} */ function imprt_(a) {}"),
+        srcs("import('./external.js')"),
+        expected("imprt_('./external.js')"));
   }
 
   @Test
@@ -290,12 +287,6 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
         externs("const ns = {}; /** @const */ ns.imprt_ = function(path) {};"),
         srcs("import('./other.js');"),
         expected("ns.imprt_('./other.js');"));
-  }
-
-  @Test
-  public void qualifiedNameAliasError() {
-    this.dynamicImportAlias = "ns.imprt_";
-    testWarning("const ns = {}; import('./other.js');", DYNAMIC_IMPORT_ALIAS_MISSING);
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
+++ b/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
@@ -59,11 +59,11 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
       // to retrieve globalTypedScope for use by Es6RewriteModules.
       ReverseAbstractInterpreter rai =
           new SemanticReverseAbstractInterpreter(compiler.getTypeRegistry());
-      compiler.setTypeCheckingHasRun(true);
       TypedScope globalTypedScope =
           checkNotNull(
               new TypeCheck(compiler, rai, compiler.getTypeRegistry())
                   .processForTesting(externs, root));
+      compiler.setTypeCheckingHasRun(true);
       // We need to make sure modules are rewritten, because RewriteDynamicImports
       // expects to be able to see the module variables.
       new Es6RewriteModules(
@@ -104,7 +104,13 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode("i1.js", "Promise.resolve();")));
 
     test(srcs(new JSModule[] {actualChunk0}), expectedSrcs);
@@ -120,7 +126,13 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode("i1.js", "const ns = Promise.resolve(module$i0);")));
 
     test(srcs(new JSModule[] {actualChunk0}), expectedSrcs);
@@ -135,7 +147,13 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode("i1.js", "const ns = Promise.resolve(module$i0);")));
 
     test(
@@ -156,7 +174,13 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode("i1.js", "import('./chunk0.js');")));
 
     test(srcs(new JSModule[] {actualChunk0, actualChunk1}), expectedSrcs);
@@ -174,7 +198,13 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode("i1.js", "imprt_('./chunk0.js');")));
 
     test(srcs(new JSModule[] {actualChunk0, actualChunk1}), expectedSrcs);
@@ -182,6 +212,7 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
 
   @Test
   public void internalImportDifferentChunksWithoutAlias_used() {
+    disableAstValidation();
     this.dynamicImportAlias = null;
     JSModule actualChunk0 = new JSModule("chunk0");
     actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
@@ -192,18 +223,25 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode(
                     "i1.js",
                     lines(
                         "const nsPromise =", //
-                        "    import('./chunk0.js').then(function() { return module$i0; });"))));
+                        "    import('./chunk0.js').then(() => module$i0);"))));
 
     test(srcs(new JSModule[] {actualChunk0, actualChunk1}), expectedSrcs);
   }
 
   @Test
   public void internalImportDifferentChunksWithAlias_used() {
+    disableAstValidation();
     allowExternsChanges();
     JSModule actualChunk0 = new JSModule("chunk0");
     actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
@@ -214,7 +252,13 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
     Expected expectedSrcs =
         new Expected(
             ImmutableList.of(
-                SourceFile.fromCode("i0.js", "const a = 1; export default a;"),
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
                 SourceFile.fromCode(
                     "i1.js", "const nsPromise = imprt_('./chunk0.js').then(() => module$i0);")));
 
@@ -228,7 +272,7 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
         lines(
             "/** @const */", //
             "const ns = {};",
-            "/**@const */",
+            "/** @const */",
             "ns.imprt_ = function(path) {};",
             "import('./other.js');"),
         lines(


### PR DESCRIPTION
Completes support for rewriting dynamic imports. See https://docs.google.com/document/d/1thSbGV5i96jltVwn76KYrPkWoNc-yj_KU3HtBGUCgMc/edit#heading=h.c037si364tjn for the full design document.

The new pass rewrites dynamic imports:
 - Optionally allows aliasing the dynamic import as a function call as a form of transpilation. Setting the alias is exposed as a cli flag.
 - Retargets import specifier paths to the correct output chunk.
 - Ensures the return value is a promise resolving to the rewritten module namespace.