### PR TITLE
Fix: Attach a function name identifier to the minified symbol instead of the `function` keyword. 

### DIFF
--- a/src/com/google/javascript/jscomp/SourceMap.java
+++ b/src/com/google/javascript/jscomp/SourceMap.java
@@ -232,6 +232,19 @@ public final class SourceMap {
     if (node.getOriginalName() != null) {
       return node.getOriginalName();
     }
+    // If this is the name identifier of a function declaration/expression and the name node itself
+    // has no originalName, fall back to the enclosing FUNCTION node's originalName.
+    // This covers functions that were originally anonymous (class methods compiled to prototype
+    // assignments, `var f = function(){}` patterns): SourceInformationAnnotator skips empty-string
+    // NAME nodes but always annotates the FUNCTION node. When the renaming pass later fills in the
+    // NAME, the node's originalName remains null. The FUNCTION node's originalName is the correct
+    // original name to use.
+    if (node.isName()) {
+      Node parent = node.getParent();
+      if (parent != null && parent.isFunction() && parent.getFirstChild() == node) {
+        return parent.getOriginalName();
+      }
+    }
     if (node.isMemberFunctionDef()) {
       return node.getFirstChild().getOriginalName();
     }

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -453,6 +453,46 @@ public final class CompilerTest {
   }
 
   @Test
+  public void testSourceMapNamesCollapsedAnonymousFunctionAfterRenaming() throws Exception {
+    // `f` starts out as the name of a variable holding an anonymous function expression.
+    // CollapseAnonymousFunctions rewrites `var f = function() {...}` into `function f() {...}`
+    // before variable renaming replaces `f` with a minified name. The source map should still
+    // attach the original name "f" to the minified identifier, not to the `function` keyword.
+    CompilerOptions options = new CompilerOptions();
+    options.setEmitUseStrict(false);
+    options.setSourceMapOutputPath("dummy");
+    options.setCollapseAnonymousFunctions(true);
+    options.setVariableRenaming(VariableRenamingPolicy.ALL);
+
+    ImmutableList<SourceFile> externs =
+        ImmutableList.of(SourceFile.fromCode("externs", "function alert(x) {}"));
+    String js = "var f = function() { return 1; };\nalert(f());\n";
+    ImmutableList<SourceFile> inputs = ImmutableList.of(SourceFile.fromCode("testcode.js", js));
+    Compiler compiler = new Compiler();
+    Result result = compiler.compile(externs, inputs, options);
+
+    assertThat(result.success).isTrue();
+    // `f` was collapsed into a function declaration and then renamed to `a`.
+    String source = compiler.toSource();
+    assertThat(source).isEqualTo("function a(){return 1}alert(a());");
+
+    SourceMap sourceMap = result.sourceMap;
+    StringWriter out = new StringWriter();
+    sourceMap.appendTo(out, "testcode-compiled.js");
+    SourceMapConsumerV3 consumer = new SourceMapConsumerV3();
+    consumer.parse(out.toString());
+
+    // Column 9 (0-based) is where the minified function name `a` appears in
+    // "function a(){return 1}alert(a());".
+    OriginalMapping declMapping = consumer.getMappingForLine(1, 10);
+    assertThat(declMapping.getIdentifier()).isEqualTo("f");
+
+    // Column 28 (0-based) is where the call site `a` appears in `alert(a());`.
+    OriginalMapping callMapping = consumer.getMappingForLine(1, 29);
+    assertThat(callMapping.getIdentifier()).isEqualTo("f");
+  }
+
+  @Test
   public void testNoSourceMapIsGeneratedWithoutPath() {
     CompilerOptions options = new CompilerOptions();
     options.setLanguageIn(LanguageMode.ECMASCRIPT3);


### PR DESCRIPTION
 Source maps could lose the original name of a minified identifier for functions that started as anonymous function expressions (e.g. `var f = function() {...}`). `SourceInformationAnnotator` records the original name on the enclosing FUNCTION node but skips the (initially empty) NAME node. When `CollapseAnonymousFunctions` later fills in that NAME node as part of rewriting to `function f() {...}`, it doesn't backfill originalName — so once `RenameVars` minifies the identifier, the source map has no original name to attach to it.

` SourceMap.getOriginalName` now falls back to the enclosing FUNCTION node's originalName for this case, so the minified identifier correctly maps back to "f".

The PR adds a regression test that fails without the implemented fix.

The original purpose of this fix was to integrate with Sentry monitoring. Sourcemaps generated by closure are uploaded to Sentry using their CLI ([docs](https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/cli/)). Sentry's parsing of sourcemaps would incorrectly label or not label certain functions at all due to the issue described here. We implemented this fix on a fork and it has been working for us for several months.