### PR TITLE
Update the --json_streams flag to support the field "source_map"

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -36,6 +36,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.google.javascript.jscomp.CompilerOptions.JsonStreamMode;
@@ -63,6 +66,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1516,17 +1520,9 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   void outputJsonStream() throws IOException {
     try (JsonWriter jsonWriter =
         new JsonWriter(new BufferedWriter(new OutputStreamWriter(defaultJsOutput, UTF_8)))) {
-      jsonWriter.beginArray();
-      for (JsonFileSpec jsonFile : this.filesToStreamOut) {
-        jsonWriter.beginObject();
-        jsonWriter.name("src").value(jsonFile.getSrc());
-        jsonWriter.name("path").value(jsonFile.getPath());
-        if (!Strings.isNullOrEmpty(jsonFile.getSourceMap())) {
-          jsonWriter.name("source_map").value(jsonFile.getSourceMap());
-        }
-        jsonWriter.endObject();
-      }
-      jsonWriter.endArray();
+      Gson gsonOut = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+      Type filesCollectionType = new TypeToken<List<JsModuleSpec>>(){}.getType();
+      gsonOut.toJson(this.filesToStreamOut, filesCollectionType, jsonWriter);
     }
   }
 
@@ -2795,10 +2791,15 @@ public abstract class AbstractCommandLineRunner<A extends Compiler,
   /** Representation of a source file from an encoded json stream input */
   @GwtIncompatible("Unnecessary")
   public static class JsonFileSpec {
+    @Nullable
     private final String src;
+    @Nullable
     private final String path;
+    @Nullable
+    @SerializedName(value="source_map", alternate={"sourceMap"})
     private String sourceMap;
     @Nullable
+    @SerializedName(value="webpack_id", alternate={"webpackId"})
     private final String webpackId;
 
     // Graal requires a non-arg constructor for use with GSON

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -750,7 +750,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
         usage =
             "Specifies whether standard input and output streams will be "
                 + "a JSON array of sources. Each source will be an object of the "
-                + "form {path: filename, src: file_contents, srcmap: srcmap_contents }. "
+                + "form {path: filename, src: file_contents, source_map: srcmap_contents }. "
                 + "Intended for use by stream-based build systems such as gulpjs. "
                 + "Options: NONE, IN, OUT, BOTH. Defaults to NONE.")
     private CompilerOptions.JsonStreamMode jsonStreamMode = CompilerOptions.JsonStreamMode.NONE;

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2383,6 +2383,60 @@ public final class CommandLineRunnerTest {
   }
 
   @Test
+  public void testJsonStreamSourceMapUnderscore() {
+    String inputSourceMap =
+        "{\n"
+            + "\"version\":3,\n"
+            + "\"file\":\"one.out.js\",\n"
+            + "\"lineCount\":1,\n"
+            + "\"mappings\":\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+            + "OAAAF,IAAA,CAAYC,CAAZ,CADc,CAGhBD,GAAA,CAAI,QAAJ;\",\n"
+            + "\"sources\":[\"one.js\"],\n"
+            + "\"names\":[\"log\",\"a\",\"console\"]\n"
+            + "}";
+    inputSourceMap = inputSourceMap.replace("\"", "\\\"");
+    String inputString =
+        "[{"
+            + "\"src\": \"function log(a){console.log(a)}log(\\\"one.js\\\");\", "
+            + "\"path\":\"one.out.js\", "
+            + "\"source_map\": \""
+            + inputSourceMap
+            + "\" }]";
+    args.add("--json_streams=BOTH");
+    args.add("--js_output_file=bar.js");
+    args.add("--apply_input_source_maps");
+
+    CommandLineRunner runner =
+        new CommandLineRunner(
+            args.toArray(new String[] {}),
+            new ByteArrayInputStream(inputString.getBytes(UTF_8)),
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    lastCompiler = runner.getCompiler();
+    try {
+      runner.doRun();
+    } catch (IOException e) {
+      e.printStackTrace();
+      assertWithMessage("Unexpected exception " + e).fail();
+    }
+    String output = new String(outReader.toByteArray(), UTF_8);
+    assertThat(output)
+        .isEqualTo(
+            "[{\"src\":\"function log(a){console.log(a)}log(\\\"one.js\\\");\\n"
+                + "\",\"path\":\"bar.js\",\"source_map\":\"{\\n"
+                + "\\\"version\\\":3,\\n"
+                + "\\\"file\\\":\\\"bar.js\\\",\\n"
+                + "\\\"lineCount\\\":1,\\n"
+                + "\\\"mappings\\\":\\\"AAAAA,QAASA,IAAG,CAACC,CAAD,CAAI,CACdC,"
+                + "OAAAF,CAAAA,GAAAE,CAAYD,CAAZC,CADc,CAGhBF,GAAAA,CAAI,QAAJA;\\\",\\n"
+                + "\\\"sources\\\":[\\\"one.js\\\"],\\n"
+                + "\\\"names\\\":[\\\"log\\\",\\\"a\\\",\\\"console\\\"]\\n"
+                + "}\\n"
+                + "\"}]");
+  }
+
+  @Test
   public void testJsonStreamAllowsAnyChunkName() {
     String inputString = "[{\"src\": \"alert('foo');\", \"path\":\"foo.js\"}]";
     args.add("--json_streams=BOTH");


### PR DESCRIPTION
The --json_streams input payload didn't match the output payload. For input the compiler expected a "sourceMap" field but for output "source_map" was used.

Updates the input JSON serialization to support either a "sourceMap" or "source_map" field name, but document "source_map" as the primary. This should continue to support existing integrations without breaking.

Also updates the flag documentation to mention the "source_map" field name.

Fixes #3811 