### PR TITLE
Update npm ci script for yarn 4

### DIFF
--- a/.github/ci_support/test_closure-compiler-npm.sh
+++ b/.github/ci_support/test_closure-compiler-npm.sh
@@ -42,7 +42,7 @@ function main() {
   # The NPM repo is divided into multiple Yarn workspaces: one for each
   # variant of the compiler, including the Graal native builds. We only
   # need to test the java build.
-  yarn workspace google-closure-compiler run test --color --java-only
+  FORCE_COLOR=1 yarn workspace google-closure-compiler run test --java-only
 }
 
 main "$@"


### PR DESCRIPTION
Companion to https://github.com/google/closure-compiler-npm/pull/329

Update the CI script to remove the `--color` flag and instead use the `FORCE_COLOR=1` env variable.