### PR TITLE
Allow import.meta references when the chunk output type is ES_MODULES

### DIFF
--- a/src/com/google/javascript/jscomp/TranspilationPasses.java
+++ b/src/com/google/javascript/jscomp/TranspilationPasses.java
@@ -44,7 +44,8 @@ public class TranspilationPasses {
                       compiler.getModuleMetadataMap(),
                       compiler.getModuleMap(),
                       preprocessorTableFactory.getInstanceOrNull(),
-                      compiler.getTopScope());
+                      compiler.getTopScope(),
+                      compiler.getOptions().getChunkOutputType());
                 })
             .setFeatureSetForChecks()
             .build());


### PR DESCRIPTION
import.meta references are only valid inside an ES module. While we cannot transpile import.meta, we should allow it to pass through the compiler when the chunk output type is ES_MODULES.