### PR TITLE
Fix typing of TypedArray.from method

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -710,10 +710,10 @@ function Int8Array(length, opt_byteOffset, opt_length) {}
 Int8Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Int8Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -743,10 +743,10 @@ function Uint8Array(length, opt_byteOffset, opt_length) {}
 Uint8Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Uint8Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -776,10 +776,10 @@ function Uint8ClampedArray(length, opt_byteOffset, opt_length) {}
 Uint8ClampedArray.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Uint8ClampedArray}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -818,10 +818,10 @@ function Int16Array(length, opt_byteOffset, opt_length) {}
 Int16Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Int16Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -851,10 +851,10 @@ function Uint16Array(length, opt_byteOffset, opt_length) {}
 Uint16Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Uint16Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -884,10 +884,10 @@ function Int32Array(length, opt_byteOffset, opt_length) {}
 Int32Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Int32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -917,10 +917,10 @@ function Uint32Array(length, opt_byteOffset, opt_length) {}
 Uint32Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Uint32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -950,10 +950,10 @@ function Float32Array(length, opt_byteOffset, opt_length) {}
 Float32Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Float32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -983,10 +983,10 @@ function Float64Array(length, opt_byteOffset, opt_length) {}
 Float64Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): number=} opt_mapFn
+ * @param {string|!IArrayLike<number>|!Iterable<number>} source
+ * @param {function(this:S, ?, number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
+ * @template S
  * @return {!Float64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -1020,6 +1020,7 @@ BigInt64Array.BYTES_PER_ELEMENT;
  * @param {function(this:S, (string|T), number): bigint=} opt_mapFn
  * @param {S=} opt_this
  * @template T,S
+ * @throws {Error}
  * @return {!BigInt64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -1053,6 +1054,7 @@ BigUint64Array.BYTES_PER_ELEMENT;
  * @param {function(this:S, (string|T), number): bigint=} opt_mapFn
  * @param {S=} opt_this
  * @template T,S
+ * @throws {Error}
  * @return {!BigUint64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -1016,11 +1016,10 @@ function BigInt64Array(lengthOrArrayOrBuffer, byteOffset, bufferLength) {}
 BigInt64Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): bigint=} opt_mapFn
+ * @param {string|!IArrayLike<bigint>|!Iterable<bigint>} source
+ * @param {function(this:S, ?, number): bigint=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
- * @throws {Error}
+ * @template S
  * @return {!BigInt64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -1050,11 +1049,10 @@ function BigUint64Array(lengthOrArrayOrBuffer, byteOffset, bufferLength) {}
 BigUint64Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<T>|!Iterable<T>} source
- * @param {function(this:S, (string|T), number): bigint=} opt_mapFn
+ * @param {string|!IArrayLike<bigint>|!Iterable<bigint>} source
+ * @param {function(this:S, ?, number): bigint=} opt_mapFn
  * @param {S=} opt_this
- * @template T,S
- * @throws {Error}
+ * @template S
  * @return {!BigUint64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -711,13 +711,13 @@ Int8Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Int8Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Int8Array.from = function(source, opt_mapFn, opt_this) {};
+Int8Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -744,13 +744,13 @@ Uint8Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Uint8Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Uint8Array.from = function(source, opt_mapFn, opt_this) {};
+Uint8Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -777,13 +777,13 @@ Uint8ClampedArray.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Uint8ClampedArray}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Uint8ClampedArray.from = function(source, opt_mapFn, opt_this) {};
+Uint8ClampedArray.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -819,13 +819,13 @@ Int16Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Int16Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Int16Array.from = function(source, opt_mapFn, opt_this) {};
+Int16Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -852,13 +852,13 @@ Uint16Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Uint16Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Uint16Array.from = function(source, opt_mapFn, opt_this) {};
+Uint16Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -885,13 +885,13 @@ Int32Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Int32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Int32Array.from = function(source, opt_mapFn, opt_this) {};
+Int32Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -918,13 +918,13 @@ Uint32Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Uint32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Uint32Array.from = function(source, opt_mapFn, opt_this) {};
+Uint32Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -951,13 +951,13 @@ Float32Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Float32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Float32Array.from = function(source, opt_mapFn, opt_this) {};
+Float32Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -984,13 +984,13 @@ Float64Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, ?, number): number=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): number=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!Float64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-Float64Array.from = function(source, opt_mapFn, opt_this) {};
+Float64Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...number} var_args
@@ -1017,13 +1017,13 @@ BigInt64Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<bigint>|!Iterable<bigint>} source
- * @param {function(this:S, ?, number): bigint=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): bigint=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!BigInt64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-BigInt64Array.from = function(source, opt_mapFn, opt_this) {};
+BigInt64Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...bigint} var_args
@@ -1050,13 +1050,13 @@ BigUint64Array.BYTES_PER_ELEMENT;
 
 /**
  * @param {string|!IArrayLike<bigint>|!Iterable<bigint>} source
- * @param {function(this:S, ?, number): bigint=} opt_mapFn
- * @param {S=} opt_this
+ * @param {function(this:S, ?, number): bigint=} mapFn
+ * @param {S=} thisArg
  * @template S
  * @return {!BigUint64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-BigUint64Array.from = function(source, opt_mapFn, opt_this) {};
+BigUint64Array.from = function(source, mapFn, thisArg) {};
 
 /**
  * @param {...bigint} var_args

--- a/externs/es6.js
+++ b/externs/es6.js
@@ -710,10 +710,10 @@ function Int8Array(length, opt_byteOffset, opt_length) {}
 Int8Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Int8Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -743,10 +743,10 @@ function Uint8Array(length, opt_byteOffset, opt_length) {}
 Uint8Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Uint8Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -776,10 +776,10 @@ function Uint8ClampedArray(length, opt_byteOffset, opt_length) {}
 Uint8ClampedArray.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Uint8ClampedArray}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -818,10 +818,10 @@ function Int16Array(length, opt_byteOffset, opt_length) {}
 Int16Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Int16Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -851,10 +851,10 @@ function Uint16Array(length, opt_byteOffset, opt_length) {}
 Uint16Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Uint16Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -884,10 +884,10 @@ function Int32Array(length, opt_byteOffset, opt_length) {}
 Int32Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Int32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -917,10 +917,10 @@ function Uint32Array(length, opt_byteOffset, opt_length) {}
 Uint32Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Uint32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -950,10 +950,10 @@ function Float32Array(length, opt_byteOffset, opt_length) {}
 Float32Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Float32Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -983,10 +983,10 @@ function Float64Array(length, opt_byteOffset, opt_length) {}
 Float64Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<number>|!Iterable<number>} source
- * @param {function(this:S, number): number=} opt_mapFn
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): number=} opt_mapFn
  * @param {S=} opt_this
- * @template S
+ * @template T,S
  * @return {!Float64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
@@ -1016,14 +1016,14 @@ function BigInt64Array(lengthOrArrayOrBuffer, byteOffset, bufferLength) {}
 BigInt64Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<bigint>|!Iterable<bigint>} source
- * @param {function(this:S, bigint): bigint=} mapFn
- * @param {S=} thisArg
- * @template S
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): bigint=} opt_mapFn
+ * @param {S=} opt_this
+ * @template T,S
  * @return {!BigInt64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-BigInt64Array.from = function(source, mapFn, thisArg) {};
+BigInt64Array.from = function(source, opt_mapFn, opt_this) {};
 
 /**
  * @param {...bigint} var_args
@@ -1049,14 +1049,14 @@ function BigUint64Array(lengthOrArrayOrBuffer, byteOffset, bufferLength) {}
 BigUint64Array.BYTES_PER_ELEMENT;
 
 /**
- * @param {string|!IArrayLike<bigint>|!Iterable<bigint>} source
- * @param {function(this:S, bigint): bigint=} mapFn
- * @param {S=} thisArg
- * @template S
+ * @param {string|!IArrayLike<T>|!Iterable<T>} source
+ * @param {function(this:S, (string|T), number): bigint=} opt_mapFn
+ * @param {S=} opt_this
+ * @template T,S
  * @return {!BigUint64Array}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
  */
-BigUint64Array.from = function(source, mapFn, thisArg) {};
+BigUint64Array.from = function(source, opt_mapFn, opt_this) {};
 
 /**
  * @param {...bigint} var_args


### PR DESCRIPTION
Refs: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from)
This mainly fixes usage with `mapFn(element[, index])` function and removes false warnings.
Just like in Array.from, `element` can be of any type, `index` is a number.

Code sample:
```js
// good:
Uint8Array.from('abcXYZ'); // 0
Uint8Array.from('abcXYZ', c => c.charCodeAt(0));
Uint8Array.from('abcXYZ', (c, i) => i);
Float64Array.from('abcXYZ'); // NaN
Float64Array.from('abcXYZ', c => c.charCodeAt(0));
Float64Array.from('abcXYZ', (c, i) => i);
BigUint64Array.from('abcXYZ', c => BigInt(c.charCodeAt(0)));
BigUint64Array.from('abcXYZ', (c, i) => BigInt(i));

// "works" but deserves a warning:
Array.from({});             Array.from(9);
Uint8Array.from({});        Uint8Array.from(9);
Float64Array.from({});      Float64Array.from(9);
BigUint64Array.from({});    BigUint64Array.from(9);

// bad:
BigUint64Array.from('abcXYZ'); // SyntaxError: Cannot convert "a" to a BigInt
BigUint64Array.from('abcXYZ', c => BigInt(c)); // SyntaxError: Cannot convert "a" to a BigInt
BigUint64Array.from('abcXYZ', (c, i) => i); // TypeError: Cannot convert 0 to a BigInt
```
False warnings:
```bash
target/tst.js:3:33: WARNING - [JSC_INEXISTENT_PROPERTY] Property charCodeAt never defined on Number
  3| Uint8Array.from('abcXYZ', c => c.charCodeAt(0));
                                      ^^^^^^^^^^

target/tst.js:4:26: WARNING - [JSC_TYPE_MISMATCH] actual parameter 2 of Uint8Array.from does not match formal parameter
found   : function(?, ?): ?
required: (function(number): number|undefined)
  4| Uint8Array.from('abcXYZ', (c, i) => i);
                               ^^^^^^^^^^^
# same for Float and BigInt
```