### PR TITLE
Adjust types for crypto.getRandomValues

### DIFF
--- a/externs/browser/w3c_webcrypto.js
+++ b/externs/browser/w3c_webcrypto.js
@@ -796,8 +796,8 @@ webCrypto.Crypto = function() {};
 
 /**
  * @see https://developer.mozilla.org/en/DOM/window.crypto.getRandomValues
- * @param {!ArrayBufferView} typedArray
- * @return {!ArrayBufferView}
+ * @param {!Int8Array|!Uint8Array|!Uint8ClampedArray|!Int16Array|!Uint16Array|!Int32Array|!Uint32Array|!BigInt64Array|!BigUint64Array} typedArray
+ * @return {!Int8Array|!Uint8Array|!Uint8ClampedArray|!Int16Array|!Uint16Array|!Int32Array|!Uint32Array|!BigInt64Array|!BigUint64Array}
  * @throws {Error}
  */
 webCrypto.Crypto.prototype.getRandomValues = function(typedArray) {};


### PR DESCRIPTION
Fixes #3905 

The union type is "any `TypedArray` but not `Float32Array` nor `Float64Array`" according to specifications: [W3C](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues), [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues).

With this adjustment, correct `JSC_TYPE_MISMATCH` warning is raised for `Float##Array` or `DataView`.
Also compiler always correctly assumes the returned value to be a subset of `TypedArray`.

This "integer-based TypedArray" is needed only for this particular method (to explicitly prevent a footgun, i.e. generating "random floats"), so it doesn't deserve its own typedef.