### PR TITLE
Remove redundant STENCIL_INDEX constant

### DIFF
--- a/externs/browser/webgl.js
+++ b/externs/browser/webgl.js
@@ -828,9 +828,6 @@ WebGLRenderingContext.RGB565;
 WebGLRenderingContext.DEPTH_COMPONENT16;
 
 /** @const {number} */
-WebGLRenderingContext.STENCIL_INDEX;
-
-/** @const {number} */
 WebGLRenderingContext.STENCIL_INDEX8;
 
 /** @const {number} */


### PR DESCRIPTION
The constant was removed from the spec, it does not exist in browsers.

https://github.com/KhronosGroup/WebGL/pull/2370
https://github.com/KhronosGroup/WebGL/pull/2371