### PR TITLE
fix: prevent prototype confusion via __proto__ key in Object.fromEntries polyfill

### DIFF
--- a/src/com/google/javascript/jscomp/js/es6/object/fromentries.js
+++ b/src/com/google/javascript/jscomp/js/es6/object/fromentries.js
@@ -52,7 +52,18 @@ $jscomp.polyfill('Object.fromEntries', function(orig) {
 
       var key = pair[0];
       var val = pair[1];
-      obj[key] = val;
+      // Use Object.defineProperty to implement CreateDataPropertyOrThrow per
+      // ECMA-262 24.1.1.2 (Object.fromEntries): defining an own property on
+      // obj rather than going through a plain assignment, which would
+      // invoke an inherited setter (e.g. for a "__proto__" key) instead of
+      // creating an own property, letting a caller-supplied key/value pair
+      // reassign obj's own prototype.
+      Object.defineProperty(obj, /** @type {string|symbol} */ (key), {
+        value: val,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
 
     return obj;
@@ -60,3 +71,4 @@ $jscomp.polyfill('Object.fromEntries', function(orig) {
 
   return fromEntries;
 }, 'es_2019', 'es3');
+


### PR DESCRIPTION
`Object.fromEntries`'s polyfill assigns each key/value pair with `obj[key] = val`. When the source iterable yields a pair whose key is the string `"__proto__"`, that plain assignment invokes `Object.prototype`'s `__proto__` accessor setter instead of creating an own property — reassigning the returned object's own `[[Prototype]]` to the caller-supplied value, rather than storing it as an own `"__proto__"` property as ECMA-262 24.1.1.2's `CreateDataPropertyOrThrow` requires.

Any code that builds an object from an untrusted iterable of key/value pairs (`URLSearchParams`, parsed JSON pairs, form data, etc.) via this polyfill is affected: an attacker-supplied `["__proto__", someObject]` pair silently reassigns the resulting object's prototype, so inherited properties on `someObject` appear to be legitimate values on the returned object to any code inspecting it afterward.

This is the same defect class already fixed for `Object.getOwnPropertyDescriptors`'s polyfill in this codebase (google/closure-compiler@f32e2796f, "Fix Object.getOwnPropertyDescriptors polyfill to prevent prototype injection"), which switched to `Object.defineProperty` for the identical reason. This applies the same fix here.

Verified with a standalone Node script exercising the extracted polyfill logic — before the fix, an attacker-controlled `__proto__` key reassigns the object's prototype and inherited properties (e.g. `isAdmin`) become visible on the result; after the fix, the prototype stays `Object.prototype`, `__proto__` is stored as a normal own property (matching spec), and ordinary key/value, duplicate-key, and symbol-key behavior are all unchanged.