### PR TITLE
Typedefs with templates

### DIFF
--- a/src/com/google/javascript/jscomp/CheckJSDoc.java
+++ b/src/com/google/javascript/jscomp/CheckJSDoc.java
@@ -254,6 +254,7 @@ final class CheckJSDoc extends AbstractPostOrderCallback implements CompilerPass
         && !info.getTemplateTypeNames().isEmpty()
         && !info.isConstructorOrInterface()
         && !isClassDecl(n)
+        && info.getTypedefType() == null
         && !info.containsFunctionDeclaration()
         && getFunctionDecl(n) == null) {
       reportMisplaced(

--- a/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
+++ b/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
@@ -256,8 +256,6 @@ final class FunctionTypeBuilder {
     this.typeRegistry = compiler.getTypeRegistry();
     this.errorRoot = errorRoot;
     this.compiler = compiler;
-
-    this.typeBuilder = new TypeBuilder(scope, typeRegistry, (Compiler) compiler, errorRoot);
   }
 
   /** Format the function name for use in warnings. */

--- a/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
+++ b/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
@@ -255,7 +255,8 @@ final class FunctionTypeBuilder {
     this.typeRegistry = compiler.getTypeRegistry();
     this.errorRoot = errorRoot;
     this.compiler = compiler;
-    this.templateScope = scope;
+
+    this.typeBuilder = new TypeBuilder(scope, typeRegistry, (Compiler) compiler, errorRoot);
   }
 
   /** Format the function name for use in warnings. */

--- a/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
+++ b/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
@@ -256,6 +256,7 @@ final class FunctionTypeBuilder {
     this.typeRegistry = compiler.getTypeRegistry();
     this.errorRoot = errorRoot;
     this.compiler = compiler;
+    this.templateScope = scope;
   }
 
   /** Format the function name for use in warnings. */

--- a/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
+++ b/src/com/google/javascript/jscomp/FunctionTypeBuilder.java
@@ -45,6 +45,7 @@ import com.google.javascript.rhino.jstype.FunctionType.Parameter;
 import com.google.javascript.rhino.jstype.JSType;
 import com.google.javascript.rhino.jstype.JSTypeRegistry;
 import com.google.javascript.rhino.jstype.ObjectType;
+import com.google.javascript.rhino.jstype.RecordType;
 import com.google.javascript.rhino.jstype.StaticTypedScope;
 import com.google.javascript.rhino.jstype.TemplateType;
 import java.util.ArrayList;
@@ -1029,7 +1030,9 @@ final class FunctionTypeBuilder {
     }
 
     fnType.setPrototypeBasedOn(baseType);
-    fnType.getInstanceType().mergeSupertypeTemplateTypes(baseType);
+    if(!(baseType instanceof RecordType)) { // inherited record types have been bound to our templates when creating their type in @extends
+      fnType.getInstanceType().mergeSupertypeTemplateTypes(baseType);
+    }
   }
 
   private FunctionType.Builder createDefaultBuilder() {

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -2377,7 +2377,7 @@ class TypeInference extends DataFlowAnalysis<Node, FlowScope> {
           var map = registry.getEmptyTemplateTypeMap().copyWithExtension(inferredTypes);
           instantiatedType = (ObjectType) registry.bindTemplatesWithMap(instantiatedType, map);
         }
-      }else {
+      } else {
         // If necessary, templatized the instance type based on the the constructor parameters.
         instantiatedType =
             registry.createTemplatizedType(instantiatedType, inferredTypes).toMaybeObjectType();

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -67,7 +67,6 @@ import com.google.javascript.rhino.jstype.TemplateTypeReplacer;
 import com.google.javascript.rhino.jstype.UnionType;
 import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -2372,7 +2372,6 @@ class TypeInference extends DataFlowAnalysis<Node, FlowScope> {
       if (instantiatedType.isTemplatizedType()) {
         instantiatedType = instantiatedType.toMaybeTemplatizedType().getRawType();
       }
-      // TODO: in function(new:C<string>), the "<string>" might get cleared despite being bound already.
       // If necessary, templatized the instance type based on the the constructor parameters.
       ImmutableMap<TemplateType, JSType> inferredTypes =
           new InvocationTemplateTypeMatcher(this.registry, ctorFnType, scope.getTypeOfThis(), n)

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -2372,6 +2372,7 @@ class TypeInference extends DataFlowAnalysis<Node, FlowScope> {
       if (instantiatedType.isTemplatizedType()) {
         instantiatedType = instantiatedType.toMaybeTemplatizedType().getRawType();
       }
+      // TODO: in function(new:C<string>), the "<string>" might get cleared despite being bound already.
       // If necessary, templatized the instance type based on the the constructor parameters.
       ImmutableMap<TemplateType, JSType> inferredTypes =
           new InvocationTemplateTypeMatcher(this.registry, ctorFnType, scope.getTypeOfThis(), n)

--- a/src/com/google/javascript/jscomp/TypeInference.java
+++ b/src/com/google/javascript/jscomp/TypeInference.java
@@ -2643,7 +2643,7 @@ class TypeInference extends DataFlowAnalysis<Node, FlowScope> {
     }
 
     if (propertyType == null && objType != null) {
-      JSType foundType = objType.findPropertyType(propName);
+      JSType foundType = objType.findPropertyType(propName, true);
       if (foundType != null) {
         propertyType = foundType;
       }

--- a/src/com/google/javascript/jscomp/TypedScopeCreator.java
+++ b/src/com/google/javascript/jscomp/TypedScopeCreator.java
@@ -3073,14 +3073,13 @@ final class TypedScopeCreator implements ScopeCreator, StaticSymbolTable<TypedVa
     /** Declares a typedef'd name in the {@link JSTypeRegistry}. */
     void declareTypedefType(Node candidate, JSDocInfo info) {
       String typedef = candidate.getQualifiedName();
-      StaticTypedScope templateScope=null;
+      StaticTypedScope templateScope = null;
 
       ImmutableMap<String, JSTypeExpression> infoTypeKeys = info.getTemplateTypes();
 
       LinkedHashMap<String, TemplateType> typedefTemplateTypes = null;
 
-      if(infoTypeKeys.size()>0) {
-        // what about bound templates (eg. see FunctionTypeBuilder.buildTemplateTypesFromJSDocInfo)
+      if(!infoTypeKeys.isEmpty()) {
         typedefTemplateTypes = new LinkedHashMap<String, TemplateType>();
         for (String templateKey : infoTypeKeys.keySet()) {
           var type=typeRegistry.createTemplateType(templateKey);

--- a/src/com/google/javascript/jscomp/TypedScopeCreator.java
+++ b/src/com/google/javascript/jscomp/TypedScopeCreator.java
@@ -3077,11 +3077,11 @@ final class TypedScopeCreator implements ScopeCreator, StaticSymbolTable<TypedVa
 
       ImmutableMap<String, JSTypeExpression> infoTypeKeys = info.getTemplateTypes();
 
-      HashMap<String, TemplateType> typedefTemplateTypes=null;
-      
+      LinkedHashMap<String, TemplateType> typedefTemplateTypes = null;
+
       if(infoTypeKeys.size()>0) {
         // what about bound templates (eg. see FunctionTypeBuilder.buildTemplateTypesFromJSDocInfo)
-        typedefTemplateTypes = new HashMap<String, TemplateType>();
+        typedefTemplateTypes = new LinkedHashMap<String, TemplateType>();
         for (String templateKey : infoTypeKeys.keySet()) {
           var type=typeRegistry.createTemplateType(templateKey);
           typedefTemplateTypes.put(templateKey,type);

--- a/src/com/google/javascript/jscomp/TypedScopeCreator.java
+++ b/src/com/google/javascript/jscomp/TypedScopeCreator.java
@@ -3098,7 +3098,7 @@ final class TypedScopeCreator implements ScopeCreator, StaticSymbolTable<TypedVa
         report(JSError.make(candidate, MALFORMED_TYPEDEF, typedef));
       } else {
         if(templates!=null) {
-          typeRegistry.registerTypedefedTemplates(templates,realType);
+          typeRegistry.registerTypedefTemplateKeysForType(templates,realType);
         }
         candidate.setTypedefTypeProp(realType);
       }

--- a/src/com/google/javascript/rhino/JSDocInfo.java
+++ b/src/com/google/javascript/rhino/JSDocInfo.java
@@ -1883,8 +1883,7 @@ public class JSDocInfo implements Serializable {
         bound = JSTypeExpression.IMPLICIT_TEMPLATE_BOUND;
       }
       Map<String, Node> transformations = getProp(TYPE_TRANSFORMATIONS);
-      if ((transformations != null && transformations.containsKey(name))
-          || props.containsKey(TYPEDEF_TYPE)) {
+      if ((transformations != null && transformations.containsKey(name))) {
         return false;
       }
       return populatePropEntry(TEMPLATE_TYPE_NAMES, RhinoStringPool.addOrGet(name), bound);

--- a/src/com/google/javascript/rhino/JSTypeExpression.java
+++ b/src/com/google/javascript/rhino/JSTypeExpression.java
@@ -46,7 +46,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.javascript.rhino.jstype.JSType;
 import com.google.javascript.rhino.jstype.JSTypeRegistry;
 import com.google.javascript.rhino.jstype.StaticTypedScope;
+import com.google.javascript.rhino.jstype.TemplateType;
+
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -166,9 +169,17 @@ public final class JSTypeExpression implements Serializable {
     return root.getToken() == Token.ITER_REST;
   }
 
-  /** Evaluates the type expression into a {@code JSType} object. */
-  public JSType evaluate(@Nullable StaticTypedScope scope, JSTypeRegistry registry) {
-    JSType type = registry.createTypeFromCommentNode(root, sourceName, scope);
+
+  /** Evaluates the type expression into a {@code JSType} object.
+   * @param templates */
+  public JSType evaluate(StaticTypedScope scope, JSTypeRegistry registry) {
+    return this.evaluate(scope, registry, null);
+  }
+
+  /** Evaluates the type expression into a {@code JSType} object.
+   * @param templates */
+  public JSType evaluate(StaticTypedScope scope, JSTypeRegistry registry, HashMap<String, TemplateType> typedefTemplateTypes) {
+    JSType type = registry.createTypeFromCommentNode(root, sourceName, scope, typedefTemplateTypes);
     root.setJSType(type);
     return type;
   }

--- a/src/com/google/javascript/rhino/JSTypeExpression.java
+++ b/src/com/google/javascript/rhino/JSTypeExpression.java
@@ -49,7 +49,7 @@ import com.google.javascript.rhino.jstype.StaticTypedScope;
 import com.google.javascript.rhino.jstype.TemplateType;
 
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -178,7 +178,7 @@ public final class JSTypeExpression implements Serializable {
 
   /** Evaluates the type expression into a {@code JSType} object.
    * @param templates */
-  public JSType evaluate(StaticTypedScope scope, JSTypeRegistry registry, HashMap<String, TemplateType> typedefTemplateTypes) {
+  public JSType evaluate(StaticTypedScope scope, JSTypeRegistry registry, LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
     JSType type = registry.createTypeFromCommentNode(root, sourceName, scope, typedefTemplateTypes);
     root.setJSType(type);
     return type;

--- a/src/com/google/javascript/rhino/jstype/EnumElementType.java
+++ b/src/com/google/javascript/rhino/jstype/EnumElementType.java
@@ -205,6 +205,11 @@ public final class EnumElementType extends ObjectType {
   }
 
   @Override
+  protected JSType findPropertyTypeConsideringTemplateTypes(String propertyName) {
+    return primitiveType.findPropertyType(propertyName, true);
+  }
+
+  @Override
   public @Nullable FunctionType getConstructor() {
     // TODO(b/147236174): This should always return null.
     return primitiveObjectType == null ? null : primitiveObjectType.getConstructor();

--- a/src/com/google/javascript/rhino/jstype/FunctionType.java
+++ b/src/com/google/javascript/rhino/jstype/FunctionType.java
@@ -1528,6 +1528,15 @@ public class FunctionType extends PrototypeObjectType implements JSType.WithSour
           .setTemplateParamCount(templateKeys.size());
     }
 
+    /** Set the template map. */
+    public Builder withTemplateHashMap(LinkedHashMap<TemplateType, JSType> map) {
+       return this.setTemplateTypeMap(
+              registry
+                  .getEmptyTemplateTypeMap()
+                  .copyWithExtension(map))
+          .setTemplateParamCount(map.size());
+    }
+
     /** Set the template name. */
     public Builder withTemplateKeys(TemplateType... templateKeys) {
       return withTemplateKeys(ImmutableList.copyOf(templateKeys));

--- a/src/com/google/javascript/rhino/jstype/FunctionType.java
+++ b/src/com/google/javascript/rhino/jstype/FunctionType.java
@@ -644,6 +644,9 @@ public class FunctionType extends PrototypeObjectType implements JSType.WithSour
 
     this.extendedInterfaces = ImmutableList.copyOf(extendedInterfaces);
     for (ObjectType extendedInterface : extendedInterfaces) {
+      if(extendedInterface instanceof RecordType) {
+        continue; // records (LC) would have been bound at the point when their type is created in @extends tag 
+      }
       typeOfThis.mergeSupertypeTemplateTypes(extendedInterface);
     }
   }

--- a/src/com/google/javascript/rhino/jstype/JSType.java
+++ b/src/com/google/javascript/rhino/jstype/JSType.java
@@ -544,13 +544,6 @@ public abstract class JSType {
   public TemplateTypeMap getTemplateTypeMap() {
     return templateTypeMap;
   }
-  /**
-   * Whether generic parameters (even with unknown values) were set up on the
-   * type.
-   */
-  public boolean isGeneric() {
-    return templateTypeMap.size() > 0;
-  }
 
   /**
    * Return, in order, the sequence of type parameters declared for this type.

--- a/src/com/google/javascript/rhino/jstype/JSType.java
+++ b/src/com/google/javascript/rhino/jstype/JSType.java
@@ -544,6 +544,12 @@ public abstract class JSType {
   public TemplateTypeMap getTemplateTypeMap() {
     return templateTypeMap;
   }
+  /**
+   * Whether there are generic params for this type.
+   */
+  public boolean canBeTemplated() {
+    return templateTypeMap.size() > 0;
+  }
 
   /**
    * Return, in order, the sequence of type parameters declared for this type.

--- a/src/com/google/javascript/rhino/jstype/JSType.java
+++ b/src/com/google/javascript/rhino/jstype/JSType.java
@@ -545,9 +545,10 @@ public abstract class JSType {
     return templateTypeMap;
   }
   /**
-   * Whether there are generic params for this type.
+   * Whether generic parameters (even with unknown values) were set up on the
+   * type.
    */
-  public boolean canBeTemplated() {
+  public boolean isGeneric() {
     return templateTypeMap.size() > 0;
   }
 

--- a/src/com/google/javascript/rhino/jstype/JSTypeIterations.java
+++ b/src/com/google/javascript/rhino/jstype/JSTypeIterations.java
@@ -104,6 +104,7 @@ final class JSTypeIterations {
   static JSType mapTypes(Function<? super JSType, ? extends JSType> mapper, UnionType union) {
     return UnionType.builder(union.registry)
         .addAlternates(mapTypes(mapper, union.getAlternates()))
+        .withTypedefTemplateTypes(union.getOwnTemplateTypes())
         .build();
   }
 

--- a/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
+++ b/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
@@ -179,7 +179,6 @@ public final class JSTypeRegistry {
   private final JSType[] nativeTypes;
 
   private final Table<Node, String, JSType> scopedNameTable = HashBasedTable.create();
-  private final Map<JSType, Iterable<TemplateType>> typedefTemplateKeys = new IdentityHashMap<>();
 
   // Only needed for type resolution at the moment
   private final transient Map<String, ClosureNamespace> closureNamespaces = new LinkedHashMap<>();

--- a/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
+++ b/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
@@ -76,7 +76,6 @@ import com.google.javascript.rhino.StaticSlot;
 import com.google.javascript.rhino.Token;
 import com.google.javascript.rhino.jstype.NamedType.ResolutionKind;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -1646,7 +1645,7 @@ public final class JSTypeRegistry {
    *
    * @return the union of the type and the Null type
    */
-  public JSType createNullableType(JSType type, HashMap<String, TemplateType> typedefTemplateTypes) {
+  public JSType createNullableType(JSType type, LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
     return createUnionType(List.of(type, getNativeType(JSTypeNative.NULL_TYPE)), typedefTemplateTypes);
   }
 
@@ -1669,7 +1668,7 @@ public final class JSTypeRegistry {
     return UnionType.builder(this).addAlternates(variants).build();
   }
 
-  public JSType createUnionType(List<? extends JSType> variants, HashMap<String, TemplateType> typedefTemplateTypes) {
+  public JSType createUnionType(List<? extends JSType> variants, LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
     return UnionType.builder(this).addAlternates(variants).withTypedefTemplateTypes(typedefTemplateTypes).build();
   }
 
@@ -1981,7 +1980,7 @@ public final class JSTypeRegistry {
    * Creates a templatized type that itself can be parameterised, e.g., `@typedef Array<T> @template T`.
    */
   public TemplatizedType createTemplatizedType(ObjectType baseType, ImmutableList<JSType> templatizedTypes,
-      HashMap<String, TemplateType> typedefTemplateTypes) {
+      LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
     checkNotNull(baseType);
     return new TemplatizedType(this, baseType, templatizedTypes, typedefTemplateTypes);
   }
@@ -2283,7 +2282,7 @@ public final class JSTypeRegistry {
     }
   }
 
-  private JSType addNullabilityBasedOnParseContext(Node n, JSType type, StaticScope scope, HashMap<String, TemplateType> typedefTemplateTypes) {
+  private JSType addNullabilityBasedOnParseContext(Node n, JSType type, StaticScope scope, LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
     // Other node types may be appropriate in the future.
     checkState(n.isName() || n.isStringLit(), n);
     checkNotNull(type);

--- a/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
+++ b/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
@@ -2018,6 +2018,38 @@ public final class JSTypeRegistry {
     return createTypeFromCommentNode(n, "[internal]", null);
   }
 
+  public JSType maybeBindTemplates(JSType nominalType, ImmutableList<JSType> templateArgs) {
+    if(nominalType instanceof RecordType) {
+      TemplateTypeMap bindingTypeMap = nominalType
+          .getTemplateTypeMap()
+          .copyWithOverride(templateArgs);
+
+      var b = bindTemplatesWithMap(nominalType, bindingTypeMap);
+      return b;
+    }
+
+    if(nominalType instanceof FunctionType) {
+      TemplateTypeMap bindingTypeMap = nominalType
+          .getTemplateTypeMap()
+          .copyWithOverride(templateArgs);
+
+      var b = bindTemplatesWithMap(nominalType, bindingTypeMap);
+      return b;
+    }
+
+    if(nominalType instanceof UnionType) {
+      var b = bindUnionTemplates((UnionType) nominalType, templateArgs);
+      return b;
+    }
+
+    if(nominalType instanceof TemplatizedType) {
+      var b = bindTemplatizedTemplates((TemplatizedType) nominalType, templateArgs);
+      return b;
+    }
+
+    return null;
+  }
+
   /**
    * Produces a new type where all templates' keys were replaced with values from the map. This
    * happens when creating types from JSDoc comments (e.g., `@type {Type<string,number>}`) only.
@@ -2172,31 +2204,9 @@ public final class JSTypeRegistry {
           }
 
           if(templateArgs != null && templateArgs.size() > 0) {
-            if(nominalType instanceof RecordType) {
-              TemplateTypeMap bindingTypeMap = nominalType
-                  .getTemplateTypeMap()
-                  .copyWithOverride(templateArgs);
-
-              var b = bindTemplatesWithMap(nominalType, bindingTypeMap);
-              return b;
-            }
-            if(nominalType instanceof FunctionType) {
-              TemplateTypeMap bindingTypeMap = nominalType
-                  .getTemplateTypeMap()
-                  .copyWithOverride(templateArgs);
-
-              var b = bindTemplatesWithMap(nominalType, bindingTypeMap);
-              return addNullabilityBasedOnParseContext(n, b, scope, typedefTemplateTypes);
-            }
-
-            if(nominalType instanceof UnionType) {
-              var b = bindUnionTemplates((UnionType) nominalType, templateArgs);
-              return addNullabilityBasedOnParseContext(n, b, scope, typedefTemplateTypes);
-            }
-
-            if(nominalType instanceof TemplatizedType) {
-              var b = bindTemplatizedTemplates((TemplatizedType) nominalType, templateArgs);
-              return addNullabilityBasedOnParseContext(n, b, scope, typedefTemplateTypes);
+            var b = maybeBindTemplates(nominalType, templateArgs);
+            if(b != null) {
+              return addNullabilityBasedOnParseContext(n, (JSType) b, scope, typedefTemplateTypes);
             }
           }
 

--- a/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
+++ b/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
@@ -2048,7 +2048,7 @@ public final class JSTypeRegistry {
   /**
    * Creates a bound type for parameterized types.
    */
-  public JSType bindOwnTemplates(HashMap<String, TemplateType> t, JSType type, ImmutableList<JSType> templateArgs) {
+  public JSType bindOwnTemplates(LinkedHashMap<String, TemplateType> t, JSType type, ImmutableList<JSType> templateArgs) {
     if(t == null || t.size() == 0) return type;
 
     TemplateTypeMap bindingTypeMap = this.getEmptyTemplateTypeMap()

--- a/src/com/google/javascript/rhino/jstype/NamedType.java
+++ b/src/com/google/javascript/rhino/jstype/NamedType.java
@@ -278,23 +278,11 @@ public final class NamedType extends ProxyObjectType {
     if (isSuccessfullyResolved()) {
       this.resolutionScope = null;
 
-      if(resolvedTypeArgs.size() > 0) {
-        var templatizedType=result.toMaybeTemplatizedType();
-        if(templatizedType != null) {
-          var newResult=registry.bindTemplatizedTemplates(templatizedType, resolvedTypeArgs);
-          if(result != newResult) {
-            setReferencedType(newResult.resolve(reporter));
-            return newResult;
-          }
-        }
-
-        var unionType=result.toMaybeUnionType();
-        if(unionType != null) {
-          var newResult=registry.bindUnionTemplates(unionType, resolvedTypeArgs);
-          if(result != newResult) {
-            setReferencedType(newResult.resolve(reporter));
-            return newResult;
-          }
+      if(!resolvedTypeArgs.isEmpty()) {
+        var b = registry.maybeBindTemplates(result, resolvedTypeArgs);
+        if(b != null) {
+          setReferencedType(b.resolve(reporter));
+          return b;
         }
       }
 

--- a/src/com/google/javascript/rhino/jstype/NamedType.java
+++ b/src/com/google/javascript/rhino/jstype/NamedType.java
@@ -255,7 +255,6 @@ public final class NamedType extends ProxyObjectType {
       // there's nothing to look up, so just resolve the referenced type.
       return super.resolveInternal(reporter);
     }
-
     checkState(
         getReferencedType().isUnknownType(),
         "NamedTypes given a referenced type pre-resolution should have ResolutionKind.NONE");
@@ -288,7 +287,7 @@ public final class NamedType extends ProxyObjectType {
             return newResult;
           }
         }
-        
+
         var unionType=result.toMaybeUnionType();
         if(unionType != null) {
           var newResult=registry.bindUnionTemplates(unionType, resolvedTypeArgs);

--- a/src/com/google/javascript/rhino/jstype/NamedType.java
+++ b/src/com/google/javascript/rhino/jstype/NamedType.java
@@ -279,12 +279,23 @@ public final class NamedType extends ProxyObjectType {
     if (isSuccessfullyResolved()) {
       this.resolutionScope = null;
 
-      var templatizedType=result.toMaybeTemplatizedType();
-      if(result instanceof TemplatizedType) {
-        var newResult=registry.bindTemplatizedTemplates(templatizedType, resolvedTypeArgs);
-        if(result != newResult) {
-          setReferencedType(newResult.resolve(reporter));
-          return newResult;
+      if(resolvedTypeArgs.size() > 0) {
+        var templatizedType=result.toMaybeTemplatizedType();
+        if(templatizedType != null) {
+          var newResult=registry.bindTemplatizedTemplates(templatizedType, resolvedTypeArgs);
+          if(result != newResult) {
+            setReferencedType(newResult.resolve(reporter));
+            return newResult;
+          }
+        }
+        
+        var unionType=result.toMaybeUnionType();
+        if(unionType != null) {
+          var newResult=registry.bindUnionTemplates(unionType, resolvedTypeArgs);
+          if(result != newResult) {
+            setReferencedType(newResult.resolve(reporter));
+            return newResult;
+          }
         }
       }
 

--- a/src/com/google/javascript/rhino/jstype/ObjectType.java
+++ b/src/com/google/javascript/rhino/jstype/ObjectType.java
@@ -470,6 +470,11 @@ public abstract class ObjectType extends JSType {
     return hasProperty(propertyName) ? getPropertyType(propertyName) : null;
   }
 
+  @Override
+  protected @Nullable JSType findPropertyTypeConsideringTemplateTypes(String propertyName) {
+    return hasProperty(propertyName) ? getPropertyType(propertyName) : null;
+  }
+
   /**
    * Gets the property type of the property whose name is given. If the
    * underlying object does not have this property, the Unknown type is

--- a/src/com/google/javascript/rhino/jstype/ProxyObjectType.java
+++ b/src/com/google/javascript/rhino/jstype/ProxyObjectType.java
@@ -311,6 +311,11 @@ public class ProxyObjectType extends ObjectType {
   }
 
   @Override
+  protected JSType findPropertyTypeConsideringTemplateTypes(String propertyName) {
+    return referencedType.findPropertyType(propertyName, true);
+  }
+
+  @Override
   public final JSDocInfo getJSDocInfo() {
     return referencedType.getJSDocInfo();
   }

--- a/src/com/google/javascript/rhino/jstype/RecordType.java
+++ b/src/com/google/javascript/rhino/jstype/RecordType.java
@@ -60,6 +60,10 @@ public final class RecordType extends PrototypeObjectType {
   private final boolean declared;
   private boolean isFrozen = false;
 
+  RecordType(JSTypeRegistry registry, Map<String, RecordProperty> properties,
+      boolean declared) {
+    this(registry, properties, declared, PrototypeObjectType.builder(registry));
+  }
   /**
    * Creates a record type.
    *
@@ -73,8 +77,8 @@ public final class RecordType extends PrototypeObjectType {
    *         with a property is null.
    */
   RecordType(JSTypeRegistry registry, Map<String, RecordProperty> properties,
-      boolean declared) {
-    super(PrototypeObjectType.builder(registry));
+      boolean declared, Builder builder) {
+    super(builder);
     setPrettyPrint(true);
     this.declared = declared;
 

--- a/src/com/google/javascript/rhino/jstype/RecordTypeBuilder.java
+++ b/src/com/google/javascript/rhino/jstype/RecordTypeBuilder.java
@@ -134,4 +134,14 @@ public final class RecordTypeBuilder {
     templateParamCount = templateKeys.size();
     return this;
   }
+
+  /** Set the template map. */
+  public RecordTypeBuilder withTemplateHashMap(LinkedHashMap<TemplateType,JSType> map) {
+    templateTypeMap = registry
+      .getEmptyTemplateTypeMap()
+      .copyWithExtension(map);
+
+    templateParamCount = map.size();
+    return this;
+  }
 }

--- a/src/com/google/javascript/rhino/jstype/RecordTypeBuilder.java
+++ b/src/com/google/javascript/rhino/jstype/RecordTypeBuilder.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.javascript.rhino.Node;
 import java.util.LinkedHashMap;
+import java.util.HashMap;
 
 /**
  * A builder for record types.

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeMap.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeMap.java
@@ -129,6 +129,25 @@ public final class TemplateTypeMap {
   }
 
   /**
+   * Create a new map in which the incoming values override existing ones in the linear iteration order.
+   *  
+   * <p>If the new value is `null`, the override is skipped.
+   */
+  TemplateTypeMap copyWithOverride(ImmutableList<JSType> values) {
+     ArrayList<JSType> newValues = new ArrayList<>();
+    newValues.addAll(this.templateValues);
+    padToSameLength(this.templateKeys, newValues);
+    for(var i=0; i<values.size(); i++) {
+      var newVal=values.get(i);
+      if(newVal == null) continue;
+      newValues.set(i, newVal);
+    }
+
+    return new TemplateTypeMap(
+        this.registry, this.templateKeys, ImmutableList.copyOf(newValues));
+  }
+
+  /**
    * Create a new map in which the keys and values have been extended by {@code extension}.
    *
    * <p>Before extension, any unfilled values in the initial map will be filled with `?`.

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeMap.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeMap.java
@@ -44,7 +44,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.javascript.jscomp.base.JSCompObjects.identical;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
@@ -156,6 +159,15 @@ public final class TemplateTypeMap {
     return copyWithExtension(extension.templateKeys, extension.templateValues);
   }
 
+  /**
+   * Create a new map in which the keys and values have been extended by {@code keys} and {@code
+   * values} respectively.
+   *
+   * <p>Before extension, any unfilled values in the initial map will be filled with `?`.
+   */
+  public TemplateTypeMap copyWithExtension(Map<TemplateType, JSType> map) {
+    return copyWithExtension(ImmutableList.copyOf(map.keySet()), ImmutableList.copyOf(map.values()));
+  }
   /**
    * Create a new map in which the keys and values have been extended by {@code keys} and {@code
    * values} respectively.

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeMap.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeMap.java
@@ -166,6 +166,9 @@ public final class TemplateTypeMap {
    * <p>Before extension, any unfilled values in the initial map will be filled with `?`.
    */
   public TemplateTypeMap copyWithExtension(Map<TemplateType, JSType> map) {
+    if(map == null) {
+      return copyWithExtension(ImmutableList.of(), ImmutableList.of());
+    }
     return copyWithExtension(ImmutableList.copyOf(map.keySet()), ImmutableList.copyOf(map.values()));
   }
   /**

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
@@ -88,6 +88,11 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
     return new TemplateTypeReplacer(registry, map, true, true, true);
   }
 
+  public static TemplateTypeReplacer forInference(
+      JSTypeRegistry registry, TemplateTypeMap bindings) {
+    return new TemplateTypeReplacer(registry, bindings, true, true, true);
+  }
+
   /**
    * Creates a replacer that will always totally eliminate {@link TemplateType}s from the
    * definitions of the types it performs replacement on.

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
@@ -48,7 +48,7 @@ import com.google.javascript.jscomp.base.LinkedIdentityHashSet;
 import com.google.javascript.rhino.Node;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -297,7 +297,7 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
       builder.add(afterTemplateType);
     }
 
-    HashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes();
+    LinkedHashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes();
     if(afterOwnTemplateTypes != null) {
       var replaced = replaceOwnTemplateTypes(afterOwnTemplateTypes, type);
       if(replaced != null) {
@@ -315,9 +315,9 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
   /**
    * Updates the own template types (added with `@typedef` notation in root JSDoc) of templatized/union types.
    */
-  private HashMap<String, TemplateType> replaceOwnTemplateTypes(HashMap<String, TemplateType> ownTemplateTypes, JSType type) {
+  private LinkedHashMap<String, TemplateType> replaceOwnTemplateTypes(LinkedHashMap<String, TemplateType> ownTemplateTypes, JSType type) {
     boolean changed = false;
-    HashMap<String, TemplateType> afterOwnTemplateTypes = new HashMap<>();
+    LinkedHashMap<String, TemplateType> afterOwnTemplateTypes = new LinkedHashMap<>();
 
     for (String ownTemplateTypeKey : ownTemplateTypes.keySet()) {
       var beforeOwnTemplateType = ownTemplateTypes.get(ownTemplateTypeKey);
@@ -389,7 +389,7 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
       results.add(replacement);
     }
 
-    HashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes();
+    LinkedHashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes();
     if(afterOwnTemplateTypes != null) {
       var replaced = replaceOwnTemplateTypes(afterOwnTemplateTypes, type);
       if(replaced != null) {
@@ -452,7 +452,7 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
   public JSType caseNamedTypeRefUnguarded(JSType ref) {
     return ref.visit(this);
   }
-  
+
   @Override
   public JSType caseNamedType(NamedType type) {
     if(!type.isResolved() || type.getReferencedType() == null) {

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
@@ -46,7 +46,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.jscomp.base.LinkedIdentityHashSet;
 import com.google.javascript.rhino.Node;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
@@ -298,13 +298,13 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
       builder.add(afterTemplateType);
     }
 
-    HashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes(); 
+    HashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes();
     if(afterOwnTemplateTypes != null) {
       var replaced = replaceOwnTemplateTypes(afterOwnTemplateTypes, type);
       if(replaced != null) {
         afterOwnTemplateTypes = replaced;
         changed = true;
-      }      
+      }
     }
 
     if (changed) {
@@ -327,7 +327,7 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
         changed = true;
       }
       if(afterOwnTemplateType.toMaybeTemplateType() == null) {
-         afterOwnTemplateType=beforeOwnTemplateType;//registry.createTemplateType("NULL");
+         afterOwnTemplateType=beforeOwnTemplateType;
       }
       afterOwnTemplateTypes.put(ownTemplateTypeKey, (TemplateType) afterOwnTemplateType);
     }
@@ -389,14 +389,14 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
       }
       results.add(replacement);
     }
-    
-    HashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes(); 
+
+    HashMap<String, TemplateType> afterOwnTemplateTypes = type.getOwnTemplateTypes();
     if(afterOwnTemplateTypes != null) {
       var replaced = replaceOwnTemplateTypes(afterOwnTemplateTypes, type);
       if(replaced != null) {
         afterOwnTemplateTypes = replaced;
         changed = true;
-      }      
+      }
     }
 
     if (changed) {

--- a/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
+++ b/src/com/google/javascript/rhino/jstype/TemplateTypeReplacer.java
@@ -228,6 +228,7 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
           .withParameters(paramsChanged ? paramBuilder.build() : type.getParameters())
           .withReturnType(afterReturn)
           .withTypeOfThis(afterThis)
+          .withTemplateHashMap(mapTemplateMap(type))
           .withIsAbstract(false) // TODO(b/187989034): Copy this from the source function.
           .build();
     }
@@ -263,12 +264,35 @@ public final class TemplateTypeReplacer implements Visitor<JSType> {
       }
       builder.addProperty(prop, afterType, propertyNode);
     }
+    
+    var newTemplateTypeMap = mapTemplateMap(objType);
+    builder.withTemplateHashMap(newTemplateTypeMap);
 
     if (changed) {
       return builder.build();
     }
 
     return objType;
+  }
+  
+  private LinkedHashMap<TemplateType, JSType> mapTemplateMap(JSType objType) {
+//    var templateMapChanged = false;
+    var newTemplateTypeHashMap = new LinkedHashMap<TemplateType, JSType>();
+    for(var t : objType.templateTypeMap.getTemplateKeys()) {
+      var val = objType.templateTypeMap.getUnresolvedOriginalTemplateType(t);
+      var newT = t.visit(this);
+      if (newT instanceof TemplateType && !identical(t, newT)) {
+        newTemplateTypeHashMap.put((TemplateType) newT, val);
+//        templateMapChanged = true;
+      }else {
+        newTemplateTypeHashMap.put(t, val);
+      }
+    }
+//    if(templateMapChanged) {
+//      return newTemplateTypeMap;
+//    }
+    return newTemplateTypeHashMap;
+//    return null;
   }
 
   @Override

--- a/src/com/google/javascript/rhino/jstype/TemplatizedType.java
+++ b/src/com/google/javascript/rhino/jstype/TemplatizedType.java
@@ -45,7 +45,7 @@ import static com.google.javascript.jscomp.base.JSCompObjects.identical;
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.rhino.ErrorReporter;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
@@ -60,7 +60,7 @@ public final class TemplatizedType extends ProxyObjectType {
 
   /** A cache of the type parameter values for this specialization. */
   private final ImmutableList<JSType> templateTypes;
-  private HashMap<String, TemplateType> typedefTemplateTypes = null;
+  private LinkedHashMap<String, TemplateType> typedefTemplateTypes = null;
   /** Whether all type parameter values for this specialization are `?`. */
   private final boolean isSpecializedOnlyWithUnknown;
 
@@ -92,7 +92,7 @@ public final class TemplatizedType extends ProxyObjectType {
   }
 
   public TemplatizedType(JSTypeRegistry jsTypeRegistry, ObjectType baseType, ImmutableList<JSType> templatizedTypes,
-      HashMap<String, TemplateType> typedefTemplateTypes) {
+      LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
     this(jsTypeRegistry, baseType, templatizedTypes);
     this.typedefTemplateTypes=typedefTemplateTypes;
   }
@@ -101,7 +101,7 @@ public final class TemplatizedType extends ProxyObjectType {
    * The template types of the templatized type itself rather than its reference object.
    * E.g., in `@typedef {Object<string,T>} @template T`, the `string,T` are the template types and T is the own template type. 
    */
-  public HashMap<String, TemplateType> getOwnTemplateTypes() {
+  public LinkedHashMap<String, TemplateType> getOwnTemplateTypes() {
     return this.typedefTemplateTypes;
   }
 

--- a/src/com/google/javascript/rhino/jstype/TemplatizedType.java
+++ b/src/com/google/javascript/rhino/jstype/TemplatizedType.java
@@ -44,6 +44,8 @@ import static com.google.javascript.jscomp.base.JSCompObjects.identical;
 
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.rhino.ErrorReporter;
+
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
@@ -58,6 +60,7 @@ public final class TemplatizedType extends ProxyObjectType {
 
   /** A cache of the type parameter values for this specialization. */
   private final ImmutableList<JSType> templateTypes;
+  private HashMap<String, TemplateType> typedefTemplateTypes = null;
   /** Whether all type parameter values for this specialization are `?`. */
   private final boolean isSpecializedOnlyWithUnknown;
 
@@ -86,6 +89,20 @@ public final class TemplatizedType extends ProxyObjectType {
     this.replacer = TemplateTypeReplacer.forPartialReplacement(registry, getTemplateTypeMap());
 
     registry.getResolver().resolveIfClosed(this, TYPE_CLASS);
+  }
+
+  public TemplatizedType(JSTypeRegistry jsTypeRegistry, ObjectType baseType, ImmutableList<JSType> templatizedTypes,
+      HashMap<String, TemplateType> typedefTemplateTypes) {
+    this(jsTypeRegistry, baseType, templatizedTypes);
+    this.typedefTemplateTypes=typedefTemplateTypes;
+  }
+  
+  /**
+   * The template types of the templatized type itself rather than its reference object.
+   * E.g., in `@typedef {Object<string,T>} @template T`, the `string,T` are the template types and T is the own template type. 
+   */
+  public HashMap<String, TemplateType> getOwnTemplateTypes() {
+    return this.typedefTemplateTypes;
   }
 
   @Override

--- a/src/com/google/javascript/rhino/jstype/TemplatizedType.java
+++ b/src/com/google/javascript/rhino/jstype/TemplatizedType.java
@@ -44,7 +44,6 @@ import static com.google.javascript.jscomp.base.JSCompObjects.identical;
 
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.rhino.ErrorReporter;
-
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -96,10 +95,10 @@ public final class TemplatizedType extends ProxyObjectType {
     this(jsTypeRegistry, baseType, templatizedTypes);
     this.typedefTemplateTypes=typedefTemplateTypes;
   }
-  
+
   /**
    * The template types of the templatized type itself rather than its reference object.
-   * E.g., in `@typedef {Object<string,T>} @template T`, the `string,T` are the template types and T is the own template type. 
+   * E.g., in `@typedef {Object<string,T>} @template T`, the `string,T` are the template types and T is the own template type.
    */
   public LinkedHashMap<String, TemplateType> getOwnTemplateTypes() {
     return this.typedefTemplateTypes;

--- a/src/com/google/javascript/rhino/jstype/UnionType.java
+++ b/src/com/google/javascript/rhino/jstype/UnionType.java
@@ -58,7 +58,7 @@ import com.google.javascript.rhino.Outcome;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
@@ -126,7 +126,7 @@ public final class UnionType extends JSType {
    * The template types of the union type itself rather than its alternates.
    * E.g., in `@typedef {Array<T>|Set<T>} @template T`, `T` is the own template type.
    */
-  public HashMap<String, TemplateType> getOwnTemplateTypes() {
+  public LinkedHashMap<String, TemplateType> getOwnTemplateTypes() {
     return this.typedefTemplateTypes;
   }
 
@@ -643,7 +643,7 @@ public final class UnionType extends JSType {
 
     private final List<JSType> alternates = new ArrayList<>();
     private @Nullable ImmutableList<JSType> finalAlternates = null;
-    private HashMap<String, TemplateType> typedefTemplateTypes;
+    private LinkedHashMap<String, TemplateType> typedefTemplateTypes;
 
     // If a union has ? or *, we do not care about any other types, except for undefined (for
     // optional properties).
@@ -706,7 +706,7 @@ public final class UnionType extends JSType {
       return this;
     }
 
-    public Builder withTypedefTemplateTypes(HashMap<String, TemplateType> typedefTemplateTypes) {
+    public Builder withTypedefTemplateTypes(LinkedHashMap<String, TemplateType> typedefTemplateTypes) {
       this.typedefTemplateTypes = typedefTemplateTypes;
       return this;
     }

--- a/src/com/google/javascript/rhino/jstype/UnionType.java
+++ b/src/com/google/javascript/rhino/jstype/UnionType.java
@@ -221,8 +221,7 @@ public final class UnionType extends JSType {
     return anyTypeMatches(JSType::matchesObjectContext, this);
   }
 
-  @Override
-  protected JSType findPropertyTypeWithoutConsideringTemplateTypes(String propertyName) {
+  protected JSType findUnionPropertyType(String propertyName, boolean forInference) {
     JSType propertyType = null;
 
     for (JSType alternate : alternates) {
@@ -231,7 +230,7 @@ public final class UnionType extends JSType {
         continue;
       }
 
-      JSType altPropertyType = alternate.findPropertyType(propertyName);
+      JSType altPropertyType = alternate.findPropertyType(propertyName, forInference);
       if (altPropertyType == null) {
         continue;
       }
@@ -244,6 +243,16 @@ public final class UnionType extends JSType {
     }
 
     return propertyType;
+  }
+  
+  @Override
+  protected JSType findPropertyTypeWithoutConsideringTemplateTypes(String propertyName) {
+    return findUnionPropertyType(propertyName, false);
+  }
+  
+  @Override
+  protected JSType findPropertyTypeConsideringTemplateTypes(String propertyName) {
+    return findUnionPropertyType(propertyName, true);
   }
 
   @Override

--- a/test/com/google/javascript/jscomp/CheckJsDocTest.java
+++ b/test/com/google/javascript/jscomp/CheckJsDocTest.java
@@ -926,6 +926,12 @@ public final class CheckJsDocTest extends CompilerTestCase {
   }
 
   @Test
+  public void testTypedefWithTemplate() {
+    testSame("/** @const */ var goog;/** @typedef {function(T)} @template T */ goog.test");
+    testSame("/** @typedef {function(T)} @template T */ var test");
+  }
+
+  @Test
   public void testGoodTypedef() {
     testSame("/** @typedef {string} */ var x;");
     testSame("/** @typedef {string} */ let x;");

--- a/test/com/google/javascript/jscomp/TypeCheckTest.java
+++ b/test/com/google/javascript/jscomp/TypeCheckTest.java
@@ -19495,6 +19495,17 @@ public final class TypeCheckTest extends TypeCheckTestCase {
                 + "/** @type {!Schema} */ var k;")
         .run();
   }
+  
+  @Test
+  @Disabled // Printing warnings for recursive types need addressing
+  public void testCheckObjectKeyRecursiveTypeDoesNotStackOverflowOnWarning() {
+    newTest()
+        .addSource(
+            "/** @typedef {!Object<string, !Predicate>} */ var Schema;\n"
+                + "/** @typedef {function(*): boolean|!Schema} */ var Predicate;\n"
+                + "/** @type {!Schema} */ var k; k = 123")
+        .run();
+  }
 
   @Test
   public void testDontOverrideNativeScalarTypes() {

--- a/test/com/google/javascript/jscomp/TypeCheckTest.java
+++ b/test/com/google/javascript/jscomp/TypeCheckTest.java
@@ -5333,6 +5333,26 @@ public final class TypeCheckTest extends TypeCheckTestCase {
   }
 
   @Test
+  public void testTypedefTemplate() {
+    newTest()
+        .addSource(
+            "/** @param {string} x */ function g(x) {}"
+                + "/** @typedef {function(T):T} @template T */"
+                + "var genericFunction;"
+                
+                + "/** @type {genericFunction<number>} */"
+                + "function test() { return '123' }"
+                + "const t=test(123);"
+                + "g(t);")
+        .addDiagnostic("inconsistent return type\n" + "found   : string\n" + "required: number")
+        .addDiagnostic(
+            "actual parameter 1 of g does not match formal parameter\n"
+                + "found   : number\n"
+                + "required: string")
+        .run();
+  }
+
+  @Test
   public void testBackwardsConstructor1() {
     newTest()
         .addSource(

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -2941,7 +2941,7 @@ public final class TypeInferenceTest {
 
   @Test
   public void testTypedefsWithTemplates() {
-    inFunction(
+    inScript(
         lines(
              "/** @typedef {!ABC<TT>} @template TT */",
              "var MyType",
@@ -2953,7 +2953,7 @@ public final class TypeInferenceTest {
              "var MyType2",
              "/** @type {MyType2<number>}*/",
              "function Test() {}",
-             "const test=new Test('123')", // could test for warning also
+             "const test=new Test('123')",
              "const t=test.abc"));
 
     assertThat(getType("t").toString()).isEqualTo("number");
@@ -2962,7 +2962,7 @@ public final class TypeInferenceTest {
   @Test
   public void testTypedefsTypeofsWithTemplates() {
     // Functions are not types, but we might want to define them as such in externs via typedefs
-    inFunction(
+    inScript(
         lines(
              // e.g., externs
              "/** @return {T} @template T */",
@@ -2972,7 +2972,7 @@ public final class TypeInferenceTest {
 
              // e.g., code
              "/** @type {genericFunction<number>}*/",
-             "function test() { return '123' }", // could test for return type warning
+             "function test() { return '123' }",
              "const t=test(123)"));
 
     assertThat(getType("t").toString()).isEqualTo("number");

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3120,7 +3120,57 @@ public final class TypeInferenceTest {
     assertThat(getType("t").toString()).isEqualTo("(Array<string>|number)");
   }
 
+  @Test
+  public void testTypedefsRecordsWithTemplates() {
+    inScript(
+        lines(
+             "/** @typedef {{f:function():{r:T}}} @template T */",
+             "var Record",
+             "var record = /** @type {Record<number>} */ ({})",
+             "const t=record.f().r"
+           ));
 
+    assertThat(getType("t").toString()).isEqualTo("number");
+  }
+
+  @Test
+  public void testTypedefsInferedRecordsFunctionsWithTemplates() {
+    inScript(
+        lines(
+             "/** @typedef {{f:function(T):{r:T}}} @template T */",
+             "var Record",
+             "var record = /** @type {Record} */ ({})",
+             "const t=record.f(123).r"
+           ));
+
+    assertThat(getType("t").toString()).isEqualTo("number");
+  }
+
+  @Test
+  public void testTypedefsForwardRecordsWithTemplates() {
+    inScript(
+        lines(
+             "var record = /** @type {Record<number>} */ ({})",
+             "const t=record.f().r",
+             "/** @typedef {{f:function():{r:T}}} @template T */",
+             "var Record"
+           ));
+
+    assertThat(getType("t").toString()).isEqualTo("number");
+  }
+
+  @Test
+  public void testTypedefsForwardInferedRecordsFunctionsWithTemplates() {
+    inScript(
+        lines(
+             "var record = /** @type {Record} */ ({})",
+             "const t=record.f(123).r",
+             "/** @typedef {{f:function(T):{r:T}}} @template T */",
+             "var Record"
+           ));
+
+    assertThat(getType("t").toString()).isEqualTo("number");
+  }
   @Test
   public void testTypedefsFunctionsWithTemplates() {
     inScript(

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3170,18 +3170,30 @@ public final class TypeInferenceTest {
              "/** @constructor @extends {Record<string>} @template A */",
              "function Abc() {}",
              "var t = /** @type {Abc} */({}).f().r",
+             
+             "/** @record @extends {Record<string>} @template A */",
+             "function Rabc() {}",
+             "var rt = /** @type {Rabc} */({}).f().r",
 
              "/** @constructor @extends {Record<A>} @template A */",
              "function Def() {}",
              "var d = /** @type {Def<boolean>} */({}).f().r",
+             
+             "/** @record @extends {Record<A>} @template A */",
+             "function Rdef() {}",
+             "var rd = /** @type {Rdef<boolean>} */({}).f().r",
 
              "/** @constructor @extends {Record} */",
              "function Ghi() {}",
-             "var i = /** @type {Ghi} */({}).f(true).r"
+             "var i = /** @type {Ghi} */({}).f(true).r",
+             
+             ""
            ));
 
     assertThat(getType("t").toString()).isEqualTo("string");
+    assertThat(getType("rt").toString()).isEqualTo("string");
     assertThat(getType("d").toString()).isEqualTo("boolean");
+    assertThat(getType("rd").toString()).isEqualTo("boolean");
     assertThat(getType("i").toString()).isEqualTo("boolean");
   }
 

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -2960,7 +2960,7 @@ public final class TypeInferenceTest {
   }
 
   @Test
-  public void testDeepUnionTypedefsWithTemplates() {
+  public void testTypedefsDeepUnionWithTemplates() {
     inScript(
         lines(
              "/** @typedef {!Array<U>|!Object<U,U>} @template U */",
@@ -2976,7 +2976,7 @@ public final class TypeInferenceTest {
   }
 
   @Test
-  public void testUnionForwardTypedefsWithTemplates1() {
+  public void testTypedefsDeepUnionForwardWithTemplates() {
     inScript(
         lines(
              "/** @typedef {!ForwardType<U>} @template U */",
@@ -2992,7 +2992,7 @@ public final class TypeInferenceTest {
   }
 
   @Test
-  public void testUnionForwardTypedefsWithTemplates() {
+  public void testTypedefsUnionForwardWithTemplates() {
     inScript(
         lines(
              "var forwardTest = /** @type {!TestType<string>} */([])",
@@ -3021,11 +3021,15 @@ public final class TypeInferenceTest {
 
   @Test
   public void testTypedefsTypeofsWithTemplates() {
-    // Functions are not types, but we might want to define them as such in externs via typedefs
+    // Functions are not types, but we might want to define them as such in externs via typedefs for comments 
     inScript(
         lines(
              // e.g., externs
-             "/** @param {T} @return {T} @template T */",
+             "/**",
+             " * @param {T} The param.",
+             " * @return {T} The updated param.",
+             " * @template T",
+             " */",
              "function _genericFunction() {}",
              "/** @typedef {typeof _genericFunction} */",
              "var genericFunction",
@@ -3046,7 +3050,7 @@ public final class TypeInferenceTest {
              "var ObjectType",
              "const object=/** @type {ObjectType<number>} */ ({})",
 
-             "/** @typedef {!Array<T>} @template T */", // creates |null union
+             "/** @typedef {Array<T>} @template T */", // creates |null union
              "var ArrayType",
              "const array=/** @type {ArrayType<number>} */ ({})",
 
@@ -3054,8 +3058,8 @@ public final class TypeInferenceTest {
            ));
 
     assertThat(getType("object").toString()).isEqualTo("Object<symbol,number>");
-    assertThat(getType("array").toString()).isEqualTo("Array<number>");
-    assertThat(getType("deep").toString()).isEqualTo("Object<symbol,Array<number>>");
+    assertThat(getType("array").toString()).isEqualTo("(Array<number>|null)");
+    assertThat(getType("deep").toString()).isEqualTo("Object<symbol,(Array<number>|null)>");
   }
 
   @Test
@@ -3091,12 +3095,12 @@ public final class TypeInferenceTest {
   public void testTypedefsUnionsWithTemplates() {
     inScript(
         lines(
-             "/** @typedef {T|S} @template T,S */",
+             "/** @typedef {T|!Array<S>} @template T,S */",
              "var Type",
              "const t=/** @type {Type<number,string>} */(void 5)"
            ));
 
-    assertThat(getType("t").toString()).isEqualTo("number|string");
+    assertThat(getType("t").toString()).isEqualTo("(Array<number>|string)");
   }
 
 

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3061,6 +3061,23 @@ public final class TypeInferenceTest {
     assertThat(getType("array").toString()).isEqualTo("(Array<number>|null)");
     assertThat(getType("deep").toString()).isEqualTo("Object<symbol,(Array<number>|null)>");
   }
+  
+  @Test
+  public void testTypedefsRecursiveObjectTypesWithTemplates() {
+    inScript(
+        lines(
+             "/**\n"
+             + " * @constructor\n"
+             + " * @extends {Array<(T|!RecursiveArray<T>)>}\n"
+             + " * @template T\n"
+             + " */\n"
+             + "var RecursiveArray = function() {}",
+
+             "const res=/** @type {RecursiveArray<string>} */ ({})"
+           ));
+
+    assertThat(getType("res").toString()).isEqualTo("(RecursiveArray<string>|null)");
+  }
 
   @Test
   public void testTypedefsForwardObjectTypesWithTemplates() {

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3136,6 +3136,21 @@ public final class TypeInferenceTest {
   }
 
   @Test
+  public void testTypedefsBackwardInferedFunctionsWithTemplates() {
+    inScript(
+        lines(
+             // ALL template keys will be propagated to inner types but that seems to be OK
+             // It's possible to determine keys for each inner type however it's not required  
+             "/** @typedef {!Array<(function(T):T)|string>} @template T,K */",
+             "var TestArray",
+             "const[test] = /** @type {TestArray} */([])", // not parameterised
+             "const t=test(123)"
+           ));
+
+    assertThat(getType("t").toString()).isEqualTo("number");
+  }
+
+  @Test
   public void testTypedefsConstructorFunctionsWithTemplates() {
     inScript(
         lines(

--- a/test/com/google/javascript/jscomp/TypeInferenceTest.java
+++ b/test/com/google/javascript/jscomp/TypeInferenceTest.java
@@ -3021,7 +3021,7 @@ public final class TypeInferenceTest {
 
   @Test
   public void testTypedefsTypeofsWithTemplates() {
-    // Functions are not types, but we might want to define them as such in externs via typedefs for comments 
+    // Functions are not types, but we might want to define them as such in externs via typedefs for comments
     inScript(
         lines(
              // e.g., externs
@@ -3061,7 +3061,7 @@ public final class TypeInferenceTest {
     assertThat(getType("array").toString()).isEqualTo("(Array<number>|null)");
     assertThat(getType("deep").toString()).isEqualTo("Object<symbol,(Array<number>|null)>");
   }
-  
+
   @Test
   public void testTypedefsRecursiveObjectTypesWithTemplates() {
     inScript(
@@ -3112,12 +3112,12 @@ public final class TypeInferenceTest {
   public void testTypedefsUnionsWithTemplates() {
     inScript(
         lines(
-             "/** @typedef {T|!Array<S>} @template T,S */",
+             "/** @typedef {N|!Array<S>} @template N,S */",
              "var Type",
              "const t=/** @type {Type<number,string>} */(void 5)"
            ));
 
-    assertThat(getType("t").toString()).isEqualTo("(Array<number>|string)");
+    assertThat(getType("t").toString()).isEqualTo("(Array<string>|number)");
   }
 
 
@@ -3140,7 +3140,7 @@ public final class TypeInferenceTest {
     inScript(
         lines(
              // ALL template keys will be propagated to inner types but that seems to be OK
-             // It's possible to determine keys for each inner type however it's not required  
+             // It's possible to determine keys for each inner type however it's not required
              "/** @typedef {!Array<(function(T):T)|string>} @template T,K */",
              "var TestArray",
              "const[test] = /** @type {TestArray} */([])", // not parameterised
@@ -3148,6 +3148,32 @@ public final class TypeInferenceTest {
            ));
 
     assertThat(getType("t").toString()).isEqualTo("number");
+  }
+
+  @Test
+  public void testTypedefsBackwardInferedConstructorsFromParameterizedTypesWithTemplates() {
+    inScript(
+        lines(
+             "/** @typedef {!Array<(function(new:ReadonlyArray<T>,T))|string>} @template T,K */",
+             "var TestArray",
+             "const[Test] = /** @type {TestArray<number>} */([])",
+             "const t=new Test(123)"
+           ));
+
+    assertThat(getType("t").toString()).isEqualTo("ReadonlyArray<number>");
+  }
+
+  @Test
+  public void testTypedefsBackwardInferedConstructorsWithTemplates() {
+    inScript(
+        lines(
+             "/** @typedef {!Array<(function(new:ReadonlyArray<T>,T))|string>} @template T,K */",
+             "var TestArray",
+             "const[Test] = /** @type {TestArray} */([])",
+             "const t=new Test(123)"
+           ));
+
+    assertThat(getType("t").toString()).isEqualTo("ReadonlyArray<number>");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -2662,14 +2662,6 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
   }
 
   @Test
-  public void testInvalidTemplatedTypedef2() {
-    parse(
-        "@typedef {Array<T>} \n * @template T */",
-        "Bad type annotation. Type name(s) for @template annotation declared twice."
-            + BAD_TYPE_WIKI_LINK);
-  }
-
-  @Test
   public void testParseImplements() {
     List<JSTypeExpression> interfaces =
         parse("@implements {SomeInterface}*/").getImplementedInterfaces();


### PR DESCRIPTION
Allows to add templates to typedefs, like

```js
/**
 * @typedef {Array<T>}
 * @template T
 */
var TypedList
```

Address https://github.com/google/closure-compiler/issues/890