### PR TITLE
Add variable and input map command line arguments.

### DIFF
--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -965,6 +965,18 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 + "stub functions in a parent chunk.")
     private boolean assumeNoPrototypeMethodEnumeration = false;
 
+    @Option(
+        name = "--variable_map_input_file",
+        usage = "File containing the serialized version of the variable "
+        + "renaming map produced by a previous compilation")
+    private String variableMapInputFile = "";
+
+    @Option(
+        name = "--property_map_input_file",
+        usage = "File containing the serialized version of the property "
+        + "renaming map produced by a previous compilation")
+    private String propertyMapInputFile = "";
+ 
     @Argument private List<String> arguments = new ArrayList<>();
     private final CmdLineParser parser;
 
@@ -1760,6 +1772,8 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
           .setVariableMapOutputFile(flags.variableMapOutputFile)
           .setCreateNameMapFiles(flags.createNameMapFiles)
           .setPropertyMapOutputFile(flags.propertyMapOutputFile)
+          .setPropertyMapInputFile(flags.propertyMapInputFile)
+          .setVariableMapInputFile(flags.variableMapInputFile)
           .setInstrumentationMappingFile(flags.instrumentationMappingOutputFile)
           .setCodingConvention(conv)
           .setSummaryDetailLevel(flags.summaryDetailLevel)


### PR DESCRIPTION
The change re-enables existing functionality which has been previously disabled as part of change  e17ddd9271874add9608c71dd9d257a5f6e6c085.

The reason to re-enable it at this time is to enable minimal binary compression diff between to build versions.
Without using input maps, 2 compilation builds, even when have small changes between them may result with completely different minified file due to renames which occur at different order and pick different rename value. When using input rename maps the resulting minified code remains very similar to minified code from earlier build version.

This is important for adopting Compression Dictionary Transport which greatly benefit from small compressed dictionary diffs.

The change addresses the ask in #4097