### PR TITLE
Specify type of digits in Number.toFixed

### DIFF
--- a/externs/es3.js
+++ b/externs/es3.js
@@ -1172,7 +1172,7 @@ Number.prototype.toExponential = function(opt_fractionDigits) {};
 
 /**
  * @this {Number|number}
- * @param {*=} opt_digits
+ * @param {number=} opt_digits
  * @return {string}
  * @nosideeffects
  * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed


### PR DESCRIPTION
According to [the docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) this argument has to be a number. Using the more specific type is needed for https://github.com/google/elemental2/issues/129