### PR TITLE
Update ANT Dependency to 1.10.11 cause the 1.9.7 has vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ an encoding of structured data.</td>
 
   <tr>
     <td>Version</td>
-    <td>1.9.7</td>
+    <td>1.10.11</td>
   </tr>
 
   <tr>

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -52,8 +52,8 @@ maven_import(
     # https://ant.apache.org/
     group_id ="org.apache.ant",
     artifact_id = "ant",
-    version ="1.9.7",
-    sha256 = "9a5dbe3f5f2cb91854c8682cab80178afa412ab35a5ab718bf39ce01b3435d93",
+    version ="1.10.11",
+    sha256 = "88c0b89bbbaae01e0d9fcae93be792f5abbe3409106f8eee858fdf365dbc0754",
     licenses = ["notice"],
 )
 


### PR DESCRIPTION
The set of the vulnerabilities of the ANT 1.9.7 which this commit fixes:
* CVE-2017-5645
* CVE-2020-1945
* CVE-2021-36373
* CVE-2021-36374

https://ant.apache.org/security.html

Fixes issue #3866