### PR TITLE
InlineSimpleMethods @noinline and PropertyRenameFunction

### DIFF
--- a/src/com/google/javascript/jscomp/InlineSimpleMethods.java
+++ b/src/com/google/javascript/jscomp/InlineSimpleMethods.java
@@ -22,6 +22,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.javascript.jscomp.NodeTraversal.AbstractPostOrderCallback;
 import com.google.javascript.rhino.IR;
+import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.Node;
 import java.util.HashSet;
 import java.util.Set;
@@ -105,6 +106,11 @@ class InlineSimpleMethods implements CompilerPass {
 
       Set<Node> definitions = methodDefinitions.get(callName);
       if (definitions == null || definitions.isEmpty()) {
+        return;
+      }
+
+      // Exit early if any definitions are annotated with @noinline
+      if (anyDefinitionsNoInline(definitions)) {
         return;
       }
 
@@ -216,6 +222,17 @@ class InlineSimpleMethods implements CompilerPass {
       } // else continue
     }
     return true;
+  }
+
+  private boolean anyDefinitionsNoInline(Set<Node> definitions) {
+    for (Node n : definitions) {
+      JSDocInfo jsDocInfo = n.getParent().getJSDocInfo();
+      System.out.println(n.toString());
+      if (jsDocInfo != null && jsDocInfo.isNoInline()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/com/google/javascript/jscomp/InlineSimpleMethods.java
+++ b/src/com/google/javascript/jscomp/InlineSimpleMethods.java
@@ -365,6 +365,14 @@ class InlineSimpleMethods implements CompilerPass {
             }
           }
           break;
+        case CALL:
+          // If a goog.reflect.objectProperty is used for a method's name, we can't assume that the method can be safely inlined.
+          if (compiler.getCodingConvention().isPropertyRenameFunction(n.getFirstChild())) {
+
+            // Other code guarantees that getSecondChild() is a STRINGLIT
+            nonMethodProperties.add(n.getSecondChild().getString());
+          }
+          break;
         default:
           break;
       }

--- a/test/com/google/javascript/jscomp/InlineSimpleMethodsTest.java
+++ b/test/com/google/javascript/jscomp/InlineSimpleMethodsTest.java
@@ -529,4 +529,16 @@ public final class InlineSimpleMethodsTest extends CompilerTestCase {
         "var x=new Foo;x.bar()",
         "var x=new Foo;x.bar()");
   }
+
+  @Test
+  public void testReflectObjectProperty() {
+    testWithPrefix(
+      lines(
+        "class Foo {",
+        " bar() { return 'hi'; }",
+        "}",
+        "const c = goog.reflect.objectProperty('bar', Foo.prototype);"),
+        "var x=new Foo;x.bar()",
+        "var x=new Foo;x.bar()");
+  }
 }

--- a/test/com/google/javascript/jscomp/InlineSimpleMethodsTest.java
+++ b/test/com/google/javascript/jscomp/InlineSimpleMethodsTest.java
@@ -518,4 +518,15 @@ public final class InlineSimpleMethodsTest extends CompilerTestCase {
             "}",
             "Foo.a;"));
   }
+
+  @Test
+  public void testNoInline() {
+    testWithPrefix(
+      lines(
+        "class Foo {",
+        " /** @noinline */ bar() { return 'hi'; }",
+        "}"),
+        "var x=new Foo;x.bar()",
+        "var x=new Foo;x.bar()");
+  }
 }


### PR DESCRIPTION
#3967 made it so methods that are used in reflection were not devirtualized, but that didn't prevent them from being inlined by InlineSimpleMethods.  This could lead to broken code if a decorator (using `goog.reflect.objectProperty`) tried to modify a method that was being inlined.  It would still modify the method, but all uses of the method would be replaced by the original source inline body, sans the decorator's modifications.