### PR TITLE
Fix npm CI build

### DIFF
--- a/.github/ci_support/test_closure-compiler-npm.sh
+++ b/.github/ci_support/test_closure-compiler-npm.sh
@@ -42,7 +42,7 @@ function main() {
   # The NPM repo is divided into multiple Yarn workspaces: one for each
   # variant of the compiler, including the Graal native builds. We only
   # need to test the java build.
-  yarn workspace google-closure-compiler run test --java-only --colors
+  yarn workspace google-closure-compiler run test --color
 }
 
 main "$@"

--- a/.github/ci_support/test_closure-compiler-npm.sh
+++ b/.github/ci_support/test_closure-compiler-npm.sh
@@ -42,7 +42,7 @@ function main() {
   # The NPM repo is divided into multiple Yarn workspaces: one for each
   # variant of the compiler, including the Graal native builds. We only
   # need to test the java build.
-  yarn workspace google-closure-compiler run test --color
+  yarn workspace google-closure-compiler run test --color --java-only
 }
 
 main "$@"


### PR DESCRIPTION
This PR requires https://github.com/google/closure-compiler-npm/pull/320 to be merged first.

Adds back the `--java-only` flag for CI test runs to ensure that compiler changes don't break NPM plugins.