### PR TITLE
Re-add the collapsibility check mistakenly removed

### DIFF
--- a/src/com/google/javascript/jscomp/CollapseProperties.java
+++ b/src/com/google/javascript/jscomp/CollapseProperties.java
@@ -360,18 +360,22 @@ class CollapseProperties implements CompilerPass {
 
     for (Name p : n.props) {
       String propAlias = appendPropForAlias(alias, p.getBaseName());
-
       final Inlinability inlinability = p.canCollapseOrInline();
-      if (inlinability.canCollapse()) {
-        logDecisionForName(p, inlinability, "will flatten references");
-        flattenReferencesTo(p, propAlias);
-      } else if (p.isCollapsingExplicitlyDenied()) {
-        logDecisionForName(p, "@nocollapse: will not flatten references");
-      } else if (p.isSimpleStubDeclaration()) {
-        logDecisionForName(p, "simple stub declaration: will flatten references");
-        flattenSimpleStubDeclaration(p, propAlias);
-      } else {
-        logDecisionForName(p, inlinability, "will not flatten references");
+
+      boolean isAllowedToCollapse =
+          propertyCollapseLevel != PropertyCollapseLevel.MODULE_EXPORT || p.isModuleExport();
+      if (isAllowedToCollapse) {
+        if (inlinability.canCollapse()) {
+          logDecisionForName(p, inlinability, "will flatten references");
+          flattenReferencesTo(p, propAlias);
+        } else if (p.isCollapsingExplicitlyDenied()) {
+          logDecisionForName(p, "@nocollapse: will not flatten references");
+        } else if (p.isSimpleStubDeclaration()) {
+          logDecisionForName(p, "simple stub declaration: will flatten references");
+          flattenSimpleStubDeclaration(p, propAlias);
+        } else {
+          logDecisionForName(p, inlinability, "will not flatten references");
+        }
       }
 
       flattenReferencesToCollapsibleDescendantNames(p, propAlias, escaped);

--- a/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
@@ -4467,4 +4467,42 @@ public final class CollapsePropertiesTest extends CompilerTestCase {
     test(
         srcs("var a = p ? x : {b: 1}; a.c = 2;"), expected("var a = p ? x : {b: 1}; var a$c = 2;"));
   }
+
+  @Test
+  public void testModuleExportsOnly() {
+    this.setupModuleExportsOnly();
+
+    ArrayList<SourceFile> inputs = new ArrayList<>();
+    inputs.add(
+        SourceFile.fromCode(
+            "entry.js",
+            lines(
+                "var mod = require('./mod1.js');",
+                "alert(mod);",
+                "var a = {};",
+                "a.b = {};",
+                "/** @constructor */",
+                "a.b.c = function(){};")));
+    inputs.add(SourceFile.fromCode("mod1.js", "module.exports = 123;"));
+
+    ArrayList<SourceFile> expected = new ArrayList<>();
+    expected.add(
+        SourceFile.fromCode(
+            "entry.js",
+            lines(
+                "var mod = module$mod1$default;",
+                "alert(module$mod1$default);",
+                "var a = {};",
+                "a.b = {};",
+                "/** @constructor */",
+                "a.b.c = function(){};")));
+    expected.add(
+        SourceFile.fromCode(
+            "mod1.js",
+            lines(
+                "/** @const */ var module$mod1 = {};",
+                "/** @const */ var module$mod1$default = 123;")));
+
+    test(inputs, expected);
+  }
 }


### PR DESCRIPTION
When the property collapse level is MODULE_EXPORT, only module exports themselves may be collapsed. Nested and unrelated properties may not be. This explicit check was mistakenly removed in #3797.

Fixes #3805