### PR TITLE
Prevent replacing "super" references when inlining

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -1064,6 +1064,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
             .putAll(
                 "Miscellaneous",
                 ImmutableList.of(
+                    "assume_static_inheritance_is_not_used",
                     "browser_featureset_year",
                     "charset",
                     "checks_only",
@@ -1073,7 +1074,6 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                     "json_streams",
                     "third_party",
                     "use_types_for_optimization",
-                    "assume_static_inheritance_required",
                     "version"))
             .build();
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -2184,6 +2184,7 @@ public final class DefaultPassConfig extends PassConfig {
                       .setChunkOutputType(options.getChunkOutputType())
                       .setHaveModulesBeenRewritten(options.getProcessCommonJSModules())
                       .setModuleResolutionMode(options.getModuleResolutionMode())
+                      .setAssumeStaticInheritanceIsNotUsed(options.getAssumeStaticInheritanceIsNotUsed())
                       .build())
           .build();
 

--- a/src/com/google/javascript/jscomp/InlineAndCollapseProperties.java
+++ b/src/com/google/javascript/jscomp/InlineAndCollapseProperties.java
@@ -95,6 +95,7 @@ class InlineAndCollapseProperties implements CompilerPass {
   private final ChunkOutputType chunkOutputType;
   private final boolean haveModulesBeenRewritten;
   private final ResolutionMode moduleResolutionMode;
+  private final boolean staticInheritanceUsed;
 
   /**
    * Used by `AggressiveInlineAliasesTest` to enable execution of the aggressive inlining logic
@@ -129,6 +130,7 @@ class InlineAndCollapseProperties implements CompilerPass {
     this.moduleResolutionMode = builder.moduleResolutionMode;
     this.testAggressiveInliningOnly = builder.testAggressiveInliningOnly;
     this.optionalGlobalNamespaceTester = builder.optionalGlobalNamespaceTester;
+    this.staticInheritanceUsed = builder.staticInheritanceUsed;
   }
 
   static final class Builder {
@@ -139,6 +141,7 @@ class InlineAndCollapseProperties implements CompilerPass {
     private ResolutionMode moduleResolutionMode;
     private boolean testAggressiveInliningOnly = false;
     private Optional<Consumer<GlobalNamespace>> optionalGlobalNamespaceTester = Optional.empty();
+    private boolean staticInheritanceUsed = false;
 
     Builder(AbstractCompiler compiler) {
       this.compiler = compiler;
@@ -173,6 +176,12 @@ class InlineAndCollapseProperties implements CompilerPass {
     public Builder testAggressiveInliningOnly(Consumer<GlobalNamespace> globalNamespaceTester) {
       this.testAggressiveInliningOnly = true;
       this.optionalGlobalNamespaceTester = Optional.of(globalNamespaceTester);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setAssumeStaticInheritanceIsNotUsed(boolean assumeStaticInheritanceIsNotUsed) {
+      this.staticInheritanceUsed = assumeStaticInheritanceIsNotUsed == false;
       return this;
     }
 
@@ -271,7 +280,9 @@ class InlineAndCollapseProperties implements CompilerPass {
 
     @Override
     public void process(Node externs, Node root) {
-      new StaticSuperPropReplacer(compiler).replaceAll(root);
+      if (!staticInheritanceUsed) {
+        new StaticSuperPropReplacer(compiler).replaceAll(root);
+      }
 
       NodeTraversal.traverse(compiler, root, new RewriteSimpleDestructuringAliases());
 

--- a/test/com/google/javascript/jscomp/InlineAndCollapsePropertiesTest.java
+++ b/test/com/google/javascript/jscomp/InlineAndCollapsePropertiesTest.java
@@ -42,6 +42,8 @@ public final class InlineAndCollapsePropertiesTest extends CompilerTestCase {
           "/** @constructor */ function String() {};",
           "var arguments");
 
+  private boolean assumeStaticInheritanceIsNotUsed = true;
+
   public InlineAndCollapsePropertiesTest() {
     super(EXTERNS);
   }
@@ -53,6 +55,7 @@ public final class InlineAndCollapsePropertiesTest extends CompilerTestCase {
         .setChunkOutputType(ChunkOutputType.GLOBAL_NAMESPACE)
         .setHaveModulesBeenRewritten(false)
         .setModuleResolutionMode(ResolutionMode.BROWSER)
+        .setAssumeStaticInheritanceIsNotUsed(this.assumeStaticInheritanceIsNotUsed)
         .build();
   }
 
@@ -2731,6 +2734,29 @@ public final class InlineAndCollapsePropertiesTest extends CompilerTestCase {
             "class Bar {}",
             "var Baz$quadruple = function(n) { return 2 * Bar$double(n); }",
             "class Baz extends Bar {}"));
+  }
+
+  @Test
+  public void testClassStaticMemberAccessedWithSuperAndThis() {
+    assumeStaticInheritanceIsNotUsed = false;
+    testSame(
+            lines(
+                    "class Bar {", //
+                    "  static get name() {",
+                    "    return 'Bar';",
+                    "  }",
+                    "  static get classname() {",
+                    "    return `${this.name} class`;",
+                    "  }",
+                    "}",
+                    "class Baz extends Bar {",
+                    "  static get name() {",
+                    "    return 'Baz';",
+                    "  }",
+                    "  static get classname() {",
+                    "    return `${super.classname} - is a subclass`;",
+                    "  }",
+                    "}"));
   }
 
   @Test


### PR DESCRIPTION
When static inheritance is utilized, references to super must not be replaced while inlining as it changes the refence of "this" when calling methods and getters.

While the `GlobalNamespace` class correctly utilized the option, there still existed an unconditional call to `StaticSuperPropReplacer`. Even though the final reference was not inlined, the `super` reference was replaced with the classname.