### PR TITLE
Add missing AbortSignal static methods

### DIFF
--- a/externs/browser/w3c_abort.js
+++ b/externs/browser/w3c_abort.js
@@ -29,6 +29,27 @@
  */
 function AbortSignal() {}
 
+/**
+ * @param {*=} reason
+ * @return {!AbortSignal}
+ * @see https://dom.spec.whatwg.org/#dom-abortsignal-abort
+ */
+AbortSignal.abort = function(reason) {};
+
+/**
+ * @param {number} miliseconds
+ * @return {!AbortSignal}
+ * @see https://dom.spec.whatwg.org/#dom-abortsignal-timeout
+ */
+AbortSignal.timeout = function(miliseconds) {};
+
+/**
+ * @param {!Iterable} signals
+ * @return {!AbortSignal}
+ * @see https://dom.spec.whatwg.org/#dom-abortsignal-any
+ */
+AbortSignal.any = function(signals) {};
+
 /** @type {boolean} */
 AbortSignal.prototype.aborted;
 


### PR DESCRIPTION
In browser externs added 3 missing static methods to AbortSignal type - defined in w3c_abort.js file. Missing statics are any(), timeout() and abort().

At this point the last 2 of those methods are living standard, any() still lacks support in Firefox and Safari, but it's practical and can be used care-free in the realm of Chromium-based browser extensions so I imagine it won't just disappear overnight.

Anyway I use those methods, can't drag my own build of the compiler to every project and I hate suppressing warnings, so here it is.