### PR TITLE
Switch CI to use Java 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: '11'
+          java-version: '21'
           java-package: jdk
           architecture: x64
 
@@ -146,7 +146,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: '11'
+          java-version: '21'
           java-package: jdk
           architecture: x64
 


### PR DESCRIPTION
Should fix

```
  stderr: 'Error: LinkageError occurred while loading main class com.google.javascript.jscomp.CommandLineRunner\n' +
    '\tjava.lang.UnsupportedClassVersionError: com/google/javascript/jscomp/CommandLineRunner has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0\n',
  exitCode: 1
```

from https://github.com/google/closure-compiler/actions/runs/12676540151/job/35331314620

https://github.com/google/closure-compiler/issues/4209