### PR TITLE
Switch from deprecated setup-bazelisk to setup-bazelisk

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,8 +137,15 @@ jobs:
           server-password: SONATYPE_PASSWORD_TOKEN
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Setup Bazel
-        uses: bazelbuild/setup-bazelisk@v3
+      # https://github.com/bazel-contrib/setup-bazel
+      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # v0.19.0
+        with:
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ github.workflow }}
+          # Share repository cache between workflows
+          repository-cache: true
 
       - name: Upload and Publish to Sonatype
         run: |


### PR DESCRIPTION
Resolves warning about Node 20:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may 
not work as expected: bazelbuild/setup-bazelisk@v3. Actions will be forced to run with 
Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on 
September 16th, 2026. Please check if updated versions of these actions are available that 
support Node.js 24.