### PR TITLE
Remove duplicate ExploitAssigns test

### DIFF
--- a/test/com/google/javascript/jscomp/ExploitAssignsTest.java
+++ b/test/com/google/javascript/jscomp/ExploitAssignsTest.java
@@ -34,11 +34,6 @@ public final class ExploitAssignsTest extends CompilerTestCase {
   }
 
   @Test
-  public void testExprExploitationTypes2() {
-    test("a = !0; b = !0", "b = a = !0");
-  }
-
-  @Test
   public void nullishCoalesce() {
     test("a = null; a ?? b;", "(a = null)??b");
     test("a = true; if (a ?? a) { foo(); }", "if ((a = true) ?? a) { foo() }");


### PR DESCRIPTION
The test case `test("a = !0; b = !0", "b = a = !0");` occurs in `testExprExploitationTypes2` and also above that in `testExprExploitationTypes`, on line 30:

https://github.com/google/closure-compiler/blob/c0ae6b551db8acd8b6f0407fc66985d9902dd7a5/test/com/google/javascript/jscomp/ExploitAssignsTest.java#L28-L30