### PR TITLE
Externs inner namespaces fix

### DIFF
--- a/src/com/google/javascript/rhino/jstype/JSType.java
+++ b/src/com/google/javascript/rhino/jstype/JSType.java
@@ -210,6 +210,10 @@ public abstract class JSType {
     return false;
   }
 
+  public boolean isFromEmptyObjLitExtern() {
+    return false;
+  }
+
   /** Whether this is the prototype of a function. */
   // TODO(sdh): consider renaming this to isPrototypeObject.
   public boolean isFunctionPrototypeType() {

--- a/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
+++ b/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
@@ -1110,7 +1110,7 @@ public final class JSTypeRegistry {
   // we don't need to store these properties in the propertyIndex separately.
   private static boolean isObjectLiteralThatCanBeSkipped(JSType t) {
     t = t.restrictByNotNullOrUndefined();
-    return t.isRecordType() || t.isLiteralObject();
+    return (t.isRecordType() || t.isLiteralObject()) && !t.isFromEmptyObjLitExtern();
   }
 
   void registerDroppedPropertiesInUnion(RecordType subtype, RecordType supertype) {
@@ -1777,7 +1777,16 @@ public final class JSTypeRegistry {
    * @param info Used to mark object literals as structs; can be {@code null}
    */
   public ObjectType createAnonymousObjectType(@Nullable JSDocInfo info) {
-    PrototypeObjectType type = PrototypeObjectType.builder(this).setAnonymous(true).build();
+	   PrototypeObjectType type = PrototypeObjectType.builder(this).setAnonymous(true).build();
+    type.setPrettyPrint(true);
+    type.setJSDocInfo(info);
+    return type;
+  }
+  public ObjectType createAnonymousObjectType(@Nullable JSDocInfo info, boolean fromExternsEmptyObjLit) {
+	   PrototypeObjectType type = PrototypeObjectType.builder(this)
+	       .setAnonymous(true)
+	       .setFromExternsEmptyObjectLit(fromExternsEmptyObjLit)
+	       .build();
     type.setPrettyPrint(true);
     type.setJSDocInfo(info);
     return type;

--- a/src/com/google/javascript/rhino/jstype/PrototypeObjectType.java
+++ b/src/com/google/javascript/rhino/jstype/PrototypeObjectType.java
@@ -76,6 +76,7 @@ public class PrototypeObjectType extends ObjectType {
   private final PropertyMap properties = new PropertyMap();
   private final boolean nativeType;
   private final boolean anonymousType;
+  private boolean fromEmptyObjLitExtern;
 
   // NOTE(nicksantos): The implicit prototype can change over time.
   // Modeling this is a bear. Always call getImplicitPrototype(), because
@@ -104,6 +105,7 @@ public class PrototypeObjectType extends ObjectType {
     this.templateParamCount = builder.templateParamCount;
     this.nativeType = builder.nativeType;
     this.anonymousType = builder.anonymousType;
+    this.fromEmptyObjLitExtern = builder.externsEmptyObjLit;
 
     this.properties.setParentSource(this);
 
@@ -136,6 +138,7 @@ public class PrototypeObjectType extends ObjectType {
 
     private boolean nativeType;
     private boolean anonymousType;
+    private boolean externsEmptyObjLit;
 
     private TemplateTypeMap templateTypeMap;
     private int templateParamCount;
@@ -163,6 +166,11 @@ public class PrototypeObjectType extends ObjectType {
 
     final T setAnonymous(boolean x) {
       this.anonymousType = x;
+      return castThis();
+    }
+
+    final T setFromExternsEmptyObjectLit(boolean x) {
+      this.externsEmptyObjLit = x;
       return castThis();
     }
 
@@ -494,5 +502,9 @@ public class PrototypeObjectType extends ObjectType {
     } else {
       return System.identityHashCode(this);
     }
+  }
+
+  public boolean isFromEmptyObjLitExtern() {
+	   return fromEmptyObjLitExtern;
   }
 }


### PR DESCRIPTION
**Inner namespace consolidation.** 

📝 The write up: [The Bitter Taste Of Bazel In My Morning Java, Or How I Consolidated Google Namespaces ](https://www.typal.dev/blog-bitter-bazel.html). 

I understand you might not go with the `isFromEmptyObjLitExtern` as in the PR and choose to properly fix `if (isObjectLiteralThatCanBeSkipped(type)` instead, i.e., by maintaining `droppedPropertiesOfUnions` correctly. It's all in the blog post.

Please leave a comment to acknowledge the presence of the bug. I work hard for this. 