### PR TITLE
Convert the first argument to optional to match the underlying API.

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -415,12 +415,12 @@ function SharedArrayBuffer(length) {}
 SharedArrayBuffer.prototype.byteLength;
 
 /**
- * @param {number} begin
+ * @param {number=} opt_begin
  * @param {number=} opt_end
  * @return {!SharedArrayBuffer}
  * @nosideeffects
  */
-SharedArrayBuffer.prototype.slice = function(begin, opt_end) {};
+SharedArrayBuffer.prototype.slice = function(opt_begin, opt_end) {};
 
 
 /**


### PR DESCRIPTION
See https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice