### PR TITLE
Unset ANDROID_HOME in workflow to fix Android SDK loading error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: bazelbuild/setup-bazelisk@v2
 
       - name: Build and Test
-        run: bazelisk test //:all
+        run: unset ANDROID_HOME && bazelisk test //:all
 
       - name: Unsymlink Bazel Artifacts
         # upload-artifact doesn't support paths with symlinks


### PR DESCRIPTION
Attempt to fix "ERROR: Analysis of target '//:test/com/google/javascript/jscomp/disambiguate/AmbiguatePropertiesTest' failed; build aborted: Android SDK api level 32 was requested but it is not installed in the Android SDK at /usr/local/lib/android/sdk. The api levels found were [35, 34]. Please choose an available api level or install api level 32 from the Android SDK Manager." - https://github.com/google/closure-compiler/actions/runs/12412367428/job/34652003730