### PR TITLE
Fix wicg_scheduler.js externs

### DIFF
--- a/externs/browser/wicg_scheduler.js
+++ b/externs/browser/wicg_scheduler.js
@@ -50,10 +50,10 @@ function Scheduler() {}
 
 /**
  * @param {!SchedulerPostTaskCallback} callback
- * @param {!SchedulerPostTaskOptions=} options
+ * @param {!SchedulerPostTaskOptions=} opt_options
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/postTask
  */
-Scheduler.prototype.postTask = function(callback, options = {}) {};
+Scheduler.prototype.postTask = function(callback, opt_options) {};
 
 /** @type {!Scheduler} */
 Window.prototype.scheduler;


### PR DESCRIPTION
Due to commit 876761b33479c1cade1e37e648d6afc4693d9ba6 I'm no longer able to compile my project using `--language_in ECMASCRIPT5_STRICT` because compilation fails with `externs.zip//wicg_scheduler.js:56:50: ERROR - [JSC_LANGUAGE_FEATURE] This language feature is only supported for ECMASCRIPT_2015 mode or better: default parameter.` error.