### PR TITLE
Avoid parsing JS files when building a bundle

### DIFF
--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2403,7 +2403,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
       // ES6 modules will need a runtime in a bundle. Skip appending this runtime if there are no
       // ES6 modules to cut down on size.
       for (CompilerInput input : inputs) {
-        if ("es6".equals(input.getLoadFlags().get("module"))) {
+        if (input.isEs6Module()) {
           appendRuntimeTo(out);
           break;
         }

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -2232,7 +2232,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       // Only process files that are detected as ES6 modules
       if (!options.getDependencyOptions().shouldPrune()
           || !JsFileRegexParser.isSupported()
-          || "es6".equals(input.getLoadFlags().get("module"))) {
+          || input.isEs6Module()) {
         filteredInputs.add(input);
       }
     }

--- a/src/com/google/javascript/jscomp/CompilerInput.java
+++ b/src/com/google/javascript/jscomp/CompilerInput.java
@@ -48,7 +48,7 @@ import org.jspecify.nullness.Nullable;
  * and maintain state such as module for the input and whether the input is an extern. Also
  * calculates provided and required types.
  */
-public class CompilerInput extends DependencyInfo.Base {
+public class CompilerInput implements DependencyInfo {
 
   private static final long serialVersionUID = 2L;
 
@@ -573,11 +573,13 @@ public class CompilerInput extends DependencyInfo.Base {
 
   @Override
   public boolean isEs6Module() {
+    // Instead of doing a full parse to read all load flags, just ask the delegate, which at least has this much info
     return getDependencyInfo().isEs6Module();
   }
 
   @Override
   public boolean isGoogModule() {
+    // Instead of doing a full parse to read all load flags, just ask the delegate, which at least has this much info
     return getDependencyInfo().isGoogModule();
   }
 

--- a/src/com/google/javascript/jscomp/CompilerInput.java
+++ b/src/com/google/javascript/jscomp/CompilerInput.java
@@ -572,6 +572,16 @@ public class CompilerInput extends DependencyInfo.Base {
   }
 
   @Override
+  public boolean isEs6Module() {
+    return getDependencyInfo().isEs6Module();
+  }
+
+  @Override
+  public boolean isGoogModule() {
+    return getDependencyInfo().isGoogModule();
+  }
+
+  @Override
   public ImmutableMap<String, String> getLoadFlags() {
     return getDependencyInfo().getLoadFlags();
   }

--- a/src/com/google/javascript/jscomp/JSChunk.java
+++ b/src/com/google/javascript/jscomp/JSChunk.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * A JavaScript chunk has a unique name, consists of a list of compiler inputs, and can depend on
  * other chunks.
  */
-public final class JSChunk extends DependencyInfo.Base implements Serializable {
+public final class JSChunk implements Serializable, DependencyInfo {
   // The name of the artificial chunk containing all strong sources when there is no chunk spec.
   // If there is a chunk spec, strong sources go in their respective chunks, and this chunk does
   // not exist.
@@ -59,7 +59,7 @@ public final class JSChunk extends DependencyInfo.Base implements Serializable {
   private final String name;
 
   /** Source code inputs */
-  // non-final for deserilaization
+  // non-final for deserialization
   // CompilerInputs must be explicitly added to the JSChunk again after deserialization
   // A map keyed by the {@code CompilerInput.getName()} to speed up getByName and removeByName.
   private transient Map<String, CompilerInput> inputs = new LinkedHashMap<>();
@@ -128,15 +128,6 @@ public final class JSChunk extends DependencyInfo.Base implements Serializable {
 
   @Override
   public ImmutableMap<String, String> getLoadFlags() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean isModule() {
-    // NOTE: The meaning of "module" has changed over time.  A "JsChunk" is
-    // a collection of inputs that are loaded together. A "module" file,
-    // is a CommonJs module, ES6 module, goog.module or other file whose
-    // top level symbols are not in global scope.
     throw new UnsupportedOperationException();
   }
 

--- a/src/com/google/javascript/jscomp/LazyParsedDependencyInfo.java
+++ b/src/com/google/javascript/jscomp/LazyParsedDependencyInfo.java
@@ -29,7 +29,7 @@ import java.util.TreeMap;
 import org.jspecify.nullness.Nullable;
 
 /** A DependencyInfo class that determines load flags by parsing the AST just-in-time. */
-public class LazyParsedDependencyInfo extends DependencyInfo.Base {
+public class LazyParsedDependencyInfo implements DependencyInfo {
 
   private final DependencyInfo delegate;
   private @Nullable JsAst ast;
@@ -45,13 +45,13 @@ public class LazyParsedDependencyInfo extends DependencyInfo.Base {
 
   @Override
   public boolean isEs6Module() {
-    // Instead of doing a full parse to look this up, just ask the delegate, which at least has this much info
+    // Instead of doing a full parse to read all load flags, just ask the delegate, which at least has this much info
     return delegate.isEs6Module();
   }
 
   @Override
   public boolean isGoogModule() {
-    // Instead of doing a full parse to look this up, just ask the delegate, which at least has this much info
+    // Instead of doing a full parse to read all load flags, just ask the delegate, which at least has this much info
     return delegate.isGoogModule();
   }
 

--- a/src/com/google/javascript/jscomp/LazyParsedDependencyInfo.java
+++ b/src/com/google/javascript/jscomp/LazyParsedDependencyInfo.java
@@ -44,6 +44,18 @@ public class LazyParsedDependencyInfo extends DependencyInfo.Base {
   }
 
   @Override
+  public boolean isEs6Module() {
+    // Instead of doing a full parse to look this up, just ask the delegate, which at least has this much info
+    return delegate.isEs6Module();
+  }
+
+  @Override
+  public boolean isGoogModule() {
+    // Instead of doing a full parse to look this up, just ask the delegate, which at least has this much info
+    return delegate.isGoogModule();
+  }
+
+  @Override
   public ImmutableMap<String, String> getLoadFlags() {
     if (loadFlags == null) {
       Map<String, String> loadFlagsBuilder = new TreeMap<>();

--- a/src/com/google/javascript/jscomp/deps/ClosureBundler.java
+++ b/src/com/google/javascript/jscomp/deps/ClosureBundler.java
@@ -189,9 +189,9 @@ public final class ClosureBundler {
   /** Append the contents of the CharSource to the supplied appendable. */
   public void appendTo(Appendable out, DependencyInfo info, CharSource content) throws IOException {
     String code = content.read();
-    if (info.isModule()) {
+    if (info.isGoogModule()) {
       mode.appendGoogModule(transpile(code), out, sourceUrl);
-    } else if ("es6".equals(info.getLoadFlags().get("module")) && transpiler == Transpiler.NULL) {
+    } else if (info.isEs6Module() && transpiler == Transpiler.NULL) {
       // TODO(johnplaisted): Make the default transpiler the ES_MODULE_TO_CJS_TRANSPILER. Currently
       // some code is passing in unicode identifiers in non-ES6 modules the compiler fails to parse.
       // Once this compiler bug is fixed we can always transpile.

--- a/src/com/google/javascript/jscomp/deps/DependencyInfo.java
+++ b/src/com/google/javascript/jscomp/deps/DependencyInfo.java
@@ -129,7 +129,9 @@ public interface DependencyInfo {
   /** Gets the symbols required by this file. */
   ImmutableList<Require> getRequires();
 
-  ImmutableList<String> getRequiredSymbols();
+  default ImmutableList<String> getRequiredSymbols() {
+    return Require.asSymbolList(getRequires());
+  }
 
   /** Gets the symbols type-required by this file (i.e. for typechecking only). */
   ImmutableList<String> getTypeRequires();
@@ -137,12 +139,11 @@ public interface DependencyInfo {
   /** Gets the loading information for this file. */
   ImmutableMap<String, String> getLoadFlags();
 
-  /** Whether the symbol is provided by a module */
-  boolean isModule();
-
+  /** Whether the symbol is provided by an ES6 module */
   default boolean isEs6Module() {
     return "es6".equals(getLoadFlags().get("module"));
   }
+  /** Whether the symbol is provided by a goog module */
   default boolean isGoogModule() {
     return "goog".equals(getLoadFlags().get("module"));
   }
@@ -152,21 +153,6 @@ public interface DependencyInfo {
 
   /** Whether the file has the '@nocompile' annotation. */
   boolean getHasNoCompileAnnotation();
-
-  /**
-   * Abstract base implementation that defines derived accessors such
-   * as {@link #isModule}.
-   */
-  abstract class Base implements DependencyInfo {
-    @Override public boolean isModule() {
-      return isGoogModule();
-    }
-
-    @Override
-    public ImmutableList<String> getRequiredSymbols() {
-      return Require.asSymbolList(getRequires());
-    }
-  }
 
   /** Utility methods. */
   class Util {

--- a/src/com/google/javascript/jscomp/deps/DependencyInfo.java
+++ b/src/com/google/javascript/jscomp/deps/DependencyInfo.java
@@ -143,6 +143,7 @@ public interface DependencyInfo {
   default boolean isEs6Module() {
     return "es6".equals(getLoadFlags().get("module"));
   }
+
   /** Whether the symbol is provided by a goog module */
   default boolean isGoogModule() {
     return "goog".equals(getLoadFlags().get("module"));

--- a/src/com/google/javascript/jscomp/deps/DependencyInfo.java
+++ b/src/com/google/javascript/jscomp/deps/DependencyInfo.java
@@ -140,6 +140,13 @@ public interface DependencyInfo {
   /** Whether the symbol is provided by a module */
   boolean isModule();
 
+  default boolean isEs6Module() {
+    return "es6".equals(getLoadFlags().get("module"));
+  }
+  default boolean isGoogModule() {
+    return "goog".equals(getLoadFlags().get("module"));
+  }
+
   /** Whether the file '@externs' annotation. */
   boolean getHasExternsAnnotation();
 
@@ -152,7 +159,7 @@ public interface DependencyInfo {
    */
   abstract class Base implements DependencyInfo {
     @Override public boolean isModule() {
-      return "goog".equals(getLoadFlags().get("module"));
+      return isGoogModule();
     }
 
     @Override

--- a/src/com/google/javascript/jscomp/deps/DepsGenerator.java
+++ b/src/com/google/javascript/jscomp/deps/DepsGenerator.java
@@ -219,7 +219,7 @@ public class DepsGenerator {
 
       ImmutableList<String> provides = dependencyInfo.getProvides();
 
-      if ("es6".equals(dependencyInfo.getLoadFlags().get("module"))) {
+      if (dependencyInfo.isEs6Module()) {
         String mungedProvide = loader.resolve(dependencyInfo.getName()).toModuleName();
         // Filter out the munged symbol.
         // Note that at the moment ES6 modules should not have any other provides! In the future
@@ -278,7 +278,7 @@ public class DepsGenerator {
           reportSameFile(namespace, depInfo);
         } else {
           depInfo.isModule();
-          boolean providerIsEs6Module = "es6".equals(provider.getLoadFlags().get("module"));
+          boolean providerIsEs6Module = provider.isEs6Module();
 
           switch (require.getType()) {
             case ES6_IMPORT:
@@ -363,7 +363,7 @@ public class DepsGenerator {
                 .toModuleName());
       } else {
         // ES6 modules already provide these munged symbols.
-        if (!"es6".equals(depInfo.getLoadFlags().get("module"))) {
+        if (!depInfo.isEs6Module()) {
           provides.add(loader.resolve(depInfo.getName()).toModuleName());
         }
       }

--- a/src/com/google/javascript/jscomp/deps/DepsGenerator.java
+++ b/src/com/google/javascript/jscomp/deps/DepsGenerator.java
@@ -277,7 +277,6 @@ public class DepsGenerator {
         } else if (provider == depInfo) {
           reportSameFile(namespace, depInfo);
         } else {
-          depInfo.isModule();
           boolean providerIsEs6Module = provider.isEs6Module();
 
           switch (require.getType()) {

--- a/src/com/google/javascript/jscomp/deps/SimpleDependencyInfo.java
+++ b/src/com/google/javascript/jscomp/deps/SimpleDependencyInfo.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * A class to hold JS dependency information for a single .js file.
  */
 @Immutable @AutoValue @AutoValue.CopyAnnotations
-public abstract class SimpleDependencyInfo extends DependencyInfo.Base {
+public abstract class SimpleDependencyInfo implements DependencyInfo {
 
   public static Builder builder(String srcPathRelativeToClosure, String pathOfDefiningFile) {
     return new AutoValue_SimpleDependencyInfo.Builder()

--- a/src/com/google/javascript/jscomp/deps/SortedDependencies.java
+++ b/src/com/google/javascript/jscomp/deps/SortedDependencies.java
@@ -207,7 +207,7 @@ public final class SortedDependencies<InputT extends DependencyInfo> {
           || (provides.size() == 1
               && firstProvide.startsWith("module$")
               // ES6 modules should always be considered as exporting something.
-              && !"es6".equals(userOrderedInput.getLoadFlags().get("module")))) {
+              && !userOrderedInput.isEs6Module())) {
         nonExportingInputs.put(
             ModuleNames.fileToModuleName(userOrderedInput.getName()), userOrderedInput);
       }

--- a/test/com/google/javascript/jscomp/LazyParsedDependencyInfoTest.java
+++ b/test/com/google/javascript/jscomp/LazyParsedDependencyInfoTest.java
@@ -67,7 +67,7 @@ public final class LazyParsedDependencyInfoTest {
     // is lifted and we can depend on a newer Truth, these assertions should be
     // changed to assertThat(info.getLoadFlags()).containsExactly(...)
     assertThat(info.getLoadFlags()).containsExactly("foo", "bar");
-    assertThat(info.isModule()).isFalse();
+    assertThat(info.isGoogModule()).isFalse();
   }
 
   @Test
@@ -82,7 +82,7 @@ public final class LazyParsedDependencyInfoTest {
     DependencyInfo info = new LazyParsedDependencyInfo(delegate, ast, compiler);
 
     assertThat(info.getLoadFlags()).containsExactly("module", "goog", "lang", "es5");
-    assertThat(info.isModule()).isTrue();
+    assertThat(info.isGoogModule()).isTrue();
   }
 
   @Test
@@ -97,7 +97,7 @@ public final class LazyParsedDependencyInfoTest {
     DependencyInfo info = new LazyParsedDependencyInfo(delegate, ast, compiler);
 
     assertThat(info.getLoadFlags()).containsExactly("foo", "bar", "lang", "es6");
-    assertThat(info.isModule()).isFalse();
+    assertThat(info.isGoogModule()).isFalse();
   }
 
   @Test
@@ -112,7 +112,7 @@ public final class LazyParsedDependencyInfoTest {
     DependencyInfo info = new LazyParsedDependencyInfo(delegate, ast, compiler);
 
     assertThat(info.getLoadFlags()).containsExactly("foo", "bar", "lang", "es6");
-    assertThat(info.isModule()).isFalse();
+    assertThat(info.isGoogModule()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
This avoids the case where LazyParsedDependencyInfo.getLoadFlags() might parse the entire file to check if a JS file can be bundled as a Closure or ES6 module.

Fixes #4006