### PR TITLE
Fold declaration identity. `var x = x;` -> `var x;`

### DIFF
--- a/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java
@@ -1432,6 +1432,11 @@ public final class PeepholeRemoveDeadCodeTest extends CompilerTestCase {
   }
 
   @Test
+  public void testFoldIdentityDeclaration() {
+    fold ("var x = x;", "var x");
+  }
+
+  @Test
   public void testEmptyArrayPatternInAssignRemoved() {
     fold("({} = {});", "");
     fold("({} = foo());", "foo()");


### PR DESCRIPTION
`var x = x;` -> `var x;` is always correct.

* var allows re-declaration of variables
* If `x` is undefined, then `var x = x` is same as `var x = undefined`, or just `var x;`
* If `x` is already defined, then `var x = x` does not do anything

Note that the same does not apply to `const` or `let`, which does not allow re-declaration of variables. Therefore, I first try to optimize `var` name declarations, then pass the resulting subtree to the generic name declaration optimization.