### PR TITLE
Fix crash in OptimizeArgumentsArray when getter/setter contains arguments[] reference

### DIFF
--- a/src/com/google/javascript/jscomp/OptimizeArgumentsArray.java
+++ b/src/com/google/javascript/jscomp/OptimizeArgumentsArray.java
@@ -149,6 +149,15 @@ class OptimizeArgumentsArray implements CompilerPass, ScopedCallback {
    * @param scope scope of the function
    */
   private void tryReplaceArguments(Node scopeRoot) {
+    Node scopeRootParent = scopeRoot.getParent();
+    // Nothing to do for getters and setters:
+    // - Getters cannot have any params.
+    // - Setters can only have one param, and it is required to be present, so we cannot synthesize
+    //   any new params.
+    if (scopeRootParent.isGetterDef() || scopeRootParent.isSetterDef()) {
+      return;
+    }
+
     // Find the number of parameters that can be accessed without using `arguments`.
     Node parametersList = NodeUtil.getFunctionParameters(scopeRoot);
     checkState(parametersList.isParamList(), parametersList);

--- a/src/com/google/javascript/jscomp/OptimizeArgumentsArray.java
+++ b/src/com/google/javascript/jscomp/OptimizeArgumentsArray.java
@@ -150,11 +150,8 @@ class OptimizeArgumentsArray implements CompilerPass, ScopedCallback {
    */
   private void tryReplaceArguments(Node scopeRoot) {
     Node scopeRootParent = scopeRoot.getParent();
-    // Nothing to do for getters and setters:
-    // - Getters cannot have any params.
-    // - Setters can only have one param, and it is required to be present, so we cannot synthesize
-    //   any new params.
-    if (scopeRootParent.isGetterDef() || scopeRootParent.isSetterDef()) {
+    // Getters cannot have any params, so there are none to replace or synthesize.
+    if (scopeRootParent.isGetterDef()) {
       return;
     }
 
@@ -170,8 +167,14 @@ class OptimizeArgumentsArray implements CompilerPass, ScopedCallback {
       return;
     }
 
-    ImmutableSortedMap<Integer, String> argNames =
-        assembleParamNames(parametersList, highestIndex + 1);
+    int maxCount = highestIndex + 1;
+    // Setters can only have one param and it is required to be present, so we cannot synthesize any
+    // new params, but we can still replace references to the first param.
+    if (scopeRootParent.isSetterDef()) {
+      maxCount = 1;
+    }
+
+    ImmutableSortedMap<Integer, String> argNames = assembleParamNames(parametersList, maxCount);
     changeMethodSignature(argNames, parametersList);
     changeBody(argNames);
   }

--- a/test/com/google/javascript/jscomp/OptimizeArgumentsArrayTest.java
+++ b/test/com/google/javascript/jscomp/OptimizeArgumentsArrayTest.java
@@ -352,4 +352,18 @@ public final class OptimizeArgumentsArrayTest extends CompilerTestCase {
             "  console.log(arguments);",
             "}"));
   }
+
+  @Test
+  public void testGettersCannotHaveAnyParams() {
+    // Getters cannot have any parameters; synthesizing one would be an error.
+    testSame("class Foo { get prop() { arguments[0] } }");
+    testSame("const a = { get prop() { arguments[0] } }");
+  }
+
+  @Test
+  public void testSettersCanOnlyHaveOneParam() {
+    // Setters can only have one parameter; synthesizing any more would be an error.
+    testSame("class Foo { set prop(x) { arguments[1] } }");
+    testSame("const a = { set prop(x) { arguments[1] } }");
+  }
 }

--- a/test/com/google/javascript/jscomp/OptimizeArgumentsArrayTest.java
+++ b/test/com/google/javascript/jscomp/OptimizeArgumentsArrayTest.java
@@ -355,9 +355,14 @@ public final class OptimizeArgumentsArrayTest extends CompilerTestCase {
 
   @Test
   public void testGettersCannotHaveAnyParams() {
-    // Getters cannot have any parameters; synthesizing one would be an error.
+    // Getters cannot have any parameters; synthesizing them would be an error.
     testSame("class Foo { get prop() { arguments[0] } }");
     testSame("const a = { get prop() { arguments[0] } }");
+
+    // Ensure references in nested functions are still eligible.
+    test(
+        "class Foo { get prop() { function f(  ) { arguments[0] } } }", //
+        "class Foo { get prop() { function f(p0) {           p0 } } }");
   }
 
   @Test
@@ -365,5 +370,15 @@ public final class OptimizeArgumentsArrayTest extends CompilerTestCase {
     // Setters can only have one parameter; synthesizing any more would be an error.
     testSame("class Foo { set prop(x) { arguments[1] } }");
     testSame("const a = { set prop(x) { arguments[1] } }");
+
+    // We can still replace references to the first param.
+    test(
+        "class Foo { set prop(x) { arguments[0]; arguments[1] } }", //
+        "class Foo { set prop(x) {            x; arguments[1] } }");
+
+    // Ensure references in nested functions are still eligible.
+    test(
+        "class Foo { set prop(x) { function f(  ) { arguments[0] } } }", //
+        "class Foo { set prop(x) { function f(p0) {           p0 } } }");
   }
 }


### PR DESCRIPTION
This PR ensures no new parameters are synthesized by OptimizeArgumentsArray for getters/setters, as these new params are illegal and can potentially crash the compiler if the AST is verified ([see this example](https://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540compilation_level%2520SIMPLE_OPTIMIZATIONS%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%2540language_out%2520ES5%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250Aconst%2520a%2520%253D%2520%257B%2520get%2520prop()%2520%257B%2520arguments%255B0%255D%2520%257D%2520%257D%250A%250A)).

Getters must not have any params, while setters are required to have exactly one, so OptimizeArgumentsArray cannot safely add any in either case.

While I'm not sure how common references to the `arguments` array are in getters/setters in the wild (I came across the crash while testing a fork of the compiler), they are valid javascript and this seems like an easy crash to avoid.