### PR TITLE
Bump gson from 2.7 to 2.9.1 to address CVE-2022-25647

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ without make's wrinkles and with the full portability of pure java code.</td>
 
   <tr>
     <td>Version</td>
-    <td>2.7</td>
+    <td>2.9.1</td>
   </tr>
 
   <tr>

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -55,8 +55,8 @@ maven_import(
     # https://github.com/google/gson
     group_id = "com.google.code.gson",
     artifact_id = "gson",
-    version = "2.7",
-    sha256 = "2d43eb5ea9e133d2ee2405cc14f5ee08951b8361302fdd93494a3a997b508d32",
+    version = "2.9.1",
+    sha256 = "378534e339e6e6d50b1736fb3abb76f1c15d1be3f4c13cec6d536412e23da603",
     licenses = ["notice"],
 )
 


### PR DESCRIPTION
This should resolve https://github.com/google/closure-compiler/issues/3957, which I believe was closed prematurely without a fix. This is needed because the closure-compiler jar is being flagged with CVE-2022-25647 as a result of the shaded version of gson `2.7` inside it.