### PR TITLE
IntersectionObserver constructor: support document root

### DIFF
--- a/externs/browser/intersection_observer.js
+++ b/externs/browser/intersection_observer.js
@@ -107,7 +107,7 @@ var IntersectionObserverCallback;
  *   threshold: (!Array<number>|number|undefined),
  *   delay: (number|undefined),
  *   trackVisibility: (boolean|undefined),
- *   root: (?Element|undefined),
+ *   root: (?Document|?Element|undefined),
  *   rootMargin: (string|undefined)
  * }}
  */


### PR DESCRIPTION
**summary**
The intersection observer spec now supports using a `Document` as root. This PR updates the extern.