### PR TITLE
Add KeyboardEvent.prototype.isComposing, correct name for InputEvent.isComposing

### DIFF
--- a/externs/browser/w3c_event.js
+++ b/externs/browser/w3c_event.js
@@ -566,7 +566,7 @@ function InputEvent(type, opt_eventInitDict) {}
 InputEvent.prototype.data;
 
 /** @type {boolean} */
-InputEvent.prototype.isComposed;
+InputEvent.prototype.isComposing;
 
 /** @type {string} */
 InputEvent.prototype.inputType;

--- a/externs/browser/w3c_event3.js
+++ b/externs/browser/w3c_event3.js
@@ -49,6 +49,9 @@ KeyboardEvent.prototype.code;
 /** @type {string} */
 KeyboardEvent.prototype.key;
 
+/** @type {boolean} */
+KeyboardEvent.prototype.isComposing;
+
 /** @type {number} */
 KeyboardEvent.prototype.location;
 


### PR DESCRIPTION
MDN:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing
https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/isComposing
I believe isComposed was simply a typo and such property never existed (it's unrelated to the existing `composed` property of `Event`)