### PR TITLE
Allow delimiter defaults in optional JSDoc parameters

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
+++ b/src/com/google/javascript/jscomp/parsing/JsDocInfoParser.java
@@ -922,7 +922,10 @@ public final class JsDocInfoParser {
               // system.
               if (JsDocToken.EQUALS == token) {
                 token = next();
-                if (JsDocToken.STRING == token) {
+                if (token != JsDocToken.RIGHT_SQUARE
+                    && token != JsDocToken.EOL
+                    && token != JsDocToken.EOC
+                    && token != JsDocToken.EOF) {
                   token = next();
                 }
               }

--- a/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest.java
@@ -5563,6 +5563,27 @@ public final class JsDocInfoParserTest extends BaseJSTypeTestCase {
   }
 
   @Test
+  public void testUnsupportedJsDocSyntaxWithDelimiterDefaultValue() {
+    for (String defaultValue : ImmutableList.of("(", ")")) {
+      JSDocInfo info =
+          parse("@param {string} [accessLevel=" + defaultValue + "] The user level */", true);
+      assertThat(info.getParameterCount()).isEqualTo(1);
+      assertTypeEquals(
+          registry.createOptionalType(STRING_TYPE), info.getParameterType("accessLevel"));
+      assertThat(info.getDescriptionForParameter("accessLevel")).isEqualTo("The user level");
+    }
+  }
+
+  @Test
+  public void testUnsupportedJsDocSyntaxWithEmptyDefaultValue() {
+    JSDocInfo info = parse("@param {string} [accessLevel=] The user level */", true);
+    assertThat(info.getParameterCount()).isEqualTo(1);
+    assertTypeEquals(
+        registry.createOptionalType(STRING_TYPE), info.getParameterType("accessLevel"));
+    assertThat(info.getDescriptionForParameter("accessLevel")).isEqualTo("The user level");
+  }
+
+  @Test
   public void testUnsupportedJsDocSyntax2() {
     JSDocInfo info =
         parse(


### PR DESCRIPTION
## Summary

- allow single-token delimiter default values in bracketed optional JSDoc parameters
- preserve the existing interpretation of `]` as the closing bracket, including empty defaults such as `[name=]`
- add regression coverage for parenthesis defaults and the empty-default compatibility case

## Root cause

The compatibility parser discarded a JSDoc Toolkit default value only when the lexer classified it as `STRING`. Parentheses are emitted as distinct tokens, so the parser left them in place and then reported a false `missing closing ]` warning.

## Validation

- `bazelisk test //:test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest --test_filter='JsDocInfoParserTest.testUnsupportedJsDocSyntax*'` (`OK (4 tests)`)
- `bazelisk test //:test/com/google/javascript/jscomp/parsing/JsDocInfoParserTest` (`OK (780 tests)`)
- `bazelisk test //:all` (431 test targets passed)
- `git diff --check`

Fixes #3767
