### PR TITLE
Fix compiler crashes caused by webpack dynamic imports

### DIFF
--- a/src/com/google/javascript/jscomp/CollapseProperties.java
+++ b/src/com/google/javascript/jscomp/CollapseProperties.java
@@ -30,7 +30,6 @@ import com.google.javascript.jscomp.GlobalNamespace.Name;
 import com.google.javascript.jscomp.GlobalNamespace.Ref;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.jscomp.Normalize.PropagateConstantAnnotationsOverVars;
-import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.javascript.jscomp.deps.ModuleLoader.ResolutionMode;
 import com.google.javascript.jscomp.diagnostic.LogFile;
 import com.google.javascript.jscomp.parsing.parser.util.format.SimpleFormat;
@@ -1076,16 +1075,23 @@ class CollapseProperties implements CompilerPass {
 
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
-      if (processCommonJSModules
-          && ProcessCommonJSModules.isCommonJsDynamicImportCallback(n, moduleResolutionMode)) {
-        String importPath = ProcessCommonJSModules.getCommonJsImportPath(n, moduleResolutionMode);
-        ModuleLoader.ModulePath modulePath =
-            t.getInput()
-                .getPath()
-                .resolveJsModule(importPath, n.getSourceFileName(), n.getLineno(), n.getCharno());
-
-        if (modulePath != null) {
-          dynamicallyImportedModules.add(modulePath.toModuleName());
+      // After rewriting, CommonJS dynamic imports are of the form
+      // __webpack_require__.e(2).then(function() { return module$mod1.default; })
+      //
+      // Mark the base module name as being dynamically imported.
+      if (processCommonJSModules&&
+          n.isGetProp() &&
+          n.isQualifiedName() &&
+          n.getParent() != null &&
+          n.getParent().isReturn() &&
+          n.getGrandparent().isBlock() &&
+          n.getGrandparent().hasOneChild() &&
+          n.getGrandparent().getParent().isFunction()) {
+        Node potentialCallback = NodeUtil.getEnclosingFunction(n);
+        if (potentialCallback != null &&
+            ProcessCommonJSModules.isCommonJsDynamicImportCallback(
+                NodeUtil.getEnclosingFunction(potentialCallback), moduleResolutionMode)) {
+          dynamicallyImportedModules.add(NodeUtil.getRootOfQualifiedName(n.getQualifiedName()));
         }
       } else if (ConvertChunksToESModules.isDynamicImportCallback(n)) {
         Node moduleNamespace =

--- a/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/CollapsePropertiesTest.java
@@ -4374,44 +4374,6 @@ public final class CollapsePropertiesTest extends CompilerTestCase {
   }
 
   @Test
-  public void testModuleDynamicImportCommonJs() {
-
-    this.setupModuleExportsOnly();
-    this.setWebpackModulesById(
-        ImmutableMap.of(
-            "1", "mod1.js",
-            "2", "entry.js"));
-    this.setModuleResolutionMode(ResolutionMode.WEBPACK);
-    this.enableDependencyManagement = true;
-    this.entryPoints = new ArrayList<>();
-    this.entryPoints.add(ModuleIdentifier.forFile("entry.js"));
-
-    ArrayList<SourceFile> inputs = new ArrayList<>();
-    inputs.add(SourceFile.fromCode("mod1.js", "module.exports = 123;"));
-    inputs.add(
-        SourceFile.fromCode(
-            "entry.js",
-            lines(
-                "__webpack_require__.e(1).then(",
-                "    function() { return __webpack_require__(1);})")));
-
-    ArrayList<SourceFile> expected = new ArrayList<>();
-    expected.add(
-        SourceFile.fromCode(
-            "mod1.js",
-            "/** @const */ var module$mod1={}; /** @const */ module$mod1.default = 123;"));
-    expected.add(
-        SourceFile.fromCode(
-            "entry.js",
-            lines(
-                "/** @const */ var module$entry={};",
-                "__webpack_require__.e(1).then(",
-                "    function() { return module$mod1.default;})")));
-
-    test(inputs, expected);
-  }
-
-  @Test
   public void testOrExpression() {
     // left branch, read declared prop
     testSame("var a = {b: 1} || x; var t = a.b;");

--- a/test/com/google/javascript/jscomp/CompilerTestCase.java
+++ b/test/com/google/javascript/jscomp/CompilerTestCase.java
@@ -1917,6 +1917,22 @@ public abstract class CompilerTestCase {
         maybeCreateSources(GENERATED_EXTERNS_NAME, extern),
         maybeCreateSources(GENERATED_SRC_NAME, input),
         options);
+    testExternChangesInternal(compiler, expectedExtern, warnings);
+  }
+
+  protected void testExternChanges(
+      String extern, JSModule[] modules, String expectedExtern, DiagnosticType... warnings) {
+    Compiler compiler = createCompiler();
+    CompilerOptions options = getOptions();
+    compiler.initModules(
+        maybeCreateSources(GENERATED_EXTERNS_NAME, extern),
+        ImmutableList.copyOf(modules),
+        options);
+    testExternChangesInternal(compiler, expectedExtern, warnings);
+  }
+
+  private void testExternChangesInternal(
+      Compiler compiler, String expectedExtern, DiagnosticType ...warnings) {
     compiler.parseInputs();
 
     if (createModuleMap) {

--- a/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
+++ b/test/com/google/javascript/jscomp/RewriteDynamicImportsTest.java
@@ -334,9 +334,17 @@ public class RewriteDynamicImportsTest extends CompilerTestCase {
   public void outputModulesExternInjected() {
     this.chunkOutputType = ChunkOutputType.ES_MODULES;
     this.dynamicImportAlias = null;
+    JSModule actualChunk0 = new JSModule("chunk0");
+    actualChunk0.add(SourceFile.fromCode("i0.js", "const a = 1; export default a;"));
+
+    JSModule actualChunk1 = new JSModule("chunk1");
+    actualChunk1.add(SourceFile.fromCode("i1.js", "const nsPromise = import('./i0.js');"));
 
     testExternChanges(
-        "import('foo.js')", "function " + DYNAMIC_IMPORT_CALLBACK_FN + "(importCallback) {}");
+        "",
+        new JSModule[] {actualChunk0, actualChunk1},
+        "function " + DYNAMIC_IMPORT_CALLBACK_FN + "(importCallback) {}",
+       (DiagnosticType[]) null);
   }
 
   @Test


### PR DESCRIPTION
Changes introduced by f30a05ac incorrectly found webpack dynamic import nodes and caused the compiler crash in #3808. Properly recognize rewritten webpack dynamic imports and prevent their properties from being collapsed.

As part of this, the collapse properties CommonJS dynamic import test was moved to the new CollapsePropertiesAndModuleRewritingTest file.