### PR TITLE
Add retrieval type enum to OriginalMappings

### DIFF
--- a/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Iterables;
 import com.google.debugging.sourcemap.Base64VLQ.CharIterator;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.Builder;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -172,7 +173,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer, SourceMappi
 
     int index = search(entries, column, 0, entries.size() - 1);
     Preconditions.checkState(index >= 0, "unexpected:%s", index);
-    return getOriginalMappingForEntry(entries.get(index));
+    return getOriginalMappingForEntry(entries.get(index), RetrievalType.EXACT);
   }
 
   @Override
@@ -431,13 +432,13 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer, SourceMappi
       lineNumber--;
     } while (lines.get(lineNumber) == null);
     ArrayList<Entry> entries = lines.get(lineNumber);
-    return getOriginalMappingForEntry(Iterables.getLast(entries));
+    return getOriginalMappingForEntry(Iterables.getLast(entries), RetrievalType.APPROXIMATED_LINE);
   }
 
   /**
    * Creates an "OriginalMapping" object for the given entry object.
    */
-  private OriginalMapping getOriginalMappingForEntry(Entry entry) {
+  private OriginalMapping getOriginalMappingForEntry(Entry entry, RetrievalType retrievalType) {
     if (entry.getSourceFileId() == UNMAPPED) {
       return null;
     } else {
@@ -445,7 +446,8 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer, SourceMappi
       Builder x = OriginalMapping.newBuilder()
         .setOriginalFile(sources[entry.getSourceFileId()])
         .setLineNumber(entry.getSourceLine() + 1)
-        .setColumnPosition(entry.getSourceColumn() + 1);
+        .setColumnPosition(entry.getSourceColumn() + 1)
+        .setRetrievalType(retrievalType);
       if (entry.getNameId() != UNMAPPED) {
         x.setIdentifier(names[entry.getNameId()]);
       }

--- a/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapConsumerV3.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Iterables;
 import com.google.debugging.sourcemap.Base64VLQ.CharIterator;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.Builder;
-import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.Precision;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -173,7 +173,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer, SourceMappi
 
     int index = search(entries, column, 0, entries.size() - 1);
     Preconditions.checkState(index >= 0, "unexpected:%s", index);
-    return getOriginalMappingForEntry(entries.get(index), RetrievalType.EXACT);
+    return getOriginalMappingForEntry(entries.get(index), Precision.EXACT);
   }
 
   @Override
@@ -432,13 +432,13 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer, SourceMappi
       lineNumber--;
     } while (lines.get(lineNumber) == null);
     ArrayList<Entry> entries = lines.get(lineNumber);
-    return getOriginalMappingForEntry(Iterables.getLast(entries), RetrievalType.APPROXIMATED_LINE);
+    return getOriginalMappingForEntry(Iterables.getLast(entries), Precision.APPROXIMATE_LINE);
   }
 
   /**
    * Creates an "OriginalMapping" object for the given entry object.
    */
-  private OriginalMapping getOriginalMappingForEntry(Entry entry, RetrievalType retrievalType) {
+  private OriginalMapping getOriginalMappingForEntry(Entry entry, Precision precision) {
     if (entry.getSourceFileId() == UNMAPPED) {
       return null;
     } else {
@@ -447,7 +447,7 @@ public final class SourceMapConsumerV3 implements SourceMapConsumer, SourceMappi
         .setOriginalFile(sources[entry.getSourceFileId()])
         .setLineNumber(entry.getSourceLine() + 1)
         .setColumnPosition(entry.getSourceColumn() + 1)
-        .setRetrievalType(retrievalType);
+        .setPrecision(precision);
       if (entry.getNameId() != UNMAPPED) {
         x.setIdentifier(names[entry.getNameId()]);
       }

--- a/src/com/google/debugging/sourcemap/proto/mapping.proto
+++ b/src/com/google/debugging/sourcemap/proto/mapping.proto
@@ -22,4 +22,13 @@ message OriginalMapping {
 
   // The original name of the identifier.
   optional string identifier = 4;
+  
+  enum RetrievalType {
+    UNKNOWN = 0;
+    EXACT = 1;
+    APPROXIMATED_LINE = 2;
+  }
+  
+  // The type of retrieval performed to get this mapping 
+  optional RetrievalType retrieval_type = 5 [default = UNKNOWN];
 }

--- a/src/com/google/debugging/sourcemap/proto/mapping.proto
+++ b/src/com/google/debugging/sourcemap/proto/mapping.proto
@@ -23,12 +23,12 @@ message OriginalMapping {
   // The original name of the identifier.
   optional string identifier = 4;
   
-  enum RetrievalType {
-    UNKNOWN = 0;
+  enum Precision {
+    UNKNOWN_PRECISION = 0;
     EXACT = 1;
-    APPROXIMATED_LINE = 2;
+    APPROXIMATE_LINE = 2;
   }
   
   // The type of retrieval performed to get this mapping 
-  optional RetrievalType retrieval_type = 5 [default = UNKNOWN];
+  optional Precision precision = 5 [default = UNKNOWN_PRECISION];
 }

--- a/test/com/google/debugging/sourcemap/SourceMapConsumerV3Test.java
+++ b/test/com/google/debugging/sourcemap/SourceMapConsumerV3Test.java
@@ -19,6 +19,8 @@ package com.google.debugging.sourcemap;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -133,5 +135,47 @@ public final class SourceMapConsumerV3Test {
     assertThat(exts).doesNotContainKey("org_int");
     assertThat(((JsonElement) exts.get("x_org_int")).getAsInt()).isEqualTo(2);
     assertThat((JsonArray) exts.get("x_org_array")).isEmpty();
+  }
+
+  @Test
+  public void testSourceMappingExactMatch() throws Exception {
+    consumer.parse(
+        GSON.toJson(
+            TestJsonBuilder.create()
+                .setVersion(3)
+                .setFile("testcode")
+                .setLineCount(1)
+                .setMappings("AAAAA,QAASA,UAAS,EAAG;")
+                .setSources("testcode")
+                .setNames("__BASIC__")
+                .build()));
+
+    OriginalMapping mapping = consumer.getMappingForLine(1,1);
+    
+    assertThat(mapping).isNotNull();
+    assertThat(mapping.getLineNumber()).isEqualTo(1);
+    assertThat(mapping.getRetrievalType()).isEqualTo(RetrievalType.EXACT);
+    
+  }
+
+  @Test
+  public void testSourceMappingApproximatedLine() throws Exception {
+    consumer.parse(
+        GSON.toJson(
+            TestJsonBuilder.create()
+                .setVersion(3)
+                .setMappings(";;;;;;;;;;;;;;;;;;IAAMA,K,GACL,eAAaC,EAAb,EAAiB;AAAA;;AAAA;;AAChB,OAAKA,EAAL,GAAUA,EAAV;AACA,C;;IAEIC,S;;;;;;;AACL,qBAAYD,EAAZ,EAAgB;AAAA;;AAAA,6BACTA,EADS;AAEf;;;EAHsBD,K;;AAKxB,IAAIG,CAAC,GAAG,IAAID,SAAJ,CAAc,UAAd,CAAR")
+                .setSourcesContent("class Shape {\n\tconstructor (id) {\n\t\tthis.id = id;\n\t}\n}\nclass Rectangle extends Shape {\n\tconstructor(id) {\n\t\tsuper(id);\n\t}\n}\nvar s = new Rectangle(\"Shape ID\");")
+                .setSources("testcode")
+                .setNames("Shape", "id", "Rectangle", "s")
+                .build()));
+
+    OriginalMapping mapping = consumer.getMappingForLine(40,10);
+    
+    assertThat(mapping).isNotNull();
+    // The Previous line mapping was retrieved, and thus it is "approximated"
+    assertThat(mapping.getLineNumber()).isEqualTo(9);
+    assertThat(mapping.getRetrievalType()).isEqualTo(RetrievalType.APPROXIMATED_LINE);
+    
   }
 }

--- a/test/com/google/debugging/sourcemap/SourceMapConsumerV3Test.java
+++ b/test/com/google/debugging/sourcemap/SourceMapConsumerV3Test.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
-import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.Precision;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -154,7 +154,7 @@ public final class SourceMapConsumerV3Test {
     
     assertThat(mapping).isNotNull();
     assertThat(mapping.getLineNumber()).isEqualTo(1);
-    assertThat(mapping.getRetrievalType()).isEqualTo(RetrievalType.EXACT);
+    assertThat(mapping.getPrecision()).isEqualTo(Precision.EXACT);
     
   }
 
@@ -175,7 +175,7 @@ public final class SourceMapConsumerV3Test {
     assertThat(mapping).isNotNull();
     // The Previous line mapping was retrieved, and thus it is "approximated"
     assertThat(mapping.getLineNumber()).isEqualTo(9);
-    assertThat(mapping.getRetrievalType()).isEqualTo(RetrievalType.APPROXIMATED_LINE);
+    assertThat(mapping.getPrecision()).isEqualTo(Precision.APPROXIMATE_LINE);
     
   }
 }

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -34,6 +34,7 @@ import com.google.debugging.sourcemap.FilePosition;
 import com.google.debugging.sourcemap.SourceMapConsumerV3;
 import com.google.debugging.sourcemap.SourceMapGeneratorV3;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.deps.ModuleLoader.ResolutionMode;
 import com.google.javascript.rhino.IR;
@@ -186,6 +187,7 @@ public final class CompilerTest {
                 .setLineNumber(18)
                 .setColumnPosition(25)
                 .setIdentifier("testSymbolName")
+                .setRetrievalType(RetrievalType.APPROXIMATED_LINE)
                 .build());
     assertThat(compiler.getSourceLine(origSourceName, 1)).isEqualTo("<div ng-show='foo()'>");
   }

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -34,7 +34,7 @@ import com.google.debugging.sourcemap.FilePosition;
 import com.google.debugging.sourcemap.SourceMapConsumerV3;
 import com.google.debugging.sourcemap.SourceMapGeneratorV3;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
-import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.Precision;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.deps.ModuleLoader.ResolutionMode;
 import com.google.javascript.rhino.IR;
@@ -187,7 +187,7 @@ public final class CompilerTest {
                 .setLineNumber(18)
                 .setColumnPosition(25)
                 .setIdentifier("testSymbolName")
-                .setRetrievalType(RetrievalType.APPROXIMATED_LINE)
+                .setPrecision(Precision.APPROXIMATE_LINE)
                 .build());
     assertThat(compiler.getSourceLine(origSourceName, 1)).isEqualTo("<div ng-show='foo()'>");
   }

--- a/test/com/google/javascript/jscomp/bundle/CoverageInstrumenterTest.java
+++ b/test/com/google/javascript/jscomp/bundle/CoverageInstrumenterTest.java
@@ -25,6 +25,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.debugging.sourcemap.SourceMapConsumerV3;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
 import com.google.javascript.jscomp.JSError;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -116,6 +117,7 @@ public final class CoverageInstrumenterTest {
                 .setLineNumber(1)
                 .setColumnPosition(5)
                 .setIdentifier("x")
+                .setRetrievalType(RetrievalType.EXACT)
                 .build());
   }
 }

--- a/test/com/google/javascript/jscomp/bundle/CoverageInstrumenterTest.java
+++ b/test/com/google/javascript/jscomp/bundle/CoverageInstrumenterTest.java
@@ -25,7 +25,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.debugging.sourcemap.SourceMapConsumerV3;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
-import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.RetrievalType;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping.Precision;
 import com.google.javascript.jscomp.JSError;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -117,7 +117,7 @@ public final class CoverageInstrumenterTest {
                 .setLineNumber(1)
                 .setColumnPosition(5)
                 .setIdentifier("x")
-                .setRetrievalType(RetrievalType.EXACT)
+                .setPrecision(Precision.EXACT)
                 .build());
   }
 }


### PR DESCRIPTION
This will allow callers to determine whether or not a mapping was approximated for the `SourceMapConsumerV3#getMappingForLine` API as discussed here https://github.com/google/closure-compiler/issues/3781