### PR TITLE
Bump protobuf-java version to 3.25.5 resolve CVE-2024-7254

### DIFF
--- a/license_check/maven_artifacts.bzl
+++ b/license_check/maven_artifacts.bzl
@@ -8,7 +8,7 @@ MAVEN_ARTIFACTS = [
     "com.google.guava:guava:32.1.2-jre",
     "com.google.guava:guava-testlib:32.1.2-jre",
     "com.google.jimfs:jimfs:1.2",
-    "com.google.protobuf:protobuf-java:3.21.12",
+    "com.google.protobuf:protobuf-java:3.25.5",
     "com.google.re2j:re2j:1.3",
     "com.google.truth.extensions:truth-liteproto-extension:1.1",
     "com.google.truth.extensions:truth-proto-extension:1.1",

--- a/maven_artifacts.bzl
+++ b/maven_artifacts.bzl
@@ -13,7 +13,7 @@ MAVEN_ARTIFACTS = [
     "com.google.guava:guava:33.0.0-jre",
     "com.google.guava:guava-testlib:33.0.0-jre",
     "com.google.jimfs:jimfs:1.2",
-    "com.google.protobuf:protobuf-java:3.25.2",
+    "com.google.protobuf:protobuf-java:3.25.5",
     "com.google.re2j:re2j:1.3",
     "com.google.truth.extensions:truth-liteproto-extension:1.4.0",
     "com.google.truth.extensions:truth-proto-extension:1.4.0",


### PR DESCRIPTION
- wasn't able to run tests locally unfortunately :grimacing:
- unsure why the license_check maven_artifacts.bzl version is so behind. I see that https://github.com/google/closure-compiler/issues/4168 is still open. Wondering if it's possible to get a maven release out with this CVE fixed at least?