### PR TITLE
Update the nodejs version in the CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 env:
-  VERSION_NODEJS: '16.16.0'
+  VERSION_NODEJS: '22'
   UNSYMLINK_DIR: bazel-bin-unsymlink
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs


### PR DESCRIPTION
Update the nodejs version used during CI runs to a recent/supported versions