### PR TITLE
Fix: Default resolveSourceMapAnnotations to false to prevent arbitrary file read (#4322)

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -1165,8 +1165,18 @@ public class CompilerOptions {
   /**
    * Whether to resolve source mapping annotations. Cannot do this in an appengine or js environment
    * since we don't have access to the filesystem.
+   *
+   * <p>Defaults to {@code false}. When enabled, a {@code //# sourceMappingURL=} comment in
+   * compiled JS is followed to a file on the local filesystem (see {@link
+   * SourceMapResolver#extractSourceMap}), including via relative paths such as {@code
+   * ../../../../etc/passwd} that resolve outside the directory of the file being compiled. If
+   * this defaulted to {@code true}, compiling untrusted or third-party JavaScript source (e.g. in
+   * a hosted minification service or CI environment) would let the input JS trigger an arbitrary
+   * local file read with no explicit opt-in required. Callers who need to resolve source mapping
+   * annotations over source they fully trust can opt back in with {@link
+   * #setResolveSourceMapAnnotations}.
    */
-  private boolean resolveSourceMapAnnotations = true;
+  private boolean resolveSourceMapAnnotations = false;
 
   private ImmutableList<? extends SourceMap.LocationMapping> sourceMapLocationMappings =
       ImmutableList.of();

--- a/test/com/google/javascript/jscomp/CompilerOptionsTest.java
+++ b/test/com/google/javascript/jscomp/CompilerOptionsTest.java
@@ -40,6 +40,15 @@ import org.junit.runners.JUnit4;
 public final class CompilerOptionsTest {
 
   @Test
+  public void testResolveSourceMapAnnotationsDefaultsToFalse() {
+    CompilerOptions options = new CompilerOptions();
+    assertThat(options.getResolveSourceMapAnnotations()).isFalse();
+
+    options.setResolveSourceMapAnnotations(true);
+    assertThat(options.getResolveSourceMapAnnotations()).isTrue();
+  }
+
+  @Test
   public void testBrowserFeaturesetYearOptionSetsLanguageOut() {
     CompilerOptions options = new CompilerOptions();
     options.setBrowserFeaturesetYear(2012);

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -259,6 +259,7 @@ public final class CompilerTest {
   public void testInputSourceMapInline() {
     Compiler compiler = new Compiler();
     compiler.initCompilerOptionsIfTesting();
+    compiler.getOptions().setResolveSourceMapAnnotations(true);
     String code = SOURCE_MAP_TEST_CODE + "\n//# sourceMappingURL=" + BASE64_ENCODED_SOURCE_MAP;
     CompilerInput input = new CompilerInput(SourceFile.fromCode("tmp", code));
     input.getAstRoot(compiler);
@@ -290,6 +291,7 @@ public final class CompilerTest {
   public void testInputSourceMapInlineContent() {
     Compiler compiler = new Compiler();
     compiler.initCompilerOptionsIfTesting();
+    compiler.getOptions().setResolveSourceMapAnnotations(true);
     String code =
         SOURCE_MAP_TEST_CODE + "\n//# sourceMappingURL=" + BASE64_ENCODED_SOURCE_MAP_WITH_CONTENT;
     CompilerInput input = new CompilerInput(SourceFile.fromCode("tmp", code));
@@ -305,6 +307,7 @@ public final class CompilerTest {
   public void testResolveRelativeSourceMap() throws Exception {
     Compiler compiler = new Compiler();
     compiler.initCompilerOptionsIfTesting();
+    compiler.getOptions().setResolveSourceMapAnnotations(true);
     File tempDir = Files.createTempDir();
     String code = SOURCE_MAP_TEST_CODE + "\n//# sourceMappingURL=foo.js.map";
     File jsFile = new File(tempDir, "foo.js");
@@ -330,6 +333,7 @@ public final class CompilerTest {
   public void testResolveRelativeDirSourceMap() throws Exception {
     Compiler compiler = new Compiler();
     compiler.initCompilerOptionsIfTesting();
+    compiler.getOptions().setResolveSourceMapAnnotations(true);
     File tempDir = Files.createTempDir();
     File relativedir = new File(tempDir, "/relativedir");
     relativedir.mkdir();
@@ -356,6 +360,7 @@ public final class CompilerTest {
   public void testMissingSourceMapFile() throws Exception {
     Compiler compiler = new Compiler();
     compiler.initCompilerOptionsIfTesting();
+    compiler.getOptions().setResolveSourceMapAnnotations(true);
     File tempDir = Files.createTempDir();
     String code = SOURCE_MAP_TEST_CODE + "\n//# sourceMappingURL=foo-does-not-exist.js.map";
     File jsFile = new File(tempDir, "foo2.js");
@@ -434,6 +439,7 @@ public final class CompilerTest {
     options.setLanguageIn(LanguageMode.ECMASCRIPT3);
     options.setSourceMapOutputPath("fake/source_map_path.js.map");
     options.setApplyInputSourceMaps(true);
+    options.setResolveSourceMapAnnotations(true);
     options.setSourceMapIncludeSourcesContent(true);
     String code =
         SOURCE_MAP_TEST_CODE + "\n//# sourceMappingURL=" + BASE64_ENCODED_SOURCE_MAP_WITH_CONTENT;
@@ -1563,6 +1569,7 @@ public final class CompilerTest {
     // maps when running the final stage later.
     options.setAlwaysGatherSourceMapInfo(true);
     options.setApplyInputSourceMaps(true);
+    options.setResolveSourceMapAnnotations(true);
     options.setSourceMapIncludeSourcesContent(true);
     CompilationLevel.ADVANCED_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
     List<SourceFile> externs =
@@ -1650,6 +1657,7 @@ public final class CompilerTest {
     // path is stored in this field.
     options.setSourceMapOutputPath("dummy");
     options.setApplyInputSourceMaps(true);
+    options.setResolveSourceMapAnnotations(true);
     options.setSourceMapIncludeSourcesContent(true);
     CompilationLevel.ADVANCED_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
     List<SourceFile> externs =


### PR DESCRIPTION
### Summary
Fixes #4322.

Changes `CompilerOptions.resolveSourceMapAnnotations` to default to `false` instead of `true`.

### Rationale
When `resolveSourceMapAnnotations` is `true` by default, compiling untrusted JS containing a `//# sourceMappingURL=` comment causes `SourceMapResolver.extractSourceMap` to resolve local filesystem paths automatically, creating an arbitrary file read vulnerability for untrusted inputs.

Flipping this default ensures `closure-compiler` is secure-by-default when handling untrusted JS inputs, following the mitigation pattern used for CVE-2026-49356 (`@babel/core`). Callers compiling trusted code can explicitly enable resolution via `options.setResolveSourceMapAnnotations(true)`.

### Verification
- Added `testResolveSourceMapAnnotationsDefaultsToFalse` in `CompilerOptionsTest.java`.
- Ran `bazel test //:test/com/google/javascript/jscomp/CompilerOptionsTest` (PASSED).

cc @lauraharker