### PR TITLE
Allow URL objects in methods expecting a url-string

### DIFF
--- a/externs/browser/fetchapi.js
+++ b/externs/browser/fetchapi.js
@@ -143,7 +143,7 @@ Body.prototype.text = function() {};
 
 
 /**
- * @typedef {!Request|string}
+ * @typedef {!Request|!URL|string}
  * @see https://fetch.spec.whatwg.org/#requestinfo
  */
 var RequestInfo;
@@ -151,12 +151,12 @@ var RequestInfo;
 
 /**
  * @param {!RequestInfo} input
- * @param {!RequestInit=} opt_init
+ * @param {!RequestInit=} init
  * @constructor
  * @implements {Body}
  * @see https://fetch.spec.whatwg.org/#request
  */
-function Request(input, opt_init) {}
+function Request(input, init) {}
 
 /** @override */
 Request.prototype.bodyUsed;
@@ -329,7 +329,7 @@ function Response(opt_body, opt_init) {}
 Response.error = function() {};
 
 /**
- * @param {string} url
+ * @param {!URL|string} url
  * @param {number=} opt_status
  * @return {!Response}
  */
@@ -410,27 +410,27 @@ var ResponseType;
 
 /**
  * @param {!RequestInfo} input
- * @param {!RequestInit=} opt_init
+ * @param {!RequestInit=} init
  * @return {!Promise<!Response>}
  * @see https://fetch.spec.whatwg.org/#fetch-method
  */
-function fetch(input, opt_init) {}
+function fetch(input, init) {}
 
 /**
  * @param {!RequestInfo} input
- * @param {!RequestInit=} opt_init
+ * @param {!RequestInit=} init
  * @return {!Promise<!Response>}
  * @see https://fetch.spec.whatwg.org/#fetch-method
  */
-Window.prototype.fetch = function(input, opt_init) {};
+Window.prototype.fetch = function(input, init) {};
 
 /**
  * @param {!RequestInfo} input
- * @param {!RequestInit=} opt_init
+ * @param {!RequestInit=} init
  * @return {!Promise<!Response>}
  * @see https://fetch.spec.whatwg.org/#fetch-method
  */
-WorkerGlobalScope.prototype.fetch = function(input, opt_init) {};
+WorkerGlobalScope.prototype.fetch = function(input, init) {};
 
 /**
  * if WorkerOptions.type = 'module', it specifies how `scriptURL` is fetched.

--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -475,7 +475,7 @@ Navigator.prototype.productSub;
 Navigator.prototype.securityPolicy;
 
 /**
- * @param {string} url
+ * @param {!URL|string} url
  * @param {ArrayBufferView|Blob|string|FormData|URLSearchParams=} opt_data
  * @return {boolean}
  * @see https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -1467,10 +1467,10 @@ Window.prototype.applicationCache;
 
 /**
  * @see https://developer.mozilla.org/En/DOM/Worker/Functions_available_to_workers
- * @param {...!TrustedScriptURL|string} var_args
+ * @param {...!TrustedScriptURL|!URL|string} urls
  * @return {undefined}
  */
-Window.prototype.importScripts = function(var_args) {};
+Window.prototype.importScripts = function(urls) {};
 
 /**
  * Decodes a string of data which has been encoded using base-64 encoding.
@@ -1492,14 +1492,14 @@ function btoa(stringToEncode) {}
 
 /**
  * @see https://developer.mozilla.org/En/DOM/Worker/Functions_available_to_workers
- * @param {...!TrustedScriptURL|string} var_args
+ * @param {...!TrustedScriptURL|!URL|string} urls
  * @return {undefined}
  */
-function importScripts(var_args) {}
+function importScripts(urls) {}
 
 /**
  * @see http://dev.w3.org/html5/workers/
- * @param {!TrustedScriptURL|string} scriptURL
+ * @param {!TrustedScriptURL|!URL|string} scriptURL
  * @param {!WorkerOptions=} opt_options
  * @constructor
  * @implements {EventTarget}
@@ -1575,7 +1575,7 @@ WorkerOptions.prototype.type;
 
 /**
  * @see http://dev.w3.org/html5/workers/
- * @param {!TrustedScriptURL|string} scriptURL The URL of the script to run in
+ * @param {!TrustedScriptURL|!URL|string} scriptURL The URL of the script to run in
  *     the SharedWorker.
  * @param {(string|!WorkerOptions)=} options A name that can
  *     later be used to obtain a reference to the same SharedWorker or a
@@ -5371,7 +5371,7 @@ Navigator.prototype.cookieEnabled;
 
 /**
  * @param {string} scheme
- * @param {string} url
+ * @param {!URL|string} url
  * @param {string} title
  * @return {undefined}
  */
@@ -5387,7 +5387,7 @@ Navigator.prototype.registerContentHandler = function(mimeType, url, title) {}
 
 /**
  * @param {string} scheme
- * @param {string} url
+ * @param {!URL|string} url
  * @return {undefined}
  */
 Navigator.prototype.unregisterProtocolHandler = function(scheme, url) {}

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -3358,7 +3358,7 @@ TimeRanges.prototype.end = function(index) { return 0; };
 /**
  * @see https://html.spec.whatwg.org/multipage/web-sockets.html
  * @constructor
- * @param {string} url
+ * @param {!URL|string} url
  * @param {(string|!Array<string>)=} opt_protocol
  * @implements {EventTarget}
  */
@@ -3531,20 +3531,20 @@ History.prototype.go = function(delta) {};
  * @see http://www.w3.org/TR/html5/history.html#the-history-interface
  * @param {*} data New state.
  * @param {string} title The title for a new session history entry.
- * @param {string=} opt_url The URL for a new session history entry.
+ * @param {!URL|string=} url The URL for a new session history entry.
  * @return {undefined}
  */
-History.prototype.pushState = function(data, title, opt_url) {};
+History.prototype.pushState = function(data, title, url) {};
 
 /**
  * Replaces the current state in the session history.
  * @see http://www.w3.org/TR/html5/history.html#the-history-interface
  * @param {*} data New state.
  * @param {string} title The title for a session history entry.
- * @param {string=} opt_url The URL for a new session history entry.
+ * @param {!URL|string=} url The URL for a new session history entry.
  * @return {undefined}
  */
-History.prototype.replaceState = function(data, title, opt_url) {};
+History.prototype.replaceState = function(data, title, url) {};
 
 /**
  * Pending state object.
@@ -3654,7 +3654,7 @@ Location.prototype.hash;
 
 /**
  * Navigates to the given page.
- * @param {string} url
+ * @param {!URL|string} url
  * @return {undefined}
  * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-assign
  */
@@ -3663,7 +3663,7 @@ Location.prototype.assign = function(url) {};
 /**
  * Removes the current page from the session history and navigates to the given
  * page.
- * @param {string} url
+ * @param {!URL|string} url
  * @return {undefined}
  * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-replace
  */

--- a/externs/browser/url.js
+++ b/externs/browser/url.js
@@ -122,8 +122,8 @@ URLSearchParams.prototype.values = function() {};
 /**
  * @see https://url.spec.whatwg.org
  * @constructor
- * @param {string} url
- * @param {(string|!URL)=} base
+ * @param {!URL|string} url
+ * @param {!URL|string=} base
  */
 function URL(url, base) {}
 
@@ -188,7 +188,7 @@ URL.createObjectURL = function(obj) {};
 
 /**
  * @see http://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL
- * @param {string} url
+ * @param {!URL|string} url
  * @return {undefined}
  */
 URL.revokeObjectURL = function(url) {};

--- a/externs/browser/w3c_dom2.js
+++ b/externs/browser/w3c_dom2.js
@@ -2964,7 +2964,7 @@ Window.prototype.stop = function() {};
 var BoolOrAttributionSourceParams;
 
 /**
- * @param {*=} url
+ * @param {!URL|string=} url
  * @param {string=} windowName
  * @param {string=} windowFeatures
  * @param {!BoolOrAttributionSourceParams=} replaceOrAttributionParams

--- a/externs/browser/w3c_eventsource.js
+++ b/externs/browser/w3c_eventsource.js
@@ -30,7 +30,7 @@ EventSourceInit.prototype.withCredentials;
 /**
  * @constructor
  * @implements {EventTarget}
- * @param {string} url
+ * @param {!URL|string} url
  * @param {EventSourceInit=} opt_eventSourceInitDict
  */
 function EventSource(url, opt_eventSourceInitDict) {}

--- a/externs/browser/w3c_serviceworker.js
+++ b/externs/browser/w3c_serviceworker.js
@@ -277,17 +277,17 @@ ServiceWorkerContainer.prototype.controller;
 ServiceWorkerContainer.prototype.ready;
 
 /**
- * @param {!TrustedScriptURL|string} scriptURL
+ * @param {!TrustedScriptURL|!URL|string} scriptURL
  * @param {RegistrationOptions=} opt_options
  * @return {!Promise<!ServiceWorkerRegistration>}
  */
 ServiceWorkerContainer.prototype.register = function(scriptURL, opt_options) {};
 
 /**
- * @param {string=} opt_documentURL
+ * @param {!URL|string=} documentURL
  * @return {!Promise<!ServiceWorkerRegistration|undefined>}
  */
-ServiceWorkerContainer.prototype.getRegistration = function(opt_documentURL) {};
+ServiceWorkerContainer.prototype.getRegistration = function(documentURL) {};
 
 /**
  * @return {!Promise<Array<!ServiceWorkerRegistration>>}
@@ -419,7 +419,7 @@ ServiceWorkerClient.prototype.postMessage = function(message, opt_transfer) {};
 ServiceWorkerClient.prototype.focus = function() {};
 
 /**
- * @param {string} url
+ * @param {!URL|string} url
  * @return {!Promise<!ServiceWorkerClient>}
  */
 ServiceWorkerClient.prototype.navigate = function(url) {};
@@ -451,7 +451,7 @@ ServiceWorkerClients.prototype.matchAll = function(opt_options) {};
 ServiceWorkerClients.prototype.claim = function() {};
 
 /**
- * @param {string} url
+ * @param {!URL|string} url
  * @return {!Promise<!ServiceWorkerClient>}
  */
 ServiceWorkerClients.prototype.openWindow = function(url) {};

--- a/externs/browser/w3c_worklets.js
+++ b/externs/browser/w3c_worklets.js
@@ -47,7 +47,7 @@ WorkletOptions.prototype.credentials;
 function Worklet() {}
 
 /**
- * @param {string} moduleURL
+ * @param {!URL|string} moduleURL
  * @param {!WorkletOptions=} options
  * @return {!Promise<void>}
  */

--- a/externs/browser/w3c_xml.js
+++ b/externs/browser/w3c_xml.js
@@ -307,7 +307,7 @@ XMLHttpRequest.prototype.dispatchEvent = function(evt) {};
 
 /**
  * @param {string} method
- * @param {string} url
+ * @param {!URL|string} url
  * @param {?boolean=} opt_async
  * @param {?string=} opt_user
  * @param {?string=} opt_password

--- a/externs/browser/webstorage.js
+++ b/externs/browser/webstorage.js
@@ -160,7 +160,7 @@ StorageEvent.prototype.storageArea;
  * @param {string} keyArg
  * @param {?string} oldValueArg
  * @param {?string} newValueArg
- * @param {string} urlArg
+ * @param {!URL|string} urlArg
  * @param {?Storage} storageAreaArg
  * @return {void}
  */


### PR DESCRIPTION
Fixes https://github.com/google/closure-compiler/issues/3919

This might encourage users to prefer transparent usage of well-encoded and well-validated absolute URLs over raw strings where applicable; and prevent potential errors where URL objects are explicitly stringified just to avoid falsy warning.


Trivia/clarification on `URL` [constructor](https://url.spec.whatwg.org/#dom-url-url):
Apparently, it does allow first param to be an absolute URL even if `base` is given. E.g.:
```js
new URL('ftp://url.com/url', 'https://base.com/base') == 'ftp://url.com/url'; // true
```
This means, it is safe to declare first param as `URL|string`, which is essential for constucting from another `URL` object:
```js
const a = new URL('https://a.com');
const b = new URL(a); // clone of a
```
...which currently raises `JSC_TYPE_MISMATCH` warning.