### PR TITLE
Fix NPE in InlineObjectLiterals when block-scoped function shadows hoisted var (fixes #4200)

### DIFF
--- a/src/com/google/javascript/jscomp/InlineObjectLiterals.java
+++ b/src/com/google/javascript/jscomp/InlineObjectLiterals.java
@@ -82,6 +82,15 @@ class InlineObjectLiterals implements CompilerPass {
 
         ReferenceCollection referenceInfo = referenceMap.getReferences(v);
 
+        // referenceInfo is null when a Var was registered in the scope by SyntacticScopeCreator
+        // but never encountered as a NAME node during traversal (e.g., a hoist-scope binding for
+        // a block-scoped function declaration whose NAME always resolved to the closer block-scope
+        // binding, so addReference was never called for the hoist-scope Var). There is nothing to
+        // inline in that case, so skip it. See: https://github.com/google/closure-compiler/issues/4200
+        if (referenceInfo == null) {
+          continue;
+        }
+
         if (isInlinableObject(referenceInfo.references)) {
           // Skiplist the object itself, as well as any other values
           // that it refers to, since they will have been moved around.

--- a/test/com/google/javascript/jscomp/InlineObjectLiteralsTest.java
+++ b/test/com/google/javascript/jscomp/InlineObjectLiteralsTest.java
@@ -937,6 +937,29 @@ public final class InlineObjectLiteralsTest extends CompilerTestCase {
         """);
   }
 
+  // Regression test for https://github.com/google/closure-compiler/issues/4200
+  @Test
+  public void testNoCrash_issue4200_blockScopedFunctionDeclarationShadowsHoistedVar() {
+    // Root cause: SyntacticScopeCreator registers a block-scoped function declaration (inside a
+    // for-loop body) ONLY in the block scope as "x_block", and separately registers "x_hoist" in
+    // the enclosing function's hoist scope (from the `var x` declaration). Because `var x` lives
+    // inside the for-loop block, all NAME "x" visits while inside the loop resolve to x_block
+    // (the closer binding). x_hoist is therefore never passed to addReference() and is absent
+    // from the referenceMap. Without the null-check, afterExitScope would NPE when iterating
+    // x_hoist from t.getScope().getVarIterable() and calling referenceInfo.references.
+    disableNormalize();
+    testSame(
+        """
+        function f() {
+          for (;;) {
+            var x;
+            function x() {}
+            break;
+          }
+        }
+        """);
+  }
+
   private static final String LOCAL_PREFIX = "function local(){";
   private static final String LOCAL_POSTFIX = "}";
 


### PR DESCRIPTION
## Summary

Fixes #4200

`InlineObjectLiterals.InliningBehavior.afterExitScope` dereferences the `ReferenceCollection` returned by `referenceMap.getReferences(v)` without checking for null:

```java
// Before (bug)
ReferenceCollection referenceInfo = referenceMap.getReferences(v);
if (isInlinableObject(referenceInfo.references)) {

// After (fix)
ReferenceCollection referenceInfo = referenceMap.getReferences(v);
if (referenceInfo == null) {
  continue;
}
if (isInlinableObject(referenceInfo.references)) {
```

## Root Cause

`t.getScope().getVarIterable()` returns every `Var` registered by `SyntacticScopeCreator` for a scope, but `referenceMap` only contains an entry for a `Var` if at least one `NAME` reference to it was actually visited during traversal.

When a block-scoped `function` declaration shadows a hoisted `var` of the same name — e.g. `var x; function x() {}` inside the same non-hoist block — the two declarations are registered as separate `Var` objects in separate scopes. Every `NAME "x"` encountered inside the block resolves to the closer (block-scope) binding, so the hoist-scope `Var` never gets a matching reference collected via `addReference()`. `referenceMap.getReferences(v)` then returns `null` for it, and the subsequent `.references` field access throws the NPE.

`InlineVariables` already guards against exactly this case (`InlineVariables.java:687`); `InlineObjectLiterals` was missing the equivalent check.

## Reachability

This precondition — an AST holding this shadowing pattern un-normalized — does not occur in the standard `Compiler.compile()` pipeline, since `Normalize` (via `MakeDeclaredNamesUnique`) always runs before `InlineObjectLiterals` and eliminates this kind of shadowing beforehand. The original crash was found by a JQF fuzzer harness exercising this pass directly on a non-normalized AST. This fix is defense-in-depth: it makes `InlineObjectLiterals` robust against a violated precondition rather than closing a crash reachable through normal compilation.

## Verification

- Added `testNoCrash_issue4200_blockScopedFunctionDeclarationShadowsHoistedVar` to `InlineObjectLiteralsTest.java`, using `disableNormalize()` to hold the AST in the vulnerable (non-normalized) state — this shadowing pattern is otherwise eliminated by `Normalize` before this pass ever runs.
- Red/green verified locally: with the fix removed, the new test reproduces the exact reported `NullPointerException`; with the fix restored, it passes.
- Full `InlineObjectLiteralsTest` suite passes with no regressions.
- Build: `bazel test //:test/com/google/javascript/jscomp/InlineObjectLiteralsTest`