### PR TITLE
Fix WebAssembly externs

### DIFF
--- a/externs/browser/webassembly.js
+++ b/externs/browser/webassembly.js
@@ -77,9 +77,12 @@ WebAssembly.LinkError = function() {};
 
 /**
  * @constructor
+ * @param {string=} message
+ * @param {string=} fileName
+ * @param {number=} lineNumber
  * @extends {Error}
  */
-WebAssembly.RuntimeError = function() {};
+WebAssembly.RuntimeError = function(message, fileName, lineNumber) {};
 
 // Note: Closure compiler does not support function overloading, omit this overload for now.
 // {function(!WebAssembly.Module, Object=):!Promise<!WebAssembly.Instance>}
@@ -91,11 +94,11 @@ WebAssembly.RuntimeError = function() {};
 WebAssembly.instantiate = function(moduleObject, importObject) {};
 
 /**
- * @param {!Promise<!Response>} moduleStream
+ * @param {!Promise<!Response>|!Response} source
  * @param {Object=} importObject
  * @return {!Promise<{module:!WebAssembly.Module, instance:!WebAssembly.Instance}>}
  */
-WebAssembly.instantiateStreaming = function(moduleStream, importObject) {};
+WebAssembly.instantiateStreaming = function(source, importObject) {};
 
 /**
  * @param {!BufferSource} bytes


### PR DESCRIPTION
WebAssembly.RuntimeError takes three optional params:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError

WebAssembly.instantiateStreaming can take a response as well as promise
of one:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming#parameters