### PR TITLE
#3990 - Add flag to set `CompilerOptions#crossChunkCodeMotionNoStubMethods`

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -962,6 +962,15 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 + " optimizations that could break code that did those things.")
     private boolean assumeStaticInheritanceIsNotUsed = true;
 
+    @Option(
+        name = "--assume_no_prototype_method_enumeration",
+        handler = BooleanOptionHandler.class,
+        usage =
+            "Assume that prototype method enumeration is not being used. This allows the compiler "
+                + "to move a prototype method declaration into a deeper chunk without creating "
+                + "stub functions in a parent chunk.")
+    private boolean assumeNoPrototypeMethodEnumeration = false;
+
     @Argument private List<String> arguments = new ArrayList<>();
     private final CmdLineParser parser;
 
@@ -2019,6 +2028,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     options.setAllowDynamicImport(flags.allowDynamicImport);
     options.setDynamicImportAlias(flags.dynamicImportAlias);
     options.setAssumeStaticInheritanceIsNotUsed(flags.assumeStaticInheritanceIsNotUsed);
+    options.setCrossChunkCodeMotionNoStubMethods(flags.assumeNoPrototypeMethodEnumeration);
 
     if (flags.chunkOutputType == ChunkOutputType.ES_MODULES) {
       if (flags.renamePrefixNamespace != null) {

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -3056,6 +3056,15 @@ public final class CommandLineRunnerTest {
     assertThat(lastCompiler.getOptions().getIsolatePolyfills()).isTrue();
   }
 
+  @Test
+  public void testCrossChunkCodeMotionNoStubMethods() {
+    testSame("");
+    assertThat(lastCompiler.getOptions().crossChunkCodeMotionNoStubMethods).isFalse();
+    args.add("--assume_no_prototype_method_enumeration=true");
+    testSame("");
+    assertThat(lastCompiler.getOptions().crossChunkCodeMotionNoStubMethods).isTrue();
+  }
+
   /* Helper functions */
 
   private void testSame(String original) {


### PR DESCRIPTION
This PR adds a compiler flag `--assume_no_prototype_method_enumeration`, which is mapped to `CompilerOptions.crossChunkCodeMotionNoStubMethods`, which controls `CrossChunkMethodMotion#noStubFunctions`.

The flag's name is the same as the one suggested in https://github.com/google/closure-compiler/issues/3990#issuecomment-1239167953.

Its default value is `false`, which is the behavior of the compiler prior to this change. When it is set to `true`, it will allow the compiler to move a prototype method declaration into a deeper chunk without creating stub functions in a parent chunk.