### PR TITLE
Provide externs for FinalizationRegistry

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -2036,6 +2036,31 @@ function WeakRef(value) {}
 WeakRef.prototype.deref = function() {};
 
 /**
+ * @constructor
+ * @struct
+ * @param {function(HOLDINGS)} cleanupCallback
+ * @template TARGET, HOLDINGS, TOKEN
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
+ */
+function FinalizationRegistry(cleanupCallback) {}
+
+/**
+ * @param {TARGET} target
+ * @param {HOLDINGS} holdings
+ * @param {TOKEN=} unregisterToken
+ * @return {void}
+ */
+FinalizationRegistry.prototype.register =
+    function(target, holdings, unregisterToken) {};
+
+/**
+ * @param {TOKEN} unregisterToken
+ * @return {void}
+ */
+FinalizationRegistry.prototype.unregister = function(unregisterToken) {};
+
+/**
  * @type {!Global}
  */
 var globalThis;

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -2038,8 +2038,8 @@ WeakRef.prototype.deref = function() {};
 /**
  * @constructor
  * @struct
- * @param {function(HOLDINGS)} cleanupCallback
- * @template TARGET, HOLDINGS, TOKEN
+ * @param {function(HELDVALUE)} cleanupCallback
+ * @template TARGET, HELDVALUE, TOKEN
  * @nosideeffects
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
  */
@@ -2047,12 +2047,12 @@ function FinalizationRegistry(cleanupCallback) {}
 
 /**
  * @param {TARGET} target
- * @param {HOLDINGS} holdings
+ * @param {HELDVALUE} heldValue
  * @param {TOKEN=} unregisterToken
  * @return {void}
  */
 FinalizationRegistry.prototype.register =
-    function(target, holdings, unregisterToken) {};
+    function(target, heldValue, unregisterToken) {};
 
 /**
  * @param {TOKEN} unregisterToken


### PR DESCRIPTION
Provide externs for `FinalizationRegistry` and its`register` and `unregister` methods.

I believe the templating is correct (it has caught type errors in my code when I updated from the previous `FinalizationGroup` API) but of course a second pair of eyes is always a good idea…