### PR TITLE
Added missed args to MediaElementAudioSourceNode at w3c_audio.js

### DIFF
--- a/externs/browser/w3c_audio.js
+++ b/externs/browser/w3c_audio.js
@@ -653,8 +653,8 @@ MediaElementAudioSourceOptions.prototype.channelInterpretation;
 
 /**
  * @constructor
- * @param {!AudioContext=} context
- * @param {!MediaElementAudioSourceOptions=} options
+ * @param {!AudioContext} context
+ * @param {!MediaElementAudioSourceOptions} options
  * @extends {AudioNode}
  * @see https://webaudio.github.io/web-audio-api/#MediaElementAudioSourceNode-constructors
  */

--- a/externs/browser/w3c_audio.js
+++ b/externs/browser/w3c_audio.js
@@ -634,10 +634,31 @@ AudioBufferSourceNode.prototype.noteGrainOn = function(when, opt_offset,
 AudioBufferSourceNode.prototype.noteOff = function(when) {};
 
 /**
- * @constructor
- * @extends {AudioNode}
+ * @record
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode
  */
-function MediaElementAudioSourceNode() {}
+function MediaElementAudioSourceOptions() {};
+
+/** @type {(HTMLMediaElement|undefined)} */
+MediaElementAudioSourceOptions.prototype.mediaElement;
+
+/** @type {(number|undefined)} */
+MediaElementAudioSourceOptions.prototype.channelCount;
+
+/** @type {(string|undefined)} */
+MediaElementAudioSourceOptions.prototype.channelCountMode;
+
+/** @type {(string|undefined)} */
+MediaElementAudioSourceOptions.prototype.channelInterpretation;
+
+/**
+ * @constructor
+ * @param {!AudioContext=} context
+ * @param {!MediaElementAudioSourceOptions=} options
+ * @extends {AudioNode}
+ * @see https://webaudio.github.io/web-audio-api/#MediaElementAudioSourceNode-constructors
+ */
+function MediaElementAudioSourceNode(context, options) {}
 
 /**
  * @constructor


### PR DESCRIPTION
According to 
https://developer.mozilla.org/en-US/docs/Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode
and
https://webaudio.github.io/web-audio-api/#MediaElementAudioSourceNode-constructors
there are two optional missing args in MediaElementAudioSourceNode constructors: AudioContext and MediaElementAudioSourceOptions