### PR TITLE
Exclude `$` from appearing in renamed variable and property names

### DIFF
--- a/src/com/google/javascript/jscomp/DefaultNameGenerator.java
+++ b/src/com/google/javascript/jscomp/DefaultNameGenerator.java
@@ -87,11 +87,11 @@ public final class DefaultNameGenerator implements NameGenerator {
   // end up balancing the huffman tree and result is bad compression.
   /** Generate short name with this first character */
   static final char[] FIRST_CHAR =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$".toCharArray();
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
 
   /** These appear after the first character */
   static final char[] NONFIRST_CHAR =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789$"
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789"
         .toCharArray();
 
   /**

--- a/test/com/google/javascript/jscomp/DefaultNameGeneratorTest.java
+++ b/test/com/google/javascript/jscomp/DefaultNameGeneratorTest.java
@@ -50,7 +50,7 @@ public final class DefaultNameGeneratorTest {
           .fail();
     } catch (IllegalArgumentException ex) {
       // The error messages should contain meaningful information.
-      assertThat(ex).hasMessageThat().contains("W, X, Y, Z, $]");
+      assertThat(ex).hasMessageThat().contains("W, X, Y, Z]");
     }
 
     try {
@@ -72,22 +72,21 @@ public final class DefaultNameGeneratorTest {
     assertThat(result[25]).isEqualTo("z");
     assertThat(result[26]).isEqualTo("A");
     assertThat(result[51]).isEqualTo("Z");
-    assertThat(result[52]).isEqualTo("$");
-    assertThat(result[53]).isEqualTo("aa");
+    assertThat(result[52]).isEqualTo("aa");
     // ba is reserved
-    assertThat(result[54]).isEqualTo("ca");
-    assertThat(result[104]).isEqualTo("$a");
+    assertThat(result[53]).isEqualTo("ca");
+    assertThat(result[103]).isEqualTo("ab");
 
     ng = new DefaultNameGenerator(RESERVED_NAMES, "x", null);
     result = generate(ng, "x", 132);
 
-    // Expected: x, xa, ..., x$, xaa, ..., x$$
+    // Expected: x, xa, ..., x9, xaa, ..., x99
     assertThat(result[0]).isEqualTo("x");
     assertThat(result[1]).isEqualTo("xa");
-    assertThat(result[64]).isEqualTo("x$");
-    assertThat(result[65]).isEqualTo("xaa");
+    assertThat(result[63]).isEqualTo("x9");
+    assertThat(result[64]).isEqualTo("xaa");
     // xba is reserved
-    assertThat(result[66]).isEqualTo("xca");
+    assertThat(result[65]).isEqualTo("xca");
   }
 
   @Test
@@ -129,8 +128,7 @@ public final class DefaultNameGeneratorTest {
     assertThat(result[25]).isEqualTo("z");
     assertThat(result[26]).isEqualTo("A");
     assertThat(result[51]).isEqualTo("Z");
-    assertThat(result[52]).isEqualTo("$");
-    assertThat(result[53]).isEqualTo("aa");
+    assertThat(result[52]).isEqualTo("aa");
 
     ng.favors("b");
     ng.reset(RESERVED_NAMES, "", null);
@@ -158,8 +156,7 @@ public final class DefaultNameGeneratorTest {
     assertThat(result[25]).isEqualTo("z");
     assertThat(result[26]).isEqualTo("A");
     assertThat(result[51]).isEqualTo("Z");
-    assertThat(result[52]).isEqualTo("$");
-    assertThat(result[53]).isEqualTo("aa");
+    assertThat(result[52]).isEqualTo("aa");
 
     ng.favors("function");
     ng.favors("function");
@@ -186,8 +183,8 @@ public final class DefaultNameGeneratorTest {
     assertThat(result[10]).isEqualTo("e");
 
     // This used to start with 'aa' but now n is prioritized over it.
-    assertThat(result[53]).isEqualTo("nn");
-    assertThat(result[54]).isEqualTo("cn");
+    assertThat(result[52]).isEqualTo("nn");
+    assertThat(result[53]).isEqualTo("cn");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/RandomNameGeneratorTest.java
+++ b/test/com/google/javascript/jscomp/RandomNameGeneratorTest.java
@@ -50,7 +50,7 @@ public final class RandomNameGeneratorTest {
           .fail();
     } catch (IllegalArgumentException ex) {
       // The error messages should contain meaningful information.
-      assertThat(ex).hasMessageThat().contains("W, X, Y, Z, $");
+      assertThat(ex).hasMessageThat().contains("W, X, Y, Z");
     }
 
     try {

--- a/test/com/google/javascript/jscomp/RenameLocalVarsTest.java
+++ b/test/com/google/javascript/jscomp/RenameLocalVarsTest.java
@@ -157,8 +157,8 @@ public final class RenameLocalVarsTest extends CompilerTestCase {
 
          "function Foo() {return 1;}" +
          "function Bar() {" +
-         "  var a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,B,C," +
-         "      D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,$,aa;"  +
+         "  var a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z," +
+         "      A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,aa,ba;"  +
          "  Foo();" +
          "} Bar();");
     prefix = DEFAULT_PREFIX;

--- a/test/com/google/javascript/jscomp/RenameVarsTest.java
+++ b/test/com/google/javascript/jscomp/RenameVarsTest.java
@@ -468,7 +468,7 @@ public final class RenameVarsTest extends CompilerTestCase {
             "function a() {return 1;}", //
             "function aa() {",
             "  var b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,",
-            "      B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,$,ba,ca;",
+            "      B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,ba,ca,da;",
             "  a();",
             "} aa();"));
     prefix = DEFAULT_PREFIX;
@@ -482,11 +482,11 @@ public final class RenameVarsTest extends CompilerTestCase {
     test(
         lines(
             "(function(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,",
-            "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,$){});",
+            "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z){});",
             "var a4,a3,a2,a1,b4,b3,b2,b1,ab,ac,ad,fg;function foo(){};"),
         lines(
             "(function(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,",
-            "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,$){});",
+            "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z){});",
             "var aa,ba,ca,da,ea,fa,ga,ha,ia,ja,ka,la;function ma(){};"));
   }
 
@@ -724,7 +724,7 @@ public final class RenameVarsTest extends CompilerTestCase {
             "function a() {return 1;}",
             "function aa() {",
             "  var b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,",
-            "      B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,$,ba,ca;",
+            "      B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,ba,ca,da;",
             "  a();",
             "} aa();"));
 
@@ -745,7 +745,7 @@ public final class RenameVarsTest extends CompilerTestCase {
             "function ab() {return 1;}",
             "function aa() {",
             "  var b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,",
-            "      B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,$,ba,ca;",
+            "      B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,ba,ca,da;",
             "  a();",
             "} aa();"));
   }


### PR DESCRIPTION
Mangled property names can be accessed via `Object.keys()`, `Object.assign()`, etc.
In most scenarios, assuming renaming consistency (i.e. all related code is processed into one file by compiler), it is completely safe to do.

However, using property names with `$` might be undesirable in some scenarios, for example in `data-*` html attritubes or regular expressions.

Refs: https://github.com/google/closure-compiler/issues/3996