### PR TITLE
Add Java 21 setup to closure-compiler-npm test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,15 @@ jobs:
     needs:
       - build-and-test
     steps:
+      - name: Setup Java
+        # https://github.com/marketplace/actions/setup-java-jdk
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '21'
+          java-package: jdk
+          architecture: x64
+
       - name: Setup Node.js
         # https://github.com/marketplace/actions/setup-node-js-environment
         uses: actions/setup-node@v4


### PR DESCRIPTION
Attempting to fix CI - https://github.com/google/closure-compiler/issues/4209

Followup to https://github.com/google/closure-compiler/pull/4210.