### PR TITLE
Infer the correct type for dynamic imports after module rewriting 

### DIFF
--- a/src/com/google/javascript/jscomp/RewriteDynamicImports.java
+++ b/src/com/google/javascript/jscomp/RewriteDynamicImports.java
@@ -112,7 +112,7 @@ public class RewriteDynamicImports extends NodeTraversal.AbstractPostOrderCallba
     // If the module specifier is a string, attempt to resolve the module
     final ModuleMap moduleMap = compiler.getModuleMap();
     final Node importSpecifier = n.getFirstChild();
-    if (importSpecifier.isString() && moduleMap != null) {
+    if (importSpecifier.isStringLit() && moduleMap != null) {
       final ModulePath targetPath =
           t.getInput()
               .getPath()

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3822,7 +3822,11 @@ public final class TypeInferenceTest {
 
     assertType(getType("foo"))
         .toStringIsEqualTo(
-            "Promise<{\n" + "  Bar: function(): string,\n" + "  default: number\n" + "}>");
+            lines(
+                "Promise<{", //
+                "  Bar: function(): string,",
+                "  default: number",
+                "}>"));
   }
 
   private static void testForAllBigInt(JSType type) {

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3808,7 +3808,6 @@ public final class TypeInferenceTest {
 
   @Test
   public void testDynamicImportAfterModuleRewriting() {
-    compiler.getOptions().setProcessCommonJSModules(true);
     withModules(
         ImmutableList.of(
             lines(


### PR DESCRIPTION
When rewriting common js modules, all module rewriting occurs before type inference. Adjust the type inference pass to correctly find the type of these rewritten module namespaces.

Also switch to using the module loader to resolve relative paths between modules. Some modules were not found in the previous methods and no warning was issued either.

