### PR TITLE
Add '--fail_on_warnings', issue #3451

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -462,6 +462,12 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 + " --parse_inline_source_maps.")
     private boolean applyInputSourceMaps = true;
 
+    @Option(
+        name = "--fail_on_warnings",
+        handler = BooleanOptionHandler.class,
+        usage = "Elevate all compiler warnings to errors")
+    private boolean failOnWarnings = false;
+
     // Used to define the flag, values are stored by the handler.
     @SuppressWarnings("unused")
     @Option(
@@ -1981,6 +1987,8 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       options.messageBundle = new EmptyMessageBundle();
       options.setWarningLevel(DiagnosticGroups.MSG_CONVENTIONS, CheckLevel.OFF);
     }
+
+    options.setFailOnWarnings(flags.failOnWarnings);
 
     options.setConformanceConfigs(loadConformanceConfigs(flags.conformanceConfigs));
 

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -3254,6 +3254,9 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       }
     }
 
+    if (level == CheckLevel.WARNING && options.shouldFailOnWarnings())
+      level = CheckLevel.ERROR;
+
     if (level.isOn()) {
       initCompilerOptionsIfTesting();
       if (getOptions().errorHandler != null) {

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -121,6 +121,9 @@ public class CompilerOptions implements Serializable {
   /** Should the compiled output start with "'use strict';"? */
   private Optional<Boolean> emitUseStrict = Optional.absent();
 
+  /** ... */
+  private boolean failOnWarnings = false;
+
   /** The JavaScript language version accepted. */
   private LanguageMode languageIn;
 
@@ -1456,6 +1459,14 @@ public class CompilerOptions implements Serializable {
   /** Whether the warnings guard in this Options object disables the given group of warnings. */
   boolean disables(DiagnosticGroup group) {
     return this.warningsGuard.mustRunChecks(group) == Tri.FALSE;
+  }
+
+  public boolean shouldFailOnWarnings() {
+    return failOnWarnings;
+  }
+
+  public void setFailOnWarnings(boolean failOnWarnings) {
+    this.failOnWarnings = failOnWarnings;
   }
 
   /** Configure the given type of warning to the given level. */
@@ -2811,6 +2822,7 @@ public class CompilerOptions implements Serializable {
         .add("externExportsPath", externExportsPath)
         .add("extraAnnotationNames", extraAnnotationNames)
         .add("extractPrototypeMemberDeclarations", extractPrototypeMemberDeclarations)
+        .add("failOnWarnings", failOnWarnings)
         .add("filesToPrintAfterEachPassRegexList", filesToPrintAfterEachPassRegexList)
         .add("flowSensitiveInlineVariables", flowSensitiveInlineVariables)
         .add("foldConstants", foldConstants)


### PR DESCRIPTION
This PR adds option `--fail_on_warnings` as requested in #3451 (and that I missed myself too). It is obviously not finished, but before adding documentations, tests, etc. I'd like to see some feedback if this option is fine in general.

Instead of meddling with existing warning guards as suggested by brad4d in the issue, I decided to keep a simple boolean flag and at the last possible point check it: if we still have a warning level by then, simply turn it into an error. I feel it is cleaner this way (and also easier, yeah), because configuration of warning guards (which is quite extensive, with all the different named categories) is completely independ from "fail on warnings" setting and you don't need to coordinate changes in them anywhere. In effect, the "fail on warnings" setting is simple "whatever I want as warnings usually, should become an error in this context" and is not dependent on how you set that "whatever" — be that the defaults or extensive custom configuration.

A possible improvement would be to pass to error reporter a boolean "error elevated from warning" so that it could report that if it so chooses.

I verified that it does produce the desired change:

    $ java -jar bazel-bin/compiler_uberjar_deploy.jar ~/test/test.js --checks_only --warning_level verbose || echo DOES NOT COMPILE
    /home/paul/test/test.js:3:0: WARNING - [JSC_TYPE_MISMATCH] assignment
    found   : string
    required: number
      3| a = 'foo'
         ^^^^^^^^^

    0 error(s), 1 warning(s), 100.0% typed
    $ java -jar bazel-bin/compiler_uberjar_deploy.jar ~/test/test.js --checks_only --warning_level verbose --fail_on_warnings || echo DOES NOT COMPILE
    /home/paul/test/test.js:3:0: ERROR - [JSC_TYPE_MISMATCH] assignment
    found   : string
    required: number
      3| a = 'foo'
         ^^^^^^^^^

    1 error(s), 0 warning(s), 100.0% typed
    DOES NOT COMPILE

Where `~/test/test.js` is:

    /** @type {number} */
    let a = 10;
    a = 'foo'
