### PR TITLE
Don't create ON_FALSE control flow edges for infinite DO loops

### DIFF
--- a/src/com/google/javascript/jscomp/ControlFlowAnalysis.java
+++ b/src/com/google/javascript/jscomp/ControlFlowAnalysis.java
@@ -476,10 +476,11 @@ public final class ControlFlowAnalysis implements NodeTraversal.Callback {
   }
 
   private void handleDo(Node node) {
-    Node cond = node.getFirstChild();
+    Node body = node.getFirstChild();
     // The first edge can be the initial iteration as well as the iterations
     // after.
-    createEdge(node, Branch.ON_TRUE, computeFallThrough(cond));
+    createEdge(node, Branch.ON_TRUE, computeFallThrough(body));
+    Node cond = body.getNext();
     if (!cond.isTrue()) {
       // The edge that leaves the do loop if the condition fails.
       createEdge(node, Branch.ON_FALSE, computeFollowNode(node, this));

--- a/test/com/google/javascript/jscomp/ControlFlowAnalysisTest.java
+++ b/test/com/google/javascript/jscomp/ControlFlowAnalysisTest.java
@@ -337,6 +337,14 @@ public final class ControlFlowAnalysisTest {
   }
 
   @Test
+  public void testInifiteLoopDoWhile() {
+    String src = "var x; do { } while (true); x();";
+    ControlFlowGraph<Node> cfg = createCfg(src);
+    assertDownEdge(cfg, Token.DO, Token.BLOCK, Branch.ON_TRUE);
+    assertNoEdge(cfg, Token.DO, Token.EXPR_RESULT);
+  }
+
+  @Test
   public void testInifiteLoopFor_emptyCond() {
     String src = "var x; for(;;) { } x();";
     ControlFlowGraph<Node> cfg = createCfg(src);


### PR DESCRIPTION
This PR changes the handling of infinite do-while loops in the control flow analysis to match other infinite loops.

Currently, for `FOR` and `WHILE` loops, no `ON_FALSE` edges are created from the loop condition if it is a `true` boolean literal (i.e. infinite loops). This is done by first retrieveing the loop's condition and then checking that it is not a true literal.
For `WHILE` loops, `handleWhile` does:
```java
Node cond = node.getFirstChild();
if (!cond.isTrue()) {
    // Create ON_FALSE branch
}
```
`handleDo` also contains this exact code, but because the first child of a `DO` loop is its body, not its condition, the value of `cond` is actually a statement (the body) and so `cond.isTrue()` is always false and therefore an `ON_FALSE` branch is always created, even if the condition is a `true` literal.

This PR corrects `handleDo`'s behaviour, bringing it in line with the other methods.