### PR TITLE
WIP: Add unit test for template literal concatenation (Issue #4148)

### DIFF
--- a/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java
@@ -2217,6 +2217,35 @@ public final class PeepholeFoldConstantsTest extends CompilerTestCase {
     test("alert(12 & x & 20);", "alert(x & 4);");
   }
 
+
+  @Test
+  public void testTemplateLiteralConcat() {
+      // --- Issue #4148 core case: template + template should merge
+
+//    string + template literal (with any order)
+//    string + string (already working)
+//    template literal + template literal (template literal can include referenced variable
+//    or valid HTML)
+
+      test(
+              "const x = 'X'; console.log('pre' + `${x}`);",
+              "const x = 'X'; console.log(`pre${x}`);");
+
+      test(
+              """
+              var a = document.location.href;
+              console.log(`<h1>${a}</h1>` + `<p>The URL is ${a}.</p>`);
+              """,
+              """
+              var a = document.location.href;
+              console.log(`<h1>${a}</h1><p>The URL is ${a}.</p>`);
+              """
+      );
+
+  }
+
+
+
   private void foldBigIntTypes(String js, String expected) {
     test(
         "function f(/** @type {bigint} */ x) { " + js + " }",


### PR DESCRIPTION
This draft PR starts addressing Issue #4148 (Concatenated template literals are not merged in ADVANCED mode).

What’s in this draft:
- Adds a minimal failing unit test in PeepholeFoldConstantsTest that asserts two untagged template literals joined by `+` should be merged into a single template literal.


Next steps (planned):

- Update PeepholeFoldConstants to fix existing failing tests
- Add more tests to cover more scenarios, including:
            - string + template literal (with any order)
            - string + string (already working)
            - template literal + template literal (template literal can include referenced variable or valid HTML)


Opening early for review to validate direction before proceeding.
