### PR TITLE
dead link to code_of_conduct.md file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ yarn compile [...args]
 ### Contributor code of conduct
 
 However you choose to contribute, please abide by our
-[code of conduct](https://github.com/closure-compiler/code_of_conduct.md) to
+[code of conduct](https://github.com/google/closure-compiler/blob/master/code_of_conduct.md) to
 keep our community a healthy and welcoming place.
 
 ### Reporting a bug


### PR DESCRIPTION
link corrected in this pr.

found using this tool I created: https://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3A%2F%2Fgithub.com%2Fgoogle%2Fclosure-compiler&User=&NumberOfReposToSearchFor=&MinStar=&UpdatedAfter=&SearchSort=2&SortAscDsc=1