### PR TITLE
Create new DiagnosticGroup for SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN

### DIFF
--- a/debian/closure-compiler.1.txt
+++ b/debian/closure-compiler.1.txt
@@ -359,6 +359,7 @@ require as a parameter a `WARNCLASS` warning class name. The following
 names are valid warning class names:
 
 * ``accessControls``
+* ``breakingOptionalChain``
 * ``checkRegExp``
 * ``checkTypes``
 * ``checkVars``

--- a/src/com/google/javascript/jscomp/DiagnosticGroups.java
+++ b/src/com/google/javascript/jscomp/DiagnosticGroups.java
@@ -120,6 +120,7 @@ public class DiagnosticGroups {
   // to parsing/ParserConfig.properties
   static final String DIAGNOSTIC_GROUP_NAMES =
       "accessControls, "
+          + "breakingOptionalChain, "
           + "checkPrototypalTypes, "
           + "checkRegExp, "
           + "checkTypes, "
@@ -499,6 +500,10 @@ public class DiagnosticGroups {
           CheckSuspiciousCode.SUSPICIOUS_NEGATED_LEFT_OPERAND_OF_IN_OPERATOR,
           ProcessCommonJSModules.SUSPICIOUS_EXPORTS_ASSIGNMENT,
           TypeCheck.DETERMINISTIC_TEST);
+
+  public static final DiagnosticGroup BREAKING_OPTIONAL_CHAIN =
+          DiagnosticGroups.registerGroup(
+                  "breakingOptionalChain", CheckSuspiciousCode.SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN);
 
   public static final DiagnosticGroup FUNCTION_PARAMS =
       DiagnosticGroups.registerGroup(

--- a/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
+++ b/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
@@ -162,6 +162,7 @@ jsdoc.annotations =\
 # This should be a subset of the list of DiagnosticGroups.
 jsdoc.suppressions =\
     accessControls,\
+    breakingOptionalChain,\
     checkDebuggerStatement,\
     checkEs5InheritanceCorrectnessConditions,\
     checkPrototypalTypes,\


### PR DESCRIPTION
Discussion on the Closure Compiler Discuss Group: https://groups.google.com/g/closure-compiler-discuss/c/ZpsidQkqdjk

### Reasoning for change: 
We have set `--jscomp_error suspiciousCode` in our codebase and noticed that we were getting warnings instead of errors for `SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN`. We would like this to be an error instead of a warning in line with the other `DiagnosticType`s defined in [CheckSuspiciousCode](https://github.com/google/closure-compiler/blob/c2af98e3bd9b1f1c333b7019597eafca3d7018ad/src/com/google/javascript/jscomp/CheckSuspiciousCode.java).  

There are concerns about adding this check to the existing `suspiciousCode` group  (see the [discussion group thread](https://groups.google.com/g/closure-compiler-discuss/c/ZpsidQkqdjk/m/rhJuKWTkAQAJ)) so I've created a new `DiagnosticGroup` with just `SUSPICIOUS_BREAKING_OUT_OF_OPTIONAL_CHAIN` so that it can be configured to be an error.