### PR TITLE
Add externs for ParentNode.replaceChildren

### DIFF
--- a/externs/browser/w3c_dom4.js
+++ b/externs/browser/w3c_dom4.js
@@ -179,6 +179,27 @@ DocumentFragment.prototype.prepend = function(nodes) {};
 /**
  * @param {...(!Node|string)} nodes
  * @return {undefined}
+ * @see https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
+ */
+Element.prototype.replaceChildren = function(nodes) {};
+
+/**
+ * @param {...(!Node|string)} nodes
+ * @return {undefined}
+ * @see https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
+ */
+Document.prototype.replaceChildren = function(nodes) {};
+
+/**
+ * @param {...(!Node|string)} nodes
+ * @return {undefined}
+ * @see https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
+ */
+DocumentFragment.prototype.replaceChildren = function(nodes) {};
+
+/**
+ * @param {...(!Node|string)} nodes
+ * @return {undefined}
  * @see https://dom.spec.whatwg.org/#dom-childnode-before
  */
 Element.prototype.before = function(nodes) {};


### PR DESCRIPTION
This convenient DOM manipulation method is well-supported for a long enough time to be acknowledged.

Refs: [WHATWG](https://dom.spec.whatwg.org/#dom-parentnode-replacechildren), [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren), [Can I use](https://caniuse.com/mdn-api_element_replacechildren)