### PR TITLE
Upgrade node version in CI job

### DIFF
--- a/.github/ci_support/test_closure-compiler-npm.sh
+++ b/.github/ci_support/test_closure-compiler-npm.sh
@@ -35,17 +35,14 @@ function main() {
   #
   # TODO(nickreid): This should be done using scripts from inside the NPM repo
   cp "${compiler_jar}" "packages/google-closure-compiler-java/compiler.jar"
-  cp "${compiler_jar}" "packages/google-closure-compiler-osx/compiler.jar"
-  cp "${compiler_jar}" "packages/google-closure-compiler-linux/compiler.jar"
-  cp "${compiler_jar}" "packages/google-closure-compiler-windows/compiler.jar"
 
-  # Run all the tests inside closure-compiler-npm. This will use the version
+  # Run the java tests inside closure-compiler-npm. This will use the version
   # of the compiler we just copied into it.
   #
   # The NPM repo is divided into multiple Yarn workspaces: one for each
-  # variant of the compiler, including the Graal native builds.
-  yarn workspaces run build
-  yarn workspaces run test
+  # variant of the compiler, including the Graal native builds. We only
+  # need to test the java build.
+  yarn workspace google-closure-compiler run test --java-only
 }
 
 main "$@"

--- a/.github/ci_support/test_closure-compiler-npm.sh
+++ b/.github/ci_support/test_closure-compiler-npm.sh
@@ -42,7 +42,7 @@ function main() {
   # The NPM repo is divided into multiple Yarn workspaces: one for each
   # variant of the compiler, including the Graal native builds. We only
   # need to test the java build.
-  yarn workspace google-closure-compiler run test --java-only
+  yarn workspace google-closure-compiler run test --java-only --colors
 }
 
 main "$@"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ on:
     - cron: '0 12 * * *'
 
 env:
-  VERSION_NODEJS: '10.21.0'
+  VERSION_NODEJS: '16.16.0'
   UNSYMLINK_DIR: bazel-bin-unsymlink
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs


### PR DESCRIPTION
The CI job is currently running on Node 10 which is no longer supported. With the dependency updates to the npm repo, the CI job is failing as dependencies cannot be installed. Upgrade the CI job to Node 16.