### PR TITLE
Fix Atomics.waitAsync return signature

### DIFF
--- a/externs/es6.js
+++ b/externs/es6.js
@@ -2688,7 +2688,7 @@ Atomics.wait = function(typedArray, index, value, timeout) {};
  * @param {number} index
  * @param {number} value
  * @param {number=} timeout
- * @return {!Promise<string>}
+ * @return {{async: boolean, value: (string|!Promise<string>)}}
  */
 Atomics.waitAsync = function(typedArray, index, value, timeout) {};
 


### PR DESCRIPTION
- Update `Atomics.waitAsync` return signature for parity with the proposal
  - https://tc39.es/proposal-atomics-wait-async/#atomics.waitasync
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync#return_value

The current signature will cause an error when attempting to access the result object:
```
ERROR - [JSC_INEXISTENT_PROPERTY] Property value never defined on Promise<string>
```