### PR TITLE
Add SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN to SUSPICIOUS_CODE DiagnosticGroup

### DIFF
--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -492,6 +492,7 @@ public class DiagnosticGroups {
           "suspiciousCode",
           CheckDuplicateCase.DUPLICATE_CASE,
           CheckSuspiciousCode.SUSPICIOUS_SEMICOLON,
+          CheckSuspiciousCode.SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN,
           CheckSuspiciousCode.SUSPICIOUS_COMPARISON_WITH_NAN,
           CheckSuspiciousCode.SUSPICIOUS_IN_OPERATOR,
           CheckSuspiciousCode.SUSPICIOUS_INSTANCEOF_LEFT_OPERAND,


### PR DESCRIPTION
Discussion on the Closure Compiler Discuss Group: https://groups.google.com/g/closure-compiler-discuss/c/ZpsidQkqdjk

Reasoning for change: We have set `--jscomp_error suspiciousCode` in our codebase and noticed that we were getting warnings instead of errors for `SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN`. We would like this to be an error instead of a warning in line with the other `DiagnosticTypes` defined in [CheckSuspiciousCode](https://github.com/google/closure-compiler/blob/c2af98e3bd9b1f1c333b7019597eafca3d7018ad/src/com/google/javascript/jscomp/CheckSuspiciousCode.java)