### PR TITLE
Turn off the currently misconfigured CI steps

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,25 +36,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
-          publish_results: true
+      # - name: "Run analysis"
+      #   uses: ossf/scorecard-action@v2
+      #   with:
+      #     results_file: results.sarif
+      #     results_format: sarif
+      #     # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+      #     # - you want to enable the Branch-Protection check on a *public* repository, or
+      #     # - you are installing Scorecard on a *private* repository
+      #     # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+      #     # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+      #
+      #     # Public repositories:
+      #     #   - Publish results to OpenSSF REST API for easy access by consumers
+      #     #   - Allows the repository to include the Scorecard badge.
+      #     #   - See https://github.com/ossf/scorecard-action#publishing-results.
+      #     # For private repositories:
+      #     #   - `publish_results` will always be set to `false`, regardless
+      #     #     of the value entered here.
+      #     publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -67,8 +67,8 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
+      # # Upload the results to GitHub's code scanning dashboard.
+      # - name: "Upload to code-scanning"
+      #   uses: github/codeql-action/upload-sarif@v3
+      #   with:
+      #     sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,8 @@ on:
     - cron: '43 23 * * 6'
   push:
     branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Ideally, it would be better to fix it, but turning it off is preferrable to having an always failing CI that obscures the other checks.

Notably, the current failure is:
   Error: Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
which represents a misocnfiguration and not an actionable scorecard failure.