### PR TITLE
Don't rename a function expression's name to match a parameter shadowing it

### DIFF
--- a/src/com/google/javascript/jscomp/RenameVars.java
+++ b/src/com/google/javascript/jscomp/RenameVars.java
@@ -132,6 +132,12 @@ final class RenameVars implements CompilerPass {
   /** A prefix to distinguish temporary local names from global names */
   private static final String LOCAL_VAR_PREFIX = "L ";
 
+  /**
+   * A suffix distinguishing the temporary name of a function expression's name from the temporary
+   * name of the parameter shadowing it. See {@link #isFunctionNameShadowedByParameter}.
+   */
+  private static final String FUNCTION_NAME_SUFFIX = " fn";
+
   // Shared name generator
   private final NameGenerator nameGenerator;
 
@@ -263,11 +269,23 @@ final class RenameVars implements CompilerPass {
         return;
       }
 
+      boolean isShadowedFunctionName = isFunctionNameShadowedByParameter(n, parent, var);
+
       if (pseudoNameMap != null) {
-        recordPseudoName(n);
+        recordPseudoName(n, isShadowedFunctionName);
       }
 
-      if (local && shouldTemporarilyRenameLocalsInScope(var.getScope())) {
+      if (isShadowedFunctionName) {
+        // Give the function name a temporary name that no other variable can share, so that it is
+        // guaranteed to be renamed to something other than the parameter's name. assignNames()
+        // reserves every name it generates, so distinct temporary names never collide.
+        String tempName = LOCAL_VAR_PREFIX + getLocalVarIndex(var) + FUNCTION_NAME_SUFFIX;
+        incCount(tempName);
+        localNameNodes.add(n);
+        // Remember the original string in a name before it's temporarily filled with an "L".
+        originalNameByNode.put(n, n.getString());
+        n.setString(tempName);
+      } else if (local && shouldTemporarilyRenameLocalsInScope(var.getScope())) {
         // Give local variables a temporary name based on the
         // variable's index in the scope to enable name reuse across
         // locals in independent scopes.
@@ -289,6 +307,51 @@ final class RenameVars implements CompilerPass {
       Assignment s = assignments.computeIfAbsent(name, Assignment::new);
       s.count++;
     }
+  }
+
+  /**
+   * Whether {@code n} is the name of a function expression that one of the function's own
+   * parameters shadows, in a function that Safari would reject if the two shared a name.
+   *
+   * <p>A function expression's name and its parameters are separate bindings, but {@link
+   * SyntacticScopeCreator} merges them when a parameter declares the same name, so {@code var} is
+   * the parameter's rather than the function name's. Renaming both to the same name is
+   * semantically correct - the parameter shadows the function name throughout the function, so the
+   * function name is unreferenceable - but it preserves a construct that Safari 16 and earlier
+   * reject: those versions treat a function expression's name as an extra parameter, so they
+   * report a duplicate parameter name whenever the parameter list is non-simple. For example,
+   * {@code function a({a}) {}} fails to parse with "SyntaxError: Duplicate parameter 'a' not
+   * allowed in function with destructuring parameters".
+   *
+   * <p>See https://github.com/swc-project/swc/issues/11083 (destructuring) and
+   * https://github.com/swc-project/swc/issues/9015 (default values).
+   */
+  private static boolean isFunctionNameShadowedByParameter(Node n, Node parent, @Nullable Var var) {
+    if (!NodeUtil.isBleedingFunctionName(n)) {
+      return false;
+    }
+    // `parent` is the function expression, since that is what makes `n` a bleeding function name.
+    return var != null
+        // The name resolved to a different declaration in this function's own scope, which can
+        // only be one of its parameters.
+        && var.getNode() != n
+        && var.getScope().getRootNode() == parent
+        && hasNonSimpleParameterList(parent);
+  }
+
+  /**
+   * Whether the given function has a non-simple parameter list, i.e. one containing a destructuring
+   * pattern, a default value, or a rest parameter.
+   */
+  private static boolean hasNonSimpleParameterList(Node function) {
+    for (Node param = NodeUtil.getFunctionParameters(function).getFirstChild();
+        param != null;
+        param = param.getNext()) {
+      if (!param.isName()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -387,10 +450,13 @@ final class RenameVars implements CompilerPass {
     return null;
   }
 
-  private void recordPseudoName(Node n) {
+  private void recordPseudoName(Node n, boolean isShadowedFunctionName) {
     // Variable names should be in a different name space than
     // property pseudo names.
-    pseudoNameMap.put(n, '$' + n.getString() + "$$");
+    // A function expression's name shares its string with the parameter shadowing it, so it needs
+    // an extra marker to keep the two pseudo names apart. See
+    // isFunctionNameShadowedByParameter().
+    pseudoNameMap.put(n, '$' + n.getString() + (isShadowedFunctionName ? "$fn$$" : "$$"));
   }
 
   /**

--- a/src/com/google/javascript/jscomp/RenameVars.java
+++ b/src/com/google/javascript/jscomp/RenameVars.java
@@ -317,14 +317,14 @@ final class RenameVars implements CompilerPass {
    * SyntacticScopeCreator} merges them when a parameter declares the same name, so {@code var} is
    * the parameter's rather than the function name's. Renaming both to the same name is
    * semantically correct - the parameter shadows the function name throughout the function, so the
-   * function name is unreferenceable - but it preserves a construct that Safari 16 and earlier
-   * reject: those versions treat a function expression's name as an extra parameter, so they
-   * report a duplicate parameter name whenever the parameter list is non-simple. For example,
-   * {@code function a({a}) {}} fails to parse with "SyntaxError: Duplicate parameter 'a' not
-   * allowed in function with destructuring parameters".
+   * function name is unreferenceable - but it preserves a construct that older versions of Safari
+   * reject: they treat a function expression's name as an extra parameter, so they report a
+   * duplicate parameter name whenever the parameter list is non-simple. For example, {@code
+   * function a({a}) {}} fails to parse with "SyntaxError: Duplicate parameter 'a' not allowed in
+   * function with destructuring parameters".
    *
-   * <p>See https://github.com/swc-project/swc/issues/11083 (destructuring) and
-   * https://github.com/swc-project/swc/issues/9015 (default values).
+   * <p>See https://bugs.webkit.org/show_bug.cgi?id=220517, fixed by
+   * https://bugs.webkit.org/show_bug.cgi?id=247433.
    */
   private static boolean isFunctionNameShadowedByParameter(Node n, Node parent, @Nullable Var var) {
     if (!NodeUtil.isBleedingFunctionName(n)) {

--- a/test/com/google/javascript/jscomp/RenameVarsTest.java
+++ b/test/com/google/javascript/jscomp/RenameVarsTest.java
@@ -416,6 +416,87 @@ public final class RenameVarsTest extends CompilerTestCase {
   }
 
   @Test
+  public void testBleedingFunctionNameShadowedByObjectPatternParam() {
+    // Safari 16 and earlier incorrectly treat a function expression's own name as one of its
+    // parameters, so they reject a function whose non-simple parameter list binds that same name:
+    // "SyntaxError: Duplicate parameter 'a' not allowed in function with destructuring
+    // parameters". The function name and the parameter are separate bindings, so they must not be
+    // renamed to the same name. See https://github.com/swc-project/swc/issues/11083.
+    test(
+        """
+        var foo = function bar({bar}) { return bar; };
+        """,
+        """
+        var c = function b({bar: a}) { return a; };
+        """);
+  }
+
+  @Test
+  public void testBleedingFunctionNameShadowedByArrayPatternParam() {
+    test(
+        """
+        var foo = function bar([bar]) { return bar; };
+        """,
+        """
+        var c = function b([a]) { return a; };
+        """);
+  }
+
+  @Test
+  public void testBleedingFunctionNameShadowedByDefaultValueParam() {
+    // The same Safari bug applies to default values:
+    // "Duplicate parameter 'a' not allowed in function with default parameter values".
+    // See https://github.com/swc-project/swc/issues/9015.
+    test(
+        """
+        var foo = function bar(bar = 1) { return bar; };
+        """,
+        """
+        var c = function b(a = 1) { return a; };
+        """);
+  }
+
+  @Test
+  public void testBleedingFunctionNameShadowedByNestedPatternParam() {
+    test(
+        """
+        var foo = function bar({baz: {bar = 1, qux}}, ...quux) {
+          return bar + qux + quux;
+        };
+        """,
+        """
+        var e = function d({baz: {bar: a = 1, qux: b}}, ...c) {
+          return a + b + c;
+        };
+        """);
+  }
+
+  @Test
+  public void testBleedingFunctionNameShadowedByPatternParamWithPseudoNames() {
+    generatePseudoNames = true;
+    test(
+        """
+        var foo = function bar({bar}) { return bar; };
+        """,
+        """
+        var $foo$$ = function $bar$fn$$({bar: $bar$$}) { return $bar$$; };
+        """);
+  }
+
+  @Test
+  public void testBleedingFunctionNameShadowedBySimpleParam() {
+    // A simple parameter list does not trigger the Safari bug, so the function name and the
+    // parameter may still share a name.
+    test(
+        """
+        var foo = function bar(bar) { return bar; };
+        """,
+        """
+        var b = function a(a) { return a; };
+        """);
+  }
+
+  @Test
   public void testRenameWithExterns1() {
     String externs = "var foo;";
     test(

--- a/test/com/google/javascript/jscomp/RenameVarsTest.java
+++ b/test/com/google/javascript/jscomp/RenameVarsTest.java
@@ -417,11 +417,11 @@ public final class RenameVarsTest extends CompilerTestCase {
 
   @Test
   public void testBleedingFunctionNameShadowedByObjectPatternParam() {
-    // Safari 16 and earlier incorrectly treat a function expression's own name as one of its
+    // Older versions of Safari incorrectly treat a function expression's own name as one of its
     // parameters, so they reject a function whose non-simple parameter list binds that same name:
     // "SyntaxError: Duplicate parameter 'a' not allowed in function with destructuring
     // parameters". The function name and the parameter are separate bindings, so they must not be
-    // renamed to the same name. See https://github.com/swc-project/swc/issues/11083.
+    // renamed to the same name. See https://bugs.webkit.org/show_bug.cgi?id=220517.
     test(
         """
         var foo = function bar({bar}) { return bar; };
@@ -446,7 +446,6 @@ public final class RenameVarsTest extends CompilerTestCase {
   public void testBleedingFunctionNameShadowedByDefaultValueParam() {
     // The same Safari bug applies to default values:
     // "Duplicate parameter 'a' not allowed in function with default parameter values".
-    // See https://github.com/swc-project/swc/issues/9015.
     test(
         """
         var foo = function bar(bar = 1) { return bar; };


### PR DESCRIPTION
Older versions of Safari treat a function expression's name as one of its parameters, so they reject a function whose non-simple parameter list binds that same name:

```js
var foo = function bar({bar = baz}) { return bar; };
// output: var b = function a({bar: a = c}) { return a; };
// Safari: SyntaxError: Duplicate parameter 'a' not allowed in function with destructuring parameters
```

See https://bugs.webkit.org/show_bug.cgi?id=220517 and https://bugs.webkit.org/show_bug.cgi?id=247433.

The function name and the parameter are separate bindings, so renaming them apart is free — the parameter shadows the function name throughout the function, making the name unreferenceable.

This gives the function name its own `Assignment` when a parameter shadows it and the parameter list is non-simple. `assignNames` reserves every name it generates, so a distinct key is enough to guarantee a distinct name. Simple parameter lists are left alone, since `function a(a) {}` doesn't trigger the bug and sharing the name is cheaper.

`recordPseudoName` needed the same distinction, otherwise `--debug` output kept the collision.

Tested: `bazel test //...` — 431/431 targets pass.
