### PR TITLE
Add ability to use renaming map produced by a previous compilation

### DIFF
--- a/src/com/google/javascript/rhino/Node.java
+++ b/src/com/google/javascript/rhino/Node.java
@@ -2194,10 +2194,9 @@ public class Node implements Serializable {
         return null;
       }
 
-      Node stringNode = this;
-      String right = stringNode.getOriginalName();
+      String right = this.getOriginalName();
       if (right == null) {
-        right = stringNode.getString();
+        right = this.getString();
       }
 
       return left + "." + right;
@@ -3720,26 +3719,5 @@ public class Node implements Serializable {
     }
     value |= current << shift;
     return value;
-  }
-
-  public static boolean isStringGetprop(Node getprop) {
-    checkState(getprop.isGetProp() || getprop.isOptChainGetProp(), getprop);
-    return getprop.hasOneChild();
-  }
-
-  public static boolean isGetpropButNotStringGetprop(Node getprop) {
-    return (getprop.isGetProp() || getprop.isOptChainGetProp()) && !isStringGetprop(getprop);
-  }
-
-  public static String getGetpropString(Node getprop) {
-    return getGetpropStringNode(getprop).getString();
-  }
-
-  public static Node getGetpropStringNode(Node getprop) {
-    return isStringGetprop(getprop) ? getprop : getprop.getSecondChild();
-  }
-
-  public static void setGetpropString(Node getprop, String value) {
-    getGetpropStringNode(getprop).setString(value);
   }
 }


### PR DESCRIPTION
--variable_map_input_file, --variable_map_output_file, --property_map_input_file and --property_map_output_file flags were removed from the master branch on April 8, 2014.
Later, --variable_map_output_file and --property_map_output_file  were added back as --variable_renaming_report and --property_renaming_report flags on  June 4, 2014 
Here is to add back --variable_map_input_file and --property_map_input_file flags as --variable_renaming_input and --property_renaming_input flags.