### PR TITLE
Support dynamic import module rewriting for ES module chunk output types

### DIFF
--- a/src/com/google/javascript/jscomp/ConvertChunksToESModules.java
+++ b/src/com/google/javascript/jscomp/ConvertChunksToESModules.java
@@ -17,13 +17,13 @@ package com.google.javascript.jscomp;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
+import com.google.javascript.jscomp.NodeTraversal.AbstractPreOrderCallback;
+import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.jscomp.parsing.parser.FeatureSet;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import com.google.javascript.rhino.jstype.JSTypeNative;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -65,9 +65,17 @@ import java.util.Set;
  * global namespace or polluting the global scope.
  */
 final class ConvertChunksToESModules implements CompilerPass {
+  private enum ImportType {
+    STATIC,
+    DYNAMIC
+  }
+
   private final AbstractCompiler compiler;
   private final Map<JSModule, Set<String>> crossChunkExports = new LinkedHashMap<>();
   private final Map<JSModule, Map<JSModule, Set<String>>> crossChunkImports = new LinkedHashMap<>();
+  private final List<Node> dynamicImportCallbacks = new ArrayList<>();
+
+  static final String DYNAMIC_IMPORT_CALLBACK_FN = "jscomp$DynamicImportCallback";
 
   static final DiagnosticType ASSIGNMENT_TO_IMPORT =
       DiagnosticType.error(
@@ -77,6 +85,11 @@ final class ConvertChunksToESModules implements CompilerPass {
       DiagnosticType.error(
           "JSC_UNABLE_TO_COMPUTE_RELATIVE_PATH",
           "Unable to compute relative import path from \"{0}\" to \"{1}\"");
+
+  static final DiagnosticType UNRECOGNIZED_DYNAMIC_IMPORT_CALLBACK =
+      DiagnosticType.error(
+          "JSC_UNRECOGNIZED_DYNAMIC_IMPORT_CALLBACK",
+          "Dynamic import callback encountered wih an invalid format.{0}");
 
   /**
    * Constructor for the ConvertChunksToESModules compiler pass.
@@ -107,6 +120,7 @@ final class ConvertChunksToESModules implements CompilerPass {
     convertChunkSourcesToModules();
     addExportStatements();
     addImportStatements();
+    rewriteDynamicImportCallbacks();
   }
 
   /**
@@ -163,9 +177,15 @@ final class ConvertChunksToESModules implements CompilerPass {
         exportSpec.putIntProp(Node.IS_SHORTHAND_PROPERTY, 1);
         exportSpecs.addChildToBack(exportSpec);
       }
-      Node export = IR.export(exportSpecs).srcrefTree(moduleBody);
-      moduleBody.addChildToBack(export);
-      compiler.reportChangeToEnclosingScope(moduleBody);
+      Map<JSModule, Set<String>> importsByChunk = crossChunkImports.get(jsModuleExports.getKey());
+
+      // Force the chunk to parse as a module by adding an empty export spec when no actual
+      // static imports or exports exist
+      if (exportSpecs.hasChildren() || importsByChunk == null || importsByChunk.isEmpty()) {
+        Node export = IR.export(exportSpecs).srcrefTree(moduleBody);
+        moduleBody.addChildToBack(export);
+        compiler.reportChangeToEnclosingScope(moduleBody);
+      }
     }
   }
 
@@ -199,7 +219,10 @@ final class ConvertChunksToESModules implements CompilerPass {
         JSModule exportingChunk = importsByChunk.getKey();
         String importPath = getChunkName(exportingChunk);
         try {
-          importPath = relativePath(getChunkName(importingChunk), getChunkName(exportingChunk));
+          importPath =
+              ModuleLoader.relativePathFrom(
+                  getChunkName(importingChunk),
+                  getChunkName(exportingChunk));
         } catch (IllegalArgumentException e) {
           compiler.report(
               JSError.make(
@@ -228,89 +251,188 @@ final class ConvertChunksToESModules implements CompilerPass {
     }
   }
 
+  private Node getDynamicImportCallbackModuleNamespace(Node call) {
+    checkState(call.isCall());
+    Node callbackFn = NodeUtil.getArgumentForCallOrNew(call, 0);
+    if (callbackFn == null ||
+        !callbackFn.isFunction() ||
+        NodeUtil.getFunctionParameters(callbackFn).hasChildren()) {
+      compiler.report(
+          JSError.make(
+              call,
+              UNRECOGNIZED_DYNAMIC_IMPORT_CALLBACK,
+              " Unable to find valid callback function."));
+      return null;
+    }
+    Node callbackBody = NodeUtil.getFunctionBody(callbackFn);
+
+    // The callback body should have a single statement that returns a name.
+    // Support both standard and arrow function semantics
+    if (callbackBody.isName()) {
+      return callbackBody;
+    } else if (callbackBody.isBlock() &&
+        callbackBody.hasOneChild() &&
+        callbackBody.getFirstChild().isReturn() &&
+        callbackBody.getFirstChild().hasOneChild() &&
+        callbackBody.getFirstFirstChild().isName()) {
+      return callbackBody.getFirstFirstChild();
+    }
+    compiler.report(
+        JSError.make(
+            call,
+            UNRECOGNIZED_DYNAMIC_IMPORT_CALLBACK,
+            " Unable to find valid namespace reference."));
+    return null;
+  }
+
+  /**
+   * The RewriteDynamicImports pass adds direct references to the original input module namespace
+   * and wraps the callback in a special external function call so that this pass can recognize
+   * them.
+   *
+   * Example:
+   *
+   * import('./chunk0.js').then(jscomp$DynamicImportCallback(() => module$input0));
+   *
+   * We need to remove the special external function call and update the original module namespace
+   * reference to be a property of the chunk namespace.
+   *
+   * import('./chunk0.js').then(($) => $.module$input0);
+   */
+  private void rewriteDynamicImportCallbacks() {
+    AstFactory astFactory = compiler.createAstFactory();
+    for (Node dynamicImportCallback : dynamicImportCallbacks) {
+      checkState(dynamicImportCallback.isCall());
+      Node moduleNamespace = getDynamicImportCallbackModuleNamespace(dynamicImportCallback);
+      if (moduleNamespace == null) {
+        continue;
+      }
+      Node callbackFn = NodeUtil.getArgumentForCallOrNew(dynamicImportCallback, 0);
+      Node callbackParamList = NodeUtil.getFunctionParameters(callbackFn);
+      Node importNamespaceParam = astFactory.createName("$", JSTypeNative.UNKNOWN_TYPE)
+          .srcref(moduleNamespace);
+      callbackParamList.addChildToFront(importNamespaceParam);
+      compiler.reportChangeToEnclosingScope(importNamespaceParam);
+
+      Node namespaceGetprop =
+          astFactory.createGetProp(
+              astFactory.createName("$", JSTypeNative.UNKNOWN_TYPE).srcref(moduleNamespace),
+              moduleNamespace.getString());
+
+      moduleNamespace.replaceWith(namespaceGetprop);
+      compiler.reportChangeToEnclosingScope(namespaceGetprop);
+      Node innerCallback = NodeUtil.getArgumentForCallOrNew(dynamicImportCallback, 0)
+          .detach();
+      dynamicImportCallback.replaceWith(innerCallback);
+      compiler.reportChangeToEnclosingScope(innerCallback);
+    }
+  }
+
   /** Find names in a module that are defined in a different module. */
-  private class FindCrossChunkReferences extends AbstractPostOrderCallback {
+  private class FindCrossChunkReferences extends AbstractPreOrderCallback {
     @Override
-    public void visit(NodeTraversal t, Node n, Node parent) {
+    public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
       if (n.isScript()) {
-        JSModule chunk = t.getModule();
-        List<JSModule> chunkDependencies = chunk.getDependencies();
-
-        // Ensure every chunk dependency is explicitly listed with an import
-        // Dependent chunks may have side effects even if there isn't an explicit name reference
-        if (!chunkDependencies.isEmpty()) {
-          Map<JSModule, Set<String>> namesToImportByModule =
-              crossChunkImports.computeIfAbsent(chunk, (JSModule k) -> new LinkedHashMap<>());
-          for (JSModule dependency : chunkDependencies) {
-            namesToImportByModule.computeIfAbsent(
-                dependency, (JSModule k) -> new LinkedHashSet<>());
-          }
-        }
+        visitScript(t, n);
+        return true;
+      } else if (n.isCall()) {
+        return visitCallAndTraverse(t, n);
       } else if (n.isName()) {
-        String name = n.getString();
-        if ("".equals(name)) {
-          return;
-        }
-        Scope s = t.getScope();
-        Var v = s.getVar(name);
-        if (v == null || !v.isGlobal()) {
-          return;
-        }
-        CompilerInput input = v.getInput();
-        if (input == null) {
-          return;
-        }
-        // Compare the chunk where the variable is declared to the current
-        // chunk. If they are different, the variable is used across modules.
-        JSModule definingChunk = input.getModule();
-        JSModule referencingChunk = t.getModule();
-        if (definingChunk != referencingChunk) {
-          if (NodeUtil.isLhsOfAssign(n)) {
-            t.report(n, ASSIGNMENT_TO_IMPORT, n.getString(), getChunkName(referencingChunk));
-          }
+        visitName(t, n, ImportType.STATIC);
+        return true;
+      }
+      return true;
+    }
 
-          // Mark the chunk where the name is declared as needing an export for this name
-          Set<String> namesToExport =
-              crossChunkExports.computeIfAbsent(
-                  definingChunk, (JSModule k) -> new LinkedHashSet<>());
-          namesToExport.add(name);
+    public void visitScript(NodeTraversal t, Node script) {
+      checkState(script.isScript());
+      JSModule chunk = t.getModule();
+      List<JSModule> chunkDependencies = chunk.getDependencies();
 
-          // Add an import for this name to this module from the source module
-          Map<JSModule, Set<String>> namesToImportByModule =
-              crossChunkImports.computeIfAbsent(
-                  referencingChunk, (JSModule k) -> new LinkedHashMap<>());
-          Set<String> importsForModule =
-              namesToImportByModule.computeIfAbsent(
-                  definingChunk, (JSModule k) -> new LinkedHashSet<>());
-          importsForModule.add(name);
+      crossChunkExports.putIfAbsent(chunk, new LinkedHashSet<>());
+
+      // Ensure every chunk dependency is explicitly listed with an import
+      // Dependent chunks may have side effects even if there isn't an explicit name reference
+      if (!chunkDependencies.isEmpty()) {
+        Map<JSModule, Set<String>> namesToImportByModule =
+            crossChunkImports.computeIfAbsent(chunk, (JSModule k) -> new LinkedHashMap<>());
+        for (JSModule dependency : chunkDependencies) {
+          namesToImportByModule.computeIfAbsent(
+              dependency, (JSModule k) -> new LinkedHashSet<>());
         }
       }
     }
   }
 
-  /**
-   * Calculate the relative path between two URI paths. To remain compliant with ES Module loading
-   * restrictions, paths must always begin with a "./", "../" or "/" or they are otherwise treated
-   * as a bare module specifier.
-   *
-   * <p>TODO(ChadKillingsworth): This method likely has use cases beyond this class and should be
-   * moved.
-   */
-  private static String relativePath(String fromUriPath, String toUriPath) {
-    Path fromPath = Paths.get(fromUriPath);
-    Path toPath = Paths.get(toUriPath);
-    Path fromFolder = fromPath.getParent();
-
-    // if the from URIs are simple names without paths, they are in the same folder
-    // example: m0.js
-    if (fromFolder == null) {
-      return "./" + toUriPath;
+  public boolean visitCallAndTraverse(NodeTraversal t, Node call) {
+    checkState(call.isCall());
+    if (!NodeUtil.isCallTo(call, DYNAMIC_IMPORT_CALLBACK_FN)) {
+      return true;
     }
 
-    String calculatedPath = fromFolder.relativize(toPath).toString();
-    if (calculatedPath.startsWith(".") || calculatedPath.startsWith("/")) {
-      return calculatedPath;
+    Node moduleNamespace = getDynamicImportCallbackModuleNamespace(call);
+    if (moduleNamespace == null) {
+      return true;
     }
-    return "./" + calculatedPath;
+    boolean isValidModuleNamespace = visitName(t, moduleNamespace, ImportType.DYNAMIC);
+    if (isValidModuleNamespace) {
+      dynamicImportCallbacks.add(call);
+    } else {
+      compiler.report(
+          JSError.make(
+              call,
+              UNRECOGNIZED_DYNAMIC_IMPORT_CALLBACK,
+              " Unable to find valid namespace reference."));
+    }
+    return false;
+  }
+
+  public boolean visitName(NodeTraversal t, Node nameNode, ImportType importType) {
+    checkState(nameNode.isName());
+    String name = nameNode.getString();
+
+    if ("".equals(name)) {
+      return false;
+    }
+
+    Scope s = t.getScope();
+    Var v = s.getVar(name);
+    if (v == null || !v.isGlobal()) {
+      return false;
+    }
+    CompilerInput input = v.getInput();
+    if (input == null) {
+      return false;
+    }
+    JSModule definingChunk = input.getModule();
+    JSModule referencingChunk = t.getModule();
+
+    if (definingChunk != referencingChunk) {
+      if (NodeUtil.isLhsOfAssign(nameNode)) {
+        t.report(
+            nameNode,
+            ASSIGNMENT_TO_IMPORT,
+            nameNode.getString(),
+            getChunkName(referencingChunk));
+      }
+
+      // Mark the chunk where the name is declared as needing an export for this name
+      Set<String> namesToExport =
+          crossChunkExports.computeIfAbsent(
+              definingChunk, (JSModule k) -> new LinkedHashSet<>());
+      namesToExport.add(name);
+
+      // Add an import for this name to this module from the source module
+      Map<JSModule, Set<String>> namesToImportByModule =
+          crossChunkImports.computeIfAbsent(
+              referencingChunk, (JSModule k) -> new LinkedHashMap<>());
+      if (importType == ImportType.STATIC) {
+        Set<String> importsForModule =
+            namesToImportByModule.computeIfAbsent(
+                definingChunk, (JSModule k) -> new LinkedHashSet<>());
+        importsForModule.add(name);
+      }
+    }
+    return true;
   }
 }

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2923,6 +2923,8 @@ public final class DefaultPassConfig extends PassConfig {
           .setInternalFactory(
               (compiler) ->
                   new RewriteDynamicImports(
-                      compiler, compiler.getOptions().getDynamicImportAlias()))
+                      compiler,
+                      compiler.getOptions().getDynamicImportAlias(),
+                      compiler.getOptions().chunkOutputType))
           .build();
 }

--- a/src/com/google/javascript/jscomp/deps/ModuleLoader.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleLoader.java
@@ -309,7 +309,9 @@ public final class ModuleLoader {
     if (fromFolder == null && toPath.getParent() == null) {
       return "./" + toUriPath;
     } else if (fromFolder == null
-        && (toUriPath.startsWith(".") || toPath.toString().startsWith("/"))) {
+        && (toUriPath.startsWith(".") ||
+            toPath.toString().startsWith("/") ||
+            toPath.toString().startsWith("\\"))) {
       return toUriPath;
     } else if (fromFolder == null) {
       throw new IllegalArgumentException("Relative path between URIs cannot be calculated");

--- a/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
+++ b/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
@@ -16,10 +16,13 @@
 package com.google.javascript.jscomp;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.javascript.jscomp.ConvertChunksToESModules.UNABLE_TO_COMPUTE_RELATIVE_PATH;
+import static com.google.javascript.jscomp.ConvertChunksToESModules.DYNAMIC_IMPORT_CALLBACK_FN;
 import static com.google.javascript.jscomp.RewriteDynamicImports.DYNAMIC_IMPORT_ALIASING_REQUIRED;
-import static com.google.javascript.jscomp.RewriteDynamicImports.UNABLE_TO_COMPUTE_RELATIVE_PATH;
+import static com.google.javascript.jscomp.deps.ModuleLoader.LOAD_WARNING;
 
 import com.google.common.collect.ImmutableList;
+import com.google.javascript.jscomp.CompilerOptions.ChunkOutputType;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.testing.TestExternsBuilder;
 import com.google.javascript.jscomp.type.ReverseAbstractInterpreter;
@@ -35,6 +38,7 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
   private String dynamicImportAlias = "imprt_";
   private LanguageMode language = null;
   private LanguageMode languageIn = null;
+  private ChunkOutputType chunkOutputType = ChunkOutputType.GLOBAL_NAMESPACE;
 
   @Override
   @Before
@@ -80,18 +84,21 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
               globalTypedScope)
           .process(externs, root);
 
-      new RewriteDynamicImports(compiler, dynamicImportAlias).process(externs, root);
+      new RewriteDynamicImports(compiler, dynamicImportAlias, chunkOutputType)
+          .process(externs, root);
     };
   }
 
   @Test
   public void externalImportWithoutAlias() {
     this.dynamicImportAlias = null;
+    ignoreWarnings(LOAD_WARNING);
     testSame("import('./external.js')");
   }
 
   @Test
   public void externalImportWithAlias() {
+    ignoreWarnings(LOAD_WARNING);
     test(
         externs("/** @param {string} a @return {!Promise<?>} */ function imprt_(a) {}"),
         srcs("import('./external.js')"),
@@ -192,7 +199,6 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
 
   @Test
   public void internalImportDifferentChunksWithAlias_unused() {
-    allowExternsChanges();
     JSModule actualChunk0 = new JSModule("chunk0");
     actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
 
@@ -246,7 +252,6 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
   @Test
   public void internalImportDifferentChunksWithAlias_used() {
     disableAstValidation();
-    allowExternsChanges();
     JSModule actualChunk0 = new JSModule("chunk0");
     actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
 
@@ -272,6 +277,7 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
   @Test
   public void qualifiedNameAlias() {
     this.dynamicImportAlias = "ns.imprt_";
+    ignoreWarnings(LOAD_WARNING);
     test(
         lines(
             "/** @const */", //
@@ -290,6 +296,7 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
   @Test
   public void qualifiedNameAliasExtern() {
     this.dynamicImportAlias = "ns.imprt_";
+    ignoreWarnings(LOAD_WARNING);
     test(
         externs("const ns = {}; /** @const */ ns.imprt_ = function(path) {};"),
         srcs("import('./other.js');"),
@@ -321,5 +328,121 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
 
     testWarning(
         srcs(new JSModule[] {actualChunk0, actualChunk1}), DYNAMIC_IMPORT_ALIASING_REQUIRED);
+  }
+
+  @Test
+  public void outputModulesExternInjected() {
+    this.chunkOutputType = ChunkOutputType.ES_MODULES;
+    this.dynamicImportAlias = null;
+
+    testExternChanges(
+        "import('foo.js')",
+        "function " + DYNAMIC_IMPORT_CALLBACK_FN + "(importCallback) {}");
+  }
+
+  @Test
+  public void outputModulesInternalImportSameChunk_unused() {
+    allowExternsChanges();
+    this.chunkOutputType = ChunkOutputType.ES_MODULES;
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+    actualChunk0.add(SourceFile.fromCode("i1.js", "import('./i0.js');"));
+
+    Expected expectedSrcs =
+        new Expected(
+            ImmutableList.of(
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
+                SourceFile.fromCode("i1.js", "Promise.resolve();")));
+
+    test(srcs(new JSModule[] {actualChunk0}), expectedSrcs);
+  }
+
+  @Test
+  public void outputModulesInternalImportSameChunk_used() {
+    allowExternsChanges();
+    this.chunkOutputType = ChunkOutputType.ES_MODULES;
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+    actualChunk0.add(SourceFile.fromCode("i1.js", "const ns = import('./i0.js');"));
+
+    Expected expectedSrcs =
+        new Expected(
+            ImmutableList.of(
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
+                SourceFile.fromCode("i1.js", "const ns = Promise.resolve(module$i0);")));
+
+    test(srcs(new JSModule[] {actualChunk0}), expectedSrcs);
+  }
+
+  @Test
+  public void outputModulesInternalImportDifferentChunks_unused() {
+    allowExternsChanges();
+    this.chunkOutputType = ChunkOutputType.ES_MODULES;
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "import('./i0.js');"));
+
+    Expected expectedSrcs =
+        new Expected(
+            ImmutableList.of(
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
+                SourceFile.fromCode("i1.js", "import('./chunk0.js');")));
+
+    test(srcs(new JSModule[] {actualChunk0, actualChunk1}), expectedSrcs);
+  }
+
+  @Test
+  public void outputModulesInternalImportDifferentChunks_used() {
+    allowExternsChanges();
+    disableAstValidation();
+    this.chunkOutputType = ChunkOutputType.ES_MODULES;
+    this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "const nsPromise = import('./i0.js');"));
+
+    Expected expectedSrcs =
+        new Expected(
+            ImmutableList.of(
+                SourceFile.fromCode(
+                    "i0.js",
+                    lines(
+                        "const a$$module$i0 = 1;",
+                        "var $jscompDefaultExport$$module$i0 = a$$module$i0;",
+                        "/** @const */ var module$i0 = {};",
+                        "/** @const */ module$i0.default = $jscompDefaultExport$$module$i0;")),
+                SourceFile.fromCode(
+                    "i1.js",
+                    lines(
+                        "const nsPromise =", //
+                        "    import('./chunk0.js')",
+                        "        .then(" + DYNAMIC_IMPORT_CALLBACK_FN + "(() => module$i0));"))));
+
+    test(srcs(new JSModule[] {actualChunk0, actualChunk1}), expectedSrcs);
   }
 }


### PR DESCRIPTION
Rewriting Dynamic Import expressions for global namespaces was handled by https://github.com/google/closure-compiler/pull/3753. This change extends that support to chunk output types of ESModules.

This requires coordination between the RewriteDynamicImports and ConvertChunksToESModules passes. The RewriteDynamicImports pass injects a specially named extern identity function and wraps the `.then` callback functions it adds in a call to the extern function. The ConvertChunksToESModules finds these extern function calls, replaces them with the original callback and updates the module export namespace variable to be a property from the chunk export namespace.

This also corrects a bug in RewriteDynamicImports finding the correct import module and adds load failed warnings.