### PR TITLE
Bump protobuf-java from 3.19.3 to 3.19.6 to remediate CVE-2022-3171

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -175,7 +175,7 @@ jar_jar_repositories()
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
-        "com.google.protobuf:protobuf-java:3.19.3",
+        "com.google.protobuf:protobuf-java:3.19.6",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",


### PR DESCRIPTION
Fixes https://github.com/google/closure-compiler/issues/4009