### PR TITLE
Rollforward of #3724: Refactor ExtractPrototypeMemberDeclarations

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.io.Files;
 import com.google.javascript.jscomp.AbstractCommandLineRunner.CommandLineConfig.ErrorFormatOption;
 import com.google.javascript.jscomp.CompilerOptions.ChunkOutputType;
+import com.google.javascript.jscomp.CompilerOptions.ExtractPrototypeMemberDeclarationsMode;
 import com.google.javascript.jscomp.CompilerOptions.InstrumentOption;
 import com.google.javascript.jscomp.CompilerOptions.IsolationMode;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
@@ -2009,6 +2010,11 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
               + "--chunk_output_type is set to ES_MODULES.");
     }
     options.chunkOutputType = flags.chunkOutputType;
+    if (options.chunkOutputType == ChunkOutputType.ES_MODULES &&
+        level == CompilationLevel.ADVANCED_OPTIMIZATIONS) {
+      options.setExtractPrototypeMemberDeclarations(
+          ExtractPrototypeMemberDeclarationsMode.USE_CHUNK_TEMP);
+    }
 
     return options;
   }

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -458,6 +458,7 @@ public class CompilerOptions implements Serializable {
   public enum ExtractPrototypeMemberDeclarationsMode {
     OFF,
     USE_GLOBAL_TEMP,
+    USE_CHUNK_TEMP,
     USE_IIFE
   }
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2450,6 +2450,9 @@ public final class DefaultPassConfig extends PassConfig {
                   case USE_GLOBAL_TEMP:
                     pattern = Pattern.USE_GLOBAL_TEMP;
                     break;
+                  case USE_CHUNK_TEMP:
+                    pattern = Pattern.USE_CHUNK_TEMP;
+                    break;
                   case USE_IIFE:
                     pattern = Pattern.USE_IIFE;
                     break;


### PR DESCRIPTION
Re-adds the changes from #3724 but only when chunk output mode is ES Modules. Prevents the code size regressions that triggered the previous rollback.