### PR TITLE
DOMMatrix does not have inverseSelf, it has invertSelf

### DIFF
--- a/externs/browser/w3c_geometry1.js
+++ b/externs/browser/w3c_geometry1.js
@@ -745,7 +745,7 @@ DOMMatrix.prototype.skewYSelf = function(sy) {};
  * @return {!DOMMatrix}
  * @see https://www.w3.org/TR/geometry-1/#dom-dommatrix-inverse
  */
-DOMMatrix.prototype.inverseSelf = function() {};
+DOMMatrix.prototype.invertSelf = function() {};
 
 /**
  * @record


### PR DESCRIPTION
I just spotted this typo, in the definitions of DOMMatrix, the right spelling is "invertSelf" and not "inverseSelf".
See https://www.w3.org/TR/geometry-1/#dom-dommatrix-invertself