### PR TITLE
Move standard properties out of gecko, deprecate obsolete

### DIFF
--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -30,13 +30,6 @@
 // Gecko DOM;
 
 /**
- * Mozilla only???
- * @constructor
- * @extends {HTMLElement}
- */
-function HTMLSpanElement() {}
-
-/**
  * @see https://developer.mozilla.org/en/Components_object
  */
 Window.prototype.Components;
@@ -69,13 +62,17 @@ Window.prototype.directories;
 /**
  * @type {boolean}
  * @see https://developer.mozilla.org/en/DOM/window.fullScreen
+ * @deprecated
  */
 Window.prototype.fullScreen;
 
 /** @see https://developer.mozilla.org/en/DOM/window.pkcs11 */
 Window.prototype.pkcs11;
 
-/** @see https://developer.mozilla.org/en/DOM/window */
+/**
+ * @see https://developer.mozilla.org/en/DOM/window
+ * @deprecated
+ */
 Window.prototype.returnValue;
 
 /**
@@ -96,6 +93,7 @@ Window.prototype.sidebar;
 /**
  * @see https://developer.mozilla.org/en/DOM/window.back
  * @return {undefined}
+ * @deprecated
  */
 Window.prototype.back = function() {};
 
@@ -108,22 +106,27 @@ Window.prototype.find;
 /**
  * @see https://developer.mozilla.org/en/DOM/window.forward
  * @return {undefined}
+ * @deprecated
  */
 Window.prototype.forward = function() {};
 
 /**
  * @see https://developer.mozilla.org/en/DOM/window.getAttention
  * @return {undefined}
+ * @depreccated
  */
 Window.prototype.getAttention = function() {};
 
 /**
  * @see https://developer.mozilla.org/en/DOM/window.home
  * @return {undefined}
+ * @deprecated
  */
 Window.prototype.home = function() {};
 
+/** @deprecated */
 Window.prototype.openDialog;
+/** @deprecated */
 Window.prototype.releaseEvents;
 Window.prototype.scrollByLines;
 Window.prototype.scrollByPages;
@@ -133,6 +136,7 @@ Window.prototype.scrollByPages;
  * @param {?=} opt_arguments
  * @param {string=} opt_options
  * @see https://developer.mozilla.org/en/DOM/window.showModalDialog
+ * @deprecated
  */
 Window.prototype.showModalDialog;
 
@@ -145,18 +149,21 @@ Window.prototype.updateCommands;
 /**
  * @see https://developer.mozilla.org/en/DOM/document.alinkColor
  * @type {string}
+ * @deprecated
  */
 Document.prototype.alinkColor;
 
 /**
  * @see https://developer.mozilla.org/en/DOM/document.anchors
  * @type {HTMLCollection<!HTMLAnchorElement>}
+ * @deprecated
  */
 Document.prototype.anchors;
 
 /**
  * @see https://developer.mozilla.org/en/DOM/document.applets
  * @type {HTMLCollection<!HTMLAppletElement>}
+ * @deprecated
  */
 Document.prototype.applets;
 /** @type {?string} */ Document.prototype.baseURI;
@@ -164,38 +171,17 @@ Document.prototype.applets;
 /**
  * @see https://developer.mozilla.org/en/DOM/document.bgColor
  * @type {string}
+ * @deprecated
  */
 Document.prototype.bgColor;
 
-/** @type {HTMLBodyElement} */ Document.prototype.body;
-Document.prototype.characterSet;
-
-/**
- * @see https://developer.mozilla.org/en/DOM/document.compatMode
- * @type {string}
- */
-Document.prototype.compatMode;
-
-Document.prototype.contentType;
-/** @type {string} */ Document.prototype.cookie;
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView
- * @type {?Window}
- */
-Document.prototype.defaultView;
-
-/**
- * @see https://developer.mozilla.org/en/DOM/document.designMode
- * @type {string}
- */
-Document.prototype.designMode;
-
+/** @deprecated */
 Document.prototype.documentURIObject;
 
 /**
  * @see https://developer.mozilla.org/en/DOM/document.domain
  * @type {string}
+ * @deprecated
  */
 Document.prototype.domain;
 
@@ -231,6 +217,7 @@ Document.prototype.lastModified;
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/DOM/document.linkColor
+ * @deprecated
  */
 Document.prototype.linkColor;
 
@@ -270,6 +257,7 @@ Document.prototype.tooltipNode;
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/DOM/document.vlinkColor
+ * @deprecated
  */
 Document.prototype.vlinkColor;
 
@@ -279,6 +267,7 @@ Document.prototype.vlinkColor;
 /**
  * @see https://developer.mozilla.org/en/DOM/document.clear
  * @return {undefined}
+ * @deprecated
  */
 Document.prototype.clear = function() {};
 
@@ -298,26 +287,31 @@ Document.prototype.evaluate;
  * @param {?boolean=} opt_showUi
  * @param {*=} opt_value
  * @see https://developer.mozilla.org/en/Rich-Text_Editing_in_Mozilla#Executing_Commands
+ * @deprecated
  */
 Document.prototype.execCommand;
 
+/** @deprecated */
 Document.prototype.loadOverlay;
 
 /**
  * @see https://developer.mozilla.org/en/Midas
  * @see http://msdn.microsoft.com/en-us/library/ms536676(VS.85).aspx
+ * @deprecated
  */
 Document.prototype.queryCommandEnabled;
 
 /**
  * @see https://developer.mozilla.org/en/Midas
  * @see http://msdn.microsoft.com/en-us/library/ms536678(VS.85).aspx
+ * @deprecated
  */
 Document.prototype.queryCommandIndeterm;
 
 /**
  * @see https://developer.mozilla.org/en/Midas
  * @see http://msdn.microsoft.com/en-us/library/ms536679(VS.85).aspx
+ * @deprecated
  */
 Document.prototype.queryCommandState;
 
@@ -326,16 +320,21 @@ Document.prototype.queryCommandState;
  * @see http://msdn.microsoft.com/en-us/library/ms536681(VS.85).aspx
  * @param {string} command
  * @return {?} Implementation-specific.
+ * @deprecated
  */
 Document.prototype.queryCommandSupported;
 
 /**
  * @see https://developer.mozilla.org/en/Midas
  * @see http://msdn.microsoft.com/en-us/library/ms536683(VS.85).aspx
+ * @deprecated
  */
 Document.prototype.queryCommandValue;
 
+// online and offline handlers belong to window, not document
+/** @deprecated */
 Document.prototype.ononline;
+/** @deprecated */
 Document.prototype.onoffline;
 
 // XUL
@@ -343,6 +342,7 @@ Document.prototype.onoffline;
  * @see http://developer.mozilla.org/en/DOM/document.getBoxObjectFor
  * @return {BoxObject}
  * @nosideeffects
+ * @deprecated
  */
 Document.prototype.getBoxObjectFor = function(element) {};
 
@@ -350,38 +350,10 @@ Document.prototype.getBoxObjectFor = function(element) {};
 // http://lxr.mozilla.org/mozilla1.8/source/dom/public/idl/range/nsIDOMNSRange.idl
 
 /**
- * @param {!TrustedHTML|string} tag
- * @return {DocumentFragment}
- */
-Range.prototype.createContextualFragment;
-
-/**
- * @param {Node} parent
- * @param {number} offset
- * @return {boolean}
- * @nosideeffects
- */
-Range.prototype.isPointInRange;
-
-/**
- * @param {Node} parent
- * @param {number} offset
- * @return {number}
- * @nosideeffects
- */
-Range.prototype.comparePoint;
-
-/**
- * @param {Node} n
- * @return {boolean}
- * @nosideeffects
- */
-Range.prototype.intersectsNode;
-
-/**
  * @param {Node} n
  * @return {number}
  * @nosideeffects
+ * @deprecated
  */
 Range.prototype.compareNode;
 
@@ -418,32 +390,6 @@ Element.prototype.style;
 /** @return {undefined} */
 Element.prototype.click = function() {};
 
-/** @type {number} */
-HTMLTextAreaElement.prototype.selectionStart;
-
-/** @type {number} */
-HTMLTextAreaElement.prototype.selectionEnd;
-
-/**
- * @param {number} selectionStart
- * @param {number} selectionEnd
- * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#dom-textarea/input-setselectionrange
- * @return {undefined}
- */
-HTMLTextAreaElement.prototype.setSelectionRange =
-    function(selectionStart, selectionEnd) {};
-
-/**
- * @param {string} replacement
- * @param {number=} start
- * @param {number=} end
- * @param {string=} selectionMode
- * @see https://html.spec.whatwg.org/#dom-textarea/input-setrangetext
- * @return {undefined}
- */
-HTMLTextAreaElement.prototype.setRangeText =
-    function(replacement, start, end, selectionMode) {};
-
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/Navigator.buildID
@@ -451,26 +397,23 @@ HTMLTextAreaElement.prototype.setRangeText =
 Navigator.prototype.buildID;
 
 /**
- * @type {!Array<string>|undefined}
- * @see https://developer.mozilla.org/en/Navigator.languages
- */
-Navigator.prototype.languages;
-
-/**
  * @type {string}
  * @see https://developer.mozilla.org/en/Navigator.oscpu
+ * @deprecated
  */
 Navigator.prototype.oscpu;
 
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/Navigator.productSub
+ * @deprecated
  */
 Navigator.prototype.productSub;
 
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/Navigator.securityPolicy
+ * @deprecated
  */
 Navigator.prototype.securityPolicy;
 
@@ -485,17 +428,22 @@ Navigator.prototype.sendBeacon = function(url, opt_data) {};
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/Navigator.vendor
+ * @deprecated
  */
 Navigator.prototype.vendor;
 
 /**
  * @type {string}
  * @see https://developer.mozilla.org/en/Navigator.vendorSub
+ * @deprecated
  */
 Navigator.prototype.vendorSub;
 
 
-/** @constructor */
+/**
+ * @constructor
+ * @deprecated
+ */
 function BoxObject() {}
 
 /** @type {Element} */

--- a/externs/browser/gecko_dom.js
+++ b/externs/browser/gecko_dom.js
@@ -175,6 +175,9 @@ Document.prototype.applets;
  */
 Document.prototype.bgColor;
 
+/** @type {HTMLBodyElement} */ Document.prototype.body;
+/** @type {string} */ Document.prototype.cookie;
+
 /** @deprecated */
 Document.prototype.documentURIObject;
 
@@ -227,15 +230,11 @@ Document.prototype.linkColor;
  */
 Document.prototype.links;
 
-/**
- * @type {!Location}
- * @implicitCast
- */
-Document.prototype.location;
-
+/** @deprecated */
 Document.prototype.namespaceURI;
+/** @deprecated */
 Document.prototype.nodePrincipal;
-Document.prototype.plugins;
+/** @deprecated */
 Document.prototype.popupNode;
 
 /**
@@ -377,6 +376,7 @@ Element.prototype.firebugIgnore;
  */
 Element.prototype.name;
 
+/** @deprecated */
 Element.prototype.nodePrincipal;
 
 /**

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -4394,6 +4394,12 @@ HTMLSelectElement.prototype.reportValidity = function() {};
  */
 HTMLSelectElement.prototype.setCustomValidity = function(message) {};
 
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLSpanElement() {}
+
 /** @type {boolean} */
 HTMLTextAreaElement.prototype.autofocus;
 
@@ -4412,6 +4418,12 @@ HTMLTextAreaElement.prototype.minLength;
 
 /** @type {string} */
 HTMLTextAreaElement.prototype.placeholder;
+
+/** @type {number} */
+HTMLTextAreaElement.prototype.selectionStart;
+
+/** @type {number} */
+HTMLTextAreaElement.prototype.selectionEnd;
 
 /** @type {number} */
 HTMLTextAreaElement.prototype.textLength;
@@ -4438,6 +4450,28 @@ HTMLTextAreaElement.prototype.reportValidity = function() {};
  * @return {undefined}
  */
 HTMLTextAreaElement.prototype.setCustomValidity = function(message) {};
+
+/**
+ * @param {number} selectionStart
+ * @param {number} selectionEnd
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#dom-textarea/input-setselectionrange
+ * @return {undefined}
+ */
+HTMLTextAreaElement.prototype.setSelectionRange =
+    function(selectionStart, selectionEnd) {};
+
+/**
+ * @param {string} replacement
+ * @param {number=} start
+ * @param {number=} end
+ * @param {string=} selectionMode
+ * @see https://html.spec.whatwg.org/#dom-textarea/input-setrangetext
+ * @return {undefined}
+ */
+HTMLTextAreaElement.prototype.setRangeText =
+    function(replacement, start, end, selectionMode) {};
+
+
 
 /**
  * @constructor
@@ -4488,6 +4522,36 @@ FullscreenOptions.prototype.navigationUI;
  * @return {!Promise<undefined>}
  */
 Element.prototype.requestFullscreen = function(options) {};
+
+/**
+ * @type {string}
+ * @see https://dom.spec.whatwg.org/#dom-document-characterset
+ */
+Document.prototype.characterSet;
+
+/**
+ * @type {string}
+ * @see https://dom.spec.whatwg.org/#dom-document-contenttype
+ */
+Document.prototype.contentType;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.compatMode
+ * @type {string}
+ */
+Document.prototype.compatMode;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView
+ * @type {?Window}
+ */
+Document.prototype.defaultView;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.designMode
+ * @type {string}
+ */
+Document.prototype.designMode;
 
 /**
  * @type {boolean}
@@ -5496,6 +5560,12 @@ Navigator.prototype.taintEnabled = function() {};
  * @see https://www.w3.org/TR/html5/webappapis.html#dom-navigator-language
  */
 Navigator.prototype.language;
+
+/**
+ * @type {!Array<string>|undefined}
+ * @see https://developer.mozilla.org/en/Navigator.languages
+ */
+Navigator.prototype.languages;
 
 /**
  * @type {boolean}

--- a/externs/browser/html5.js
+++ b/externs/browser/html5.js
@@ -4765,6 +4765,18 @@ Document.prototype.webkitHidden;
 Document.prototype.msHidden;
 
 /**
+ * @type {!Location}
+ * @implicitCast
+ */
+Document.prototype.location;
+
+/**
+ * @type {HTMLCollection<!HTMLEmbedElement>}
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/plugins
+ */
+Document.prototype.plugins;
+
+/**
  * @see http://www.w3.org/TR/components-intro/
  * @see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register
  * @param {string} type

--- a/externs/browser/w3c_range.js
+++ b/externs/browser/w3c_range.js
@@ -232,10 +232,40 @@ Range.prototype.surroundContents = function(newParent) {};
 Range.prototype.cloneRange = function() {};
 
 /**
+ * @param {Node} parent
+ * @param {number} offset
+ * @return {number}
+ * @nosideeffects
+ */
+Range.prototype.comparePoint;
+
+/**
  * @return {undefined}
  * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-detach
  */
 Range.prototype.detach = function() {};
+
+/**
+ * @param {!TrustedHTML|string} tag
+ * @return {DocumentFragment}
+ */
+Range.prototype.createContextualFragment;
+
+/**
+ * @param {Node} n
+ * @return {boolean}
+ * @nosideeffects
+ */
+Range.prototype.intersectsNode;
+
+/**
+ * @param {Node} parent
+ * @param {number} offset
+ * @return {boolean}
+ * @nosideeffects
+ */
+Range.prototype.isPointInRange;
+
 
 // Introduced in DOM Level 2:
 /**


### PR DESCRIPTION
As indicated in https://github.com/google/closure-compiler/issues/2478 there are many standardized APIs in `gecko` specific extern.  This PR moves some of them to more suitable places and marks others as deprecated.