### PR TITLE
Add GamepadEvent to w3c_gamepad.js

### DIFF
--- a/externs/browser/w3c_gamepad.js
+++ b/externs/browser/w3c_gamepad.js
@@ -89,3 +89,25 @@ GamepadButton.prototype.pressed;  // read-only
  * @type {number}
  */
 GamepadButton.prototype.value;  // read-only
+
+/**
+ * @record
+ * @extends {EventInit}
+ * @see https://w3c.github.io/gamepad/#gamepadeventinit-dictionary
+ */
+function GamepadEventInit() {}
+
+/** @const {Gamepad} */
+GamepadEventInit.prototype.gamepad;
+
+/**
+ * @constructor
+ * @param {string} type
+ * @param {GamepadEventInit=} opt_gamepadEventInit
+ * @extends {Event}
+ * @see https://w3c.github.io/gamepad/#gamepadevent-interface
+ */
+function GamepadEvent(type, opt_gamepadEventInit) {}
+
+/** @const {Gamepad} */
+GamepadEvent.prototype.gamepad;


### PR DESCRIPTION
It would be nice to have GamepadEvent in gamepas externs

ps: there are some additional useful Gamepad APIs ( like GamepadHapticActuator ) that are experimental and because of that, they can't be added, right ?