### PR TITLE
Use double in test expectation for NodeTest#testCloneValues

### DIFF
--- a/test/com/google/javascript/rhino/NodeTest.java
+++ b/test/com/google/javascript/rhino/NodeTest.java
@@ -462,7 +462,7 @@ public class NodeTest {
   @Test
   public void testCloneValues() {
     Node number = Node.newNumber(100);
-    assertThat(number.cloneNode().getDouble()).isEqualTo(100);
+    assertThat(number.cloneNode().getDouble()).isEqualTo(100.0D);
 
     Node string = Node.newString(new String("a"));
     assertThat(string.cloneNode().getString()).isSameInstanceAs(string.getString());


### PR DESCRIPTION
```
There was 1 failure:
1) testCloneValues(com.google.javascript.rhino.NodeTest)
expected: 100
but was : 100.0
	at com.google.javascript.rhino.NodeTest.testCloneValues(NodeTest.java:465)
```