### PR TITLE
Prevent arrow functions from being improperly inlined

### DIFF
--- a/src/com/google/javascript/jscomp/InlineSimpleMethods.java
+++ b/src/com/google/javascript/jscomp/InlineSimpleMethods.java
@@ -99,7 +99,7 @@ class InlineSimpleMethods extends MethodCompilerPass {
           // Verify this is a trivial return
           Node returned = returnedExpression(firstDefinition);
           if (returned != null) {
-            if (isPropertyTree(returned)) {
+            if (isPropertyTree(returned) && !firstDefinition.isArrowFunction()) {
               if (logger.isLoggable(Level.FINE)) {
                 logger.fine("Inlining property accessor: " + callName);
               }

--- a/test/com/google/javascript/jscomp/InlineSimpleMethodsTest.java
+++ b/test/com/google/javascript/jscomp/InlineSimpleMethodsTest.java
@@ -387,6 +387,23 @@ public final class InlineSimpleMethodsTest extends CompilerTestCase {
   }
 
   @Test
+  public void testArrowFunction() {
+    // Arrow functions cannot be trivially inlined.
+    // This is only an issue if ES6+ is being targetted,
+    // because otherwise the arrow function is removed before this pass.
+    testSame(
+        lines(
+          "class Holder {",
+          "    constructor() {",
+          "        this.val = {internal: true};",
+          "        this.context =  {getVal: () => this.val}",
+          "    }",
+          "}",
+          "",
+          "console.log(new Holder().context.getVal().internal);"));
+  }
+
+  @Test
   public void testAnonymousGet() {
     // Anonymous object definition without side-effect should be removed.
     testSame("({get a(){return function(){}},b:alert}).a('a')");


### PR DESCRIPTION
Closes #3756.