### PR TITLE
Replace ! in filenames when converting to JS identifiers

### DIFF
--- a/src/com/google/javascript/jscomp/deps/ModuleNames.java
+++ b/src/com/google/javascript/jscomp/deps/ModuleNames.java
@@ -62,6 +62,7 @@ public class ModuleNames {
         .replace('\\', '$')
         .replace('@', '$')
         .replace('+', '$')
+        .replace('!', '$')
         .replace('-', '_')
         .replace(':', '_')
         .replace('.', '_')

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -263,7 +263,7 @@ public final class ModuleLoaderTest {
   @Test
   public void testToJSIdentifier() {
     assertThat(ModuleNames.toJSIdentifier("com/example/test")).isEqualTo("com$example$test");
-    assertThat(ModuleNames.toJSIdentifier("file://a/b.jar!com/example/test")).isEqualTo("file_$a$b_jar$com$example$test");
+    assertThat(ModuleNames.toJSIdentifier("file://a/b.jar!com/example/test")).isEqualTo("file_$$a$b_jar$com$example$test");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -261,6 +261,12 @@ public final class ModuleLoaderTest {
   }
 
   @Test
+  public void testToJSIdentifier() {
+    assertThat(ModuleNames.toJSIdentifier("com/example/test")).isEqualTo("com$example$test");
+    assertThat(ModuleNames.toJSIdentifier("file://a/b.jar!com/example/test")).isEqualTo("file_$a$b_jar$com$example$test");
+  }
+
+  @Test
   public void testEscapePath() {
     ModuleLoader loader =
         ModuleLoader.builder()

--- a/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
+++ b/test/com/google/javascript/jscomp/deps/ModuleLoaderTest.java
@@ -263,7 +263,8 @@ public final class ModuleLoaderTest {
   @Test
   public void testToJSIdentifier() {
     assertThat(ModuleNames.toJSIdentifier("com/example/test")).isEqualTo("com$example$test");
-    assertThat(ModuleNames.toJSIdentifier("file://a/b.jar!com/example/test")).isEqualTo("file_$$a$b_jar$com$example$test");
+    assertThat(ModuleNames.toJSIdentifier("file://a/b.jar!com/example/test"))
+        .isEqualTo("file_$$a$b_jar$com$example$test");
   }
 
   @Test


### PR DESCRIPTION
When using Closure to emit ES5 code for ClojureScript, the source filename of the input code can be in a jar, such as `file:/Users/myuser/.m2/repository/org/clojure/google-closure-library/0.0-20230227-c7c0a541/google-closure-library-0.0-20230227-c7c0a541.jar!goog/log/log.js`. The `!` is not replaced when converting this filename to a JS identifier, resulting in the following input/output pair:

```
goog.log.Level = class Level { constructor() ... }
```

```
file_$Users$myuser$_m2$repository$org$clojure$google_closure_library$0_0_20201211_3e6c510d$google_closure_library_0_0_20201211_3e6c510d_jar!$goog$log$log$classdecl$var0 = function(name, value) { ...
```

Note that the variable name has `!` in it, which does not parse.

This PR adds `!` to the list of special characters to replace so that jar-sourced input files can produce legal ES5 output.