### PR TITLE
Optimize compiler, add controls for speed-size tradeoffs, and allow for AST as input

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,22 +2,22 @@
 #
 # Copied from https://github.com/google/j2cl/blob/master/.bazelrc since Bazel
 # doesn't support referring to .bazelrc from different workspaces.
-build --watchfs
-build --spawn_strategy=local
-build --strategy=J2cl=worker
-build --strategy=Closure=worker
+common --watchfs
+common --spawn_strategy=local
+common --strategy=J2cl=worker
+common --strategy=Closure=worker
 
 # Avoid the problem where build fails with:
 # //:compiler_unshaded.publish: $(COMPILER_VERSION) not defined.
-build --define=COMPILER_VERSION=1.0-SNAPSHOT
+common --define=COMPILER_VERSION=1.0-SNAPSHOT
 
 # Setting for running in remote CI
-build --color=yes
+common --color=yes
 
 # Enable Java 21
-build --java_runtime_version=21
-build --java_language_version=21
-build --tool_java_language_version=21
-build --tool_java_runtime_version=21
+common --java_runtime_version=21
+common --java_language_version=21
+common --tool_java_language_version=21
+common --tool_java_runtime_version=21
 
-test --test_output=errors
+common --test_output=errors

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,0 +1,3772 @@
+{
+  "lockFileVersion": 16,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/MODULE.bazel": "d1086e248cda6576862b4b3fe9ad76a214e08c189af5b42557a6e1888812c5d5",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/source.json": "1b996859f840d8efc7c720efc61dcf2a84b1261cb3974cbbe9b6666ebf567775",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.13.0/MODULE.bazel": "7c8cdea7e031b7f9f67f0b497adf6d2c6a2675e9304ca93a9af6ed84eef5a524",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/source.json": "517f2b77430084c541bc9be2db63fdcbb7102938c5f64c17ee60ffda2e5cf07b",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/source.json": "f5a28b1320e5f444e798b4afc1465c8b720bfaec7522cca38a23583dffe85e6d",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/source.json": "a8f93e4ad8843e8aa407fa5fd7c8b63a63846c0ce255371ff23384582813b13d",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/source.json": "9a3668e1ee219170e22c0e7f3ab959724c6198fdd12cd503fa10b1c6923a2559",
+    "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/source.json": "c72c61b722d7c3f884994fe647afeb2ed1ae66c437f8f370753551f7b4d8be7f",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_jar_jar/0.1.5/MODULE.bazel": "d7af63ea4ca3d0a9a5ce40ede2601e275d55b3331034b8910857e143b38fdd9f",
+    "https://bcr.bazel.build/modules/bazel_jar_jar/0.1.5/source.json": "7196b6ef33c41e8c1a977a395f9d32d5745ea1d78d65b9eec607f7fa7dac8ea4",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gazelle/0.27.0/MODULE.bazel": "3446abd608295de6d90b4a8a118ed64a9ce11dcb3dda2dc3290a22056bd20996",
+    "https://bcr.bazel.build/modules/gazelle/0.30.0/MODULE.bazel": "f888a1effe338491f35f0e0e85003b47bb9d8295ccba73c37e07702d8d31c65b",
+    "https://bcr.bazel.build/modules/gazelle/0.30.0/source.json": "7af0779f99120aafc73be127615d224f26da2fc5a606b52bdffb221fd9efb737",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/source.json": "dbdda654dcb3a0d7a8bc5d0ac5fc7e150b58c2a986025ae5bc634bb2cb61f470",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/protobuf/30.2/MODULE.bazel": "6b8b37f8390fbaf9bee5eed558697238082fab658a8a8996328628292ae79d2e",
+    "https://bcr.bazel.build/modules/protobuf/30.2/source.json": "7d7f541c637b49edbefa5aeca2cc365f2e3edac8d75fedb448d68ea003d9ded7",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/source.json": "547d0111a9d4f362db32196fef805abbf3676e8d6afbe44d395d87816c1130ca",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.13.0/MODULE.bazel": "b4559a2c6281ca3165275bb36c1f0ac74666632adc5bdb680e366de7ce845f43",
+    "https://bcr.bazel.build/modules/rules_apple/3.13.0/source.json": "fe31c678e2256daa91a802664b578c1de71dc43a49a7ccc16db001378f312cd3",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/source.json": "021363d254f7438f3f10725355969c974bb2c67e0c28667782ade31a9cdb747f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
+    "https://bcr.bazel.build/modules/rules_go/0.33.0/MODULE.bazel": "a2b11b64cd24bf94f57454f53288a5dacfe6cb86453eee7761b7637728c1910c",
+    "https://bcr.bazel.build/modules/rules_go/0.38.1/MODULE.bazel": "fb8e73dd3b6fc4ff9d260ceacd830114891d49904f5bda1c16bc147bcc254f71",
+    "https://bcr.bazel.build/modules/rules_go/0.39.1/MODULE.bazel": "d34fb2a249403a5f4339c754f1e63dc9e5ad70b47c5e97faee1441fc6636cd61",
+    "https://bcr.bazel.build/modules/rules_go/0.39.1/source.json": "f21e042154010ae2c944ab230d572b17d71cdb27c5255806d61df6ccaed4354c",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.3.1/MODULE.bazel": "5a3471c8b84d53d58d5f6e316313680d7dd2c70afac696dbe14b761b0b5c6a06",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.6/MODULE.bazel": "153042249c7060536dc95b6bb9f9bb8063b8a0b0cb7acdb381bddbc2374aed55",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.6/source.json": "b1d7ffc3877e5a76e6e48e6bce459cbb1712c90eba14861b112bd299587a534d",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/0.0.8/MODULE.bazel": "5669c6fe49b5134dbf534db681ad3d67a2d49cfc197e4a95f1ca2fd7f3aebe96",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.1.0/MODULE.bazel": "9db8031e71b6ef32d1846106e10dd0ee2deac042bd9a2de22b4761b0c3036453",
+    "https://bcr.bazel.build/modules/rules_pkg/1.1.0/source.json": "fef768df13a92ce6067e1cd0cdc47560dace01354f1d921cfb1d632511f7d608",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/source.json": "b0162a65c6312e45e7912e39abd1a7f8856c2c7e41ecc9b6dc688a6f6400a917",
+    "https://bcr.bazel.build/modules/rules_rust/0.51.0/MODULE.bazel": "2b6d1617ac8503bfdcc0e4520c20539d4bba3a691100bee01afe193ceb0310f9",
+    "https://bcr.bazel.build/modules/rules_rust/0.51.0/source.json": "79a530199d9826a93b31d05b7d9b39dc753a80f88856d3ca5376f665a82cc5e6",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
+    "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "okb7JAyJ9zeL+SDmtbWT0XBLq8WRoLJ0zWAG783RLVI=",
+        "usagesDigest": "xv9z2c7OWE3Yp+Azbwv1ImqlF3yAZhfTG5FR1K+/isk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc_toolchains": {
+            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          },
+          "local_config_apple_cc": {
+            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ]
+        ]
+      }
+    },
+    "@@aspect_bazel_lib+//lib:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "TGnRoh+5JjQRL6rkWCQneJpM89XjhPyydRXWIn0HmDw=",
+        "usagesDigest": "HyCD/AMcHKcynL86oRSbi4rhw9cjPb8yfXrC363gBKE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "copy_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_directory"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "jq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.6"
+            }
+          },
+          "jq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_host_alias_repo",
+            "attributes": {}
+          },
+          "jq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.25.2"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_host_alias_repo",
+            "attributes": {}
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "expand_template_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "expand_template_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "expand_template_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "expand_template_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "expand_template_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "expand_template_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "expand_template_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "expand_template"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@platforms//host:extension.bzl%host_platform": {
+      "general": {
+        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
+        "usagesDigest": "SeQiIN/f8/Qt9vYQk7qcXp4I4wJeEC0RnQDiaaJ4tb8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "host_platform": {
+            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_buf+//buf:extensions.bzl%ext": {
+      "general": {
+        "bzlTransitiveDigest": "3jGepUu1j86kWsTP3Fgogw/XfktHd4UIQt8zj494n/Y=",
+        "usagesDigest": "RTc2BMQ2b0wGU8CRvN3EoPz34m3LMe+K/oSkFkN83+M=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_buf_toolchains": {
+            "repoRuleId": "@@rules_buf+//buf/internal:toolchain.bzl%buf_download_releases",
+            "attributes": {
+              "version": "v1.27.0"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_buf+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "general": {
+        "bzlTransitiveDigest": "GI0gnOeyAURBWF+T+482mWnxAoSjspZNDIVvAHGR7Yk=",
+        "usagesDigest": "G0DymwAVABR+Olml5OAfLhVRqUVCU372GHdSQxQ1PJw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "go_default_sdk": {
+            "repoRuleId": "@@rules_go+//go/private:sdk.bzl%go_download_sdk_rule",
+            "attributes": {
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.19.8"
+            }
+          },
+          "go_toolchains": {
+            "repoRuleId": "@@rules_go+//go/private:sdk.bzl%go_multiple_toolchains",
+            "attributes": {
+              "prefixes": [
+                "_0000_go_default_sdk_"
+              ],
+              "geese": [
+                ""
+              ],
+              "goarchs": [
+                ""
+              ],
+              "sdk_repos": [
+                "go_default_sdk"
+              ],
+              "sdk_types": [
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.19.8"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_go+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
+        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_nodejs+//nodejs:extensions.bzl%node": {
+      "general": {
+        "bzlTransitiveDigest": "btnelILPo3ngQN9vWtsQMclvJZPf3X2vcGTjmW7Owy8=",
+        "usagesDigest": "CtwJeycIo1YVyKAUrO/7bkpB6yqctQd8XUnRtqUbwRI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nodejs_linux_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_s390x": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_s390x",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_ppc64le": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_windows_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "windows_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_host": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_toolchains": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_nodejs+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_nodejs+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust+//rust:extensions.bzl%rust": {
+      "general": {
+        "bzlTransitiveDigest": "OciETRsKBMlTOGLtSrO/VkogJGlAo/7ecKIMwc0VYlY=",
+        "usagesDigest": "ozx08ZbgRXTJw0zCaO/xtMUzgGLvwaQkZGnUo6tlyHM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rust_analyzer_1.81.0_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_analyzer_toolchain_tools_repository",
+            "attributes": {
+              "version": "1.81.0",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_analyzer_1.81.0": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_analyzer_1.81.0_tools//:rust_analyzer_toolchain",
+              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
+              "exec_compatible_with": [],
+              "target_compatible_with": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-apple-darwin",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-apple-darwin",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_aarch64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_darwin_aarch64__aarch64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_aarch64__aarch64-apple-darwin__nightly//:toolchain",
+                "@rust_darwin_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_darwin_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_darwin_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-apple-darwin"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-pc-windows-msvc",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-pc-windows-msvc",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_aarch64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly//:toolchain",
+                "@rust_windows_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_windows_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_windows_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_windows_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-pc-windows-msvc"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_aarch64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "s390x-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "s390x-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_s390x": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_s390x__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_s390x__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_s390x__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_s390x__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "s390x-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-apple-darwin",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-apple-darwin",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_darwin_x86_64__x86_64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_x86_64__x86_64-apple-darwin__nightly//:toolchain",
+                "@rust_darwin_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_darwin_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_darwin_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-apple-darwin"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-pc-windows-msvc",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-pc-windows-msvc",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly//:toolchain",
+                "@rust_windows_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_windows_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_windows_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_windows_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-pc-windows-msvc"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-freebsd",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-freebsd",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable//:toolchain",
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-freebsd"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_toolchains": {
+            "repoRuleId": "@@rules_rust+//rust/private:repository_utils.bzl%toolchain_repository_hub",
+            "attributes": {
+              "toolchain_names": [
+                "rust_analyzer_1.81.0",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_darwin_aarch64__wasm32-wasi__stable",
+                "rust_darwin_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_windows_aarch64__wasm32-wasi__stable",
+                "rust_windows_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_linux_aarch64__wasm32-wasi__stable",
+                "rust_linux_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly",
+                "rust_linux_s390x__wasm32-wasi__stable",
+                "rust_linux_s390x__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_darwin_x86_64__wasm32-wasi__stable",
+                "rust_darwin_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_windows_x86_64__wasm32-wasi__stable",
+                "rust_windows_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_freebsd_x86_64__wasm32-wasi__stable",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_linux_x86_64__wasm32-wasi__stable",
+                "rust_linux_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu"
+              ],
+              "toolchain_labels": {
+                "rust_analyzer_1.81.0": "@rust_analyzer_1.81.0_tools//:rust_analyzer_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__nightly": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-wasi__nightly": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-wasi__nightly": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": "@rust_linux_s390x__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": "@rust_linux_s390x__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-wasi__stable": "@rust_linux_s390x__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-wasi__nightly": "@rust_linux_s390x__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__nightly": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-wasi__nightly": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-wasi__nightly": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
+              },
+              "toolchain_types": {
+                "rust_analyzer_1.81.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
+              },
+              "exec_compatible_with": {
+                "rust_analyzer_1.81.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-wasi__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-wasi__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ]
+              },
+              "target_compatible_with": {
+                "rust_analyzer_1.81.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_s390x__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_s390x__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [],
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/src/com/google/debugging/sourcemap/SourceMapGenerator.java
+++ b/src/com/google/debugging/sourcemap/SourceMapGenerator.java
@@ -28,6 +28,15 @@ import org.jspecify.annotations.Nullable;
 public interface SourceMapGenerator {
 
   /**
+   * Returns an independent snapshot that may share immutable data with this generator.
+   *
+   * @throws UnsupportedOperationException if this generator does not support snapshots
+   */
+  default SourceMapGenerator snapshot() {
+    throw new UnsupportedOperationException("This source map generator cannot be snapshotted");
+  }
+
+  /**
    * Appends the source map to the given buffer.
    *
    * @param out The stream to which the map will be appended.

--- a/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
+++ b/src/com/google/debugging/sourcemap/SourceMapGeneratorV3.java
@@ -79,8 +79,8 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
   /**
    * A map of source names to source file contents
    */
-  private final LinkedHashMap<String, String> sourceFileContentMap =
-       new LinkedHashMap<>();
+  private LinkedHashMap<String, String> sourceFileContentMap = new LinkedHashMap<>();
+  private boolean sourceFileContentMapShared = false;
 
   /**
    * A map of source names to source name index
@@ -124,6 +124,21 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
    * on the source entry.
    */
   private String sourceRootPath;
+
+  @Override
+  public SourceMapGeneratorV3 snapshot() {
+    SourceMapGeneratorV3 snapshot = new SourceMapGeneratorV3();
+    this.sourceFileContentMapShared = true;
+    snapshot.sourceFileContentMap = this.sourceFileContentMap;
+    snapshot.sourceFileContentMapShared = true;
+    snapshot.mappings.addAll(this.mappings);
+    snapshot.lastMapping = this.lastMapping;
+    snapshot.offsetPosition = this.offsetPosition;
+    snapshot.prefixPosition = this.prefixPosition;
+    snapshot.sourceRootPath = this.sourceRootPath;
+    snapshot.extensions.putAll(this.extensions);
+    return snapshot;
+  }
 
   /**
    * {@inheritDoc}
@@ -264,6 +279,10 @@ public final class SourceMapGeneratorV3 implements SourceMapGenerator {
   }
 
   @Override public void addSourcesContent(String source, String content) {
+    if (sourceFileContentMapShared) {
+      sourceFileContentMap = new LinkedHashMap<>(sourceFileContentMap);
+      sourceFileContentMapShared = false;
+    }
     sourceFileContentMap.put(source, content);
   }
 

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1550,13 +1550,19 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
         }
       } else {
         long outputStartNanos = System.nanoTime();
+        long[] outputPhaseNanos = new long[2];
         DiagnosticType error;
         try {
-          error = outputChunkBinaryAndSourceMaps(compiler.getChunkGraph(), options);
+          error =
+              outputChunkBinaryAndSourceMaps(
+                  compiler.getChunkGraph(), options, outputPhaseNanos);
         } finally {
+          long outputNanos = System.nanoTime() - outputStartNanos;
+          compiler.recordPassRuntime("outputChunkCode", outputPhaseNanos[0] / 1_000_000);
+          compiler.recordPassRuntime("outputChunkSourceMaps", outputPhaseNanos[1] / 1_000_000);
           compiler.recordPassRuntime(
-              "outputChunkBinaryAndSourceMaps",
-              (System.nanoTime() - outputStartNanos) / 1_000_000);
+              "outputChunkIoAndSetup",
+              (outputNanos - outputPhaseNanos[0] - outputPhaseNanos[1]) / 1_000_000);
         }
         if (error != null) {
           compiler.report(JSError.make(error));
@@ -1672,7 +1678,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
   }
 
   private @Nullable DiagnosticType outputChunkBinaryAndSourceMaps(
-      JSChunkGraph chunkGraph, B options) throws IOException {
+      JSChunkGraph chunkGraph, B options, long[] outputPhaseNanos) throws IOException {
     Iterable<JSChunk> chunks = chunkGraph.getAllChunks();
     parsedChunkWrappers = parseChunkWrappers(config.chunkWrapper, chunks);
     if (!isOutputInJson()) {
@@ -1715,9 +1721,13 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
             compiler.resetAndIntitializeSourceMap();
           }
           mlicenseTracker.setCurrentChunkContext(m);
+          long codeStartNanos = System.nanoTime();
           writeChunkOutput(chunkFilename, writer, mlicenseTracker, m);
+          outputPhaseNanos[0] += System.nanoTime() - codeStartNanos;
           if (options.shouldGatherSourceMapInfo()) {
+            long sourceMapStartNanos = System.nanoTime();
             compiler.getSourceMap().appendTo(mapFileOut, chunkFilename);
+            outputPhaseNanos[1] += System.nanoTime() - sourceMapStartNanos;
           }
         }
 

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1624,6 +1624,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
       outputInstrumentationMapping();
 
       outputInputReductionReport();
+      outputOptimizationWorkReport(options);
 
       if (isOutputInJson()) {
         outputJsonStream();
@@ -1682,6 +1683,19 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
             .append(inputName.replace('\t', ' ').replace('\n', ' '))
             .append('\n');
       }
+    }
+  }
+
+  private void outputOptimizationWorkReport(B options) throws IOException {
+    if (config.outputOptimizationWorkReport.isEmpty()) {
+      return;
+    }
+    OptimizationWorkReporter reporter =
+        checkNotNull(options.getOptimizationWorkReporter(), "optimization work reporter");
+    maybeCreateDirsForPath(config.outputOptimizationWorkReport);
+    try (Writer writer =
+        checkNotNull(fileNameToOutputWriter2(config.outputOptimizationWorkReport))) {
+      reporter.write(writer);
     }
   }
 
@@ -3037,10 +3051,19 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
 
     private String outputInputReductionReport = "";
 
+    private String outputOptimizationWorkReport = "";
+
     /** Sets the path for a report comparing each input's initial and final AST size. */
     @CanIgnoreReturnValue
     public CommandLineConfig setOutputInputReductionReport(String outputInputReductionReport) {
       this.outputInputReductionReport = outputInputReductionReport;
+      return this;
+    }
+
+    /** Sets the path for a report attributing expensive optimizer work to source functions. */
+    @CanIgnoreReturnValue
+    public CommandLineConfig setOutputOptimizationWorkReport(String outputOptimizationWorkReport) {
+      this.outputOptimizationWorkReport = outputOptimizationWorkReport;
       return this;
     }
 

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -72,6 +72,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
@@ -1779,6 +1780,23 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
   }
 
   private @Nullable DiagnosticType outputChunkBinaryAndSourceMaps(
+      JSChunkGraph chunkGraph, B options, long[] outputPhaseNanos) throws IOException {
+    try {
+      return compiler.runInCompilerThread(
+          () -> {
+            try {
+              return outputChunkBinaryAndSourceMapsOnCompilerThread(
+                  chunkGraph, options, outputPhaseNanos);
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          });
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private @Nullable DiagnosticType outputChunkBinaryAndSourceMapsOnCompilerThread(
       JSChunkGraph chunkGraph, B options, long[] outputPhaseNanos) throws IOException {
     Iterable<JSChunk> chunks = chunkGraph.getAllChunks();
     parsedChunkWrappers = parseChunkWrappers(config.chunkWrapper, chunks);

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -2014,8 +2014,11 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     }
     ImmutableSet<String> licensedSources = compiler.getLicensedSourceNamesForOutput();
 
+    // Keep enough work queued to prevent a large early chunk from leaving the other workers idle
+    // while preserving a bound on completed code and source maps retained before they are written.
+    int pendingLimit = min(parallelism * 4, outputChunks.size());
     int nextChunk = 0;
-    while (nextChunk < min(parallelism, outputChunks.size())) {
+    while (nextChunk < pendingLimit) {
       JSChunk chunk = outputChunks.get(nextChunk++);
       pending.addLast(
           submitConcurrentChunkOutput(

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -201,6 +201,8 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
 
   private @Nullable ImmutableMap<String, String> parsedChunkConformanceFiles = null;
 
+  private ImmutableMap<String, Integer> initialInputAstSizes = ImmutableMap.of();
+
   private final Gson gson;
 
   static final String OUTPUT_MARKER = "%output%";
@@ -1341,6 +1343,10 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     // Parse, restore from a save file, or initialize from a TypedAST list.
     initializeStateBeforeCompilation();
 
+    if (!config.outputInputReductionReport.isEmpty()) {
+      initialInputAstSizes = countAstNodesBySourceFile();
+    }
+
     // Do the interesting work - checks, optimizations, etc.
     runCompilerPasses(metricsRecorder);
 
@@ -1353,6 +1359,24 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     // Perform post-compilation tasks even if compiler.hasErrors(). The command-line runner emits
     // normal outputs afterward, so delay its tracer report until those outputs are recorded too.
     compiler.performPostCompilationTasksWithoutTracerReport();
+  }
+
+  private ImmutableMap<String, Integer> countAstNodesBySourceFile() {
+    Map<String, Integer> nodeCounts = new LinkedHashMap<>();
+    Node jsRoot = compiler.getJsRoot();
+    if (jsRoot == null) {
+      return ImmutableMap.of();
+    }
+    for (Node node : NodeUtil.preOrderIterable(jsRoot)) {
+      if (node.isRoot() || node.isScript()) {
+        continue;
+      }
+      String sourceName = node.getSourceFileName();
+      if (sourceName != null) {
+        nodeCounts.merge(sourceName, 1, Integer::sum);
+      }
+    }
+    return ImmutableMap.copyOf(nodeCounts);
   }
 
   private void runCompilerPasses(CompileMetricsRecorderInterface metricsRecorder) {
@@ -1599,12 +1623,66 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
       // Output the production instrumentation param mapping if requested.
       outputInstrumentationMapping();
 
+      outputInputReductionReport();
+
       if (isOutputInJson()) {
         outputJsonStream();
       }
     }
 
     return getExitStatusForResult(result);
+  }
+
+  private void outputInputReductionReport() throws IOException {
+    if (config.outputInputReductionReport.isEmpty()) {
+      return;
+    }
+
+    ImmutableMap<String, Integer> finalInputAstSizes = countAstNodesBySourceFile();
+    List<CompilerInput> inputs = new ArrayList<>();
+    compiler.getInputsInOrder().forEach(inputs::add);
+    inputs.sort(
+        (left, right) -> {
+          String leftName = left.getName();
+          String rightName = right.getName();
+          int leftInitial = initialInputAstSizes.getOrDefault(leftName, 0);
+          int rightInitial = initialInputAstSizes.getOrDefault(rightName, 0);
+          int leftRemoved = leftInitial - finalInputAstSizes.getOrDefault(leftName, 0);
+          int rightRemoved = rightInitial - finalInputAstSizes.getOrDefault(rightName, 0);
+          int byRemovedNodes = Integer.compare(rightRemoved, leftRemoved);
+          if (byRemovedNodes != 0) {
+            return byRemovedNodes;
+          }
+          int byInitialNodes = Integer.compare(rightInitial, leftInitial);
+          return byInitialNodes != 0 ? byInitialNodes : leftName.compareTo(rightName);
+        });
+
+    maybeCreateDirsForPath(config.outputInputReductionReport);
+    try (Writer writer =
+        checkNotNull(fileNameToOutputWriter2(config.outputInputReductionReport))) {
+      writer.append(
+          "input_bytes\tinput_lines\tinitial_ast_nodes\tfinal_ast_nodes\t"
+              + "removed_ast_nodes\tinput\n");
+      for (CompilerInput input : inputs) {
+        String inputName = input.getName();
+        int initialNodes = initialInputAstSizes.getOrDefault(inputName, 0);
+        int finalNodes = finalInputAstSizes.getOrDefault(inputName, 0);
+        SourceFile sourceFile = input.getSourceFile();
+        writer
+            .append(Integer.toString(sourceFile.getNumBytes()))
+            .append('\t')
+            .append(Integer.toString(sourceFile.getNumLines()))
+            .append('\t')
+            .append(Integer.toString(initialNodes))
+            .append('\t')
+            .append(Integer.toString(finalNodes))
+            .append('\t')
+            .append(Integer.toString(initialNodes - finalNodes))
+            .append('\t')
+            .append(inputName.replace('\t', ' ').replace('\n', ' '))
+            .append('\n');
+      }
+    }
   }
 
   private static int getExitStatusForResult(Result result) {
@@ -2956,6 +3034,15 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     }
 
     private List<String> outputManifests = ImmutableList.of();
+
+    private String outputInputReductionReport = "";
+
+    /** Sets the path for a report comparing each input's initial and final AST size. */
+    @CanIgnoreReturnValue
+    public CommandLineConfig setOutputInputReductionReport(String outputInputReductionReport) {
+      this.outputInputReductionReport = outputInputReductionReport;
+      return this;
+    }
 
     /** Sets whether to print output manifest files. Filter out empty file names. */
     @CanIgnoreReturnValue

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -76,6 +76,7 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -1086,6 +1087,27 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
       @Nullable Function<String, String> escaper,
       String filename)
       throws IOException {
+    writeOutput(
+        out,
+        compiler,
+        code,
+        wrapper,
+        codePlaceholder,
+        escaper,
+        filename,
+        compiler == null ? null : compiler.getSourceMap());
+  }
+
+  private void writeOutput(
+      Appendable out,
+      Compiler compiler,
+      String code,
+      String wrapper,
+      String codePlaceholder,
+      @Nullable Function<String, String> escaper,
+      String filename,
+      @Nullable SourceMap outputSourceMap)
+      throws IOException {
     int pos = wrapper.indexOf(codePlaceholder);
     if (pos != -1) {
       String prefix = "";
@@ -1108,8 +1130,8 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
 
       // If we have a source map, adjust its offsets to match
       // the code WITHIN the wrapper.
-      if (compiler != null && compiler.getSourceMap() != null) {
-        compiler.getSourceMap().setWrapperPrefix(prefix);
+      if (outputSourceMap != null) {
+        outputSourceMap.setWrapperPrefix(prefix);
       }
     } else {
       out.append(code);
@@ -1816,6 +1838,10 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     }
 
     ChunkGraphAwareLicenseTracker mlicenseTracker = new ChunkGraphAwareLicenseTracker(compiler);
+    if (!isOutputInJson() && options.getNumParallelThreads() > 1) {
+      return outputChunksConcurrently(
+          chunks, options, outputPhaseNanos, mlicenseTracker);
+    }
     // Code generation mutates shared compiler state, but completed source maps can be serialized
     // independently while the main thread generates the next chunk.
     boolean parallelSourceMaps =
@@ -1904,6 +1930,219 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
       }
     }
     return null;
+  }
+
+  private static final class PendingChunkOutput {
+    final JSChunk chunk;
+    final Future<ConcurrentChunkOutput> output;
+
+    PendingChunkOutput(JSChunk chunk, Future<ConcurrentChunkOutput> output) {
+      this.chunk = chunk;
+      this.output = output;
+    }
+  }
+
+  private static final class ConcurrentChunkOutput {
+    final Compiler.@Nullable GeneratedChunkOutput generated;
+    final @Nullable String preassembledCode;
+    final @Nullable SourceMap sourceMap;
+
+    ConcurrentChunkOutput(
+        Compiler.@Nullable GeneratedChunkOutput generated,
+        @Nullable String preassembledCode,
+        @Nullable SourceMap sourceMap) {
+      this.generated = generated;
+      this.preassembledCode = preassembledCode;
+      this.sourceMap = sourceMap;
+    }
+  }
+
+  private static final LicenseTracker NO_LICENSE_TRACKER =
+      new LicenseTracker() {
+        @Override
+        public void trackLicensesForNode(Node node) {}
+
+        @Override
+        public ImmutableSet<String> emitLicenses() {
+          return ImmutableSet.of();
+        }
+      };
+
+  /**
+   * Generates immutable chunk code/mapping results concurrently, then replays license decisions
+   * and assembles outputs in dependency order. Compiler passes have finished before this method is
+   * called, so worker threads only read AST and option state.
+   */
+  private @Nullable DiagnosticType outputChunksConcurrently(
+      Iterable<JSChunk> chunks,
+      B options,
+      long[] outputPhaseNanos,
+      ChunkGraphAwareLicenseTracker licenseTracker)
+      throws IOException {
+    int parallelism = options.getNumParallelThreads();
+    ExecutorService codeExecutor =
+        Executors.newFixedThreadPool(
+            parallelism,
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-CodeOutput");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ExecutorService sourceMapExecutor =
+        options.shouldGatherSourceMapInfo()
+            ? Executors.newFixedThreadPool(
+                parallelism,
+                runnable -> {
+                  Thread thread = new Thread(runnable, "jscompiler-SourceMapOutput");
+                  thread.setDaemon(true);
+                  return thread;
+                })
+            : null;
+    List<Future<Long>> sourceMapOutputs = new ArrayList<>();
+    ArrayDeque<PendingChunkOutput> pending = new ArrayDeque<>();
+    List<JSChunk> outputChunks = new ArrayList<>();
+    for (JSChunk chunk : chunks) {
+      if (!chunk.getName().equals(JSChunk.WEAK_CHUNK_NAME)) {
+        outputChunks.add(chunk);
+      }
+    }
+
+    @Nullable SourceMap sourceMapTemplate = null;
+    if (options.shouldGatherSourceMapInfo()) {
+      compiler.resetAndIntitializeSourceMap();
+      sourceMapTemplate = compiler.snapshotSourceMap();
+    }
+    ImmutableSet<String> licensedSources = compiler.getLicensedSourceNamesForOutput();
+
+    int nextChunk = 0;
+    while (nextChunk < min(parallelism, outputChunks.size())) {
+      JSChunk chunk = outputChunks.get(nextChunk++);
+      pending.addLast(
+          submitConcurrentChunkOutput(
+              codeExecutor, chunk, sourceMapTemplate, licensedSources));
+    }
+
+    boolean outputCompleted = false;
+    try {
+      while (!pending.isEmpty()) {
+        PendingChunkOutput next = pending.removeFirst();
+        if (nextChunk < outputChunks.size()) {
+          JSChunk chunk = outputChunks.get(nextChunk++);
+          pending.addLast(
+              submitConcurrentChunkOutput(
+                  codeExecutor, chunk, sourceMapTemplate, licensedSources));
+        }
+
+        ConcurrentChunkOutput generated;
+        try {
+          generated = next.output.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while generating chunk output", e);
+        } catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          if (cause instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+          }
+          if (cause instanceof Error error) {
+            throw error;
+          }
+          throw new RuntimeException(cause);
+        }
+
+        JSChunk chunk = next.chunk;
+        String chunkFilename = getChunkOutputFileName(chunk);
+        maybeCreateDirsForPath(chunkFilename);
+        licenseTracker.setCurrentChunkContext(chunk);
+        SourceMap chunkSourceMap = generated.sourceMap;
+        String code = generated.preassembledCode;
+        if (code == null) {
+          code =
+              compiler.assembleGeneratedChunkOutput(
+                  checkNotNull(generated.generated), licenseTracker, chunkSourceMap);
+        }
+        String baseName = new File(chunkFilename).getName();
+        String wrapper =
+            parsedChunkWrappers.get(chunk.getName()).replace("%basename%", baseName);
+        try (Writer writer = fileNameToLegacyOutputWriter(chunkFilename)) {
+          writeOutput(
+              writer,
+              compiler,
+              code,
+              wrapper,
+              "%s",
+              null,
+              chunkFilename,
+              chunkSourceMap);
+        }
+
+        if (chunkSourceMap != null) {
+          String sourceMapFilename = expandSourceMapPath(options, chunk);
+          sourceMapOutputs.add(
+              checkNotNull(sourceMapExecutor)
+                  .submit(
+                      () -> {
+                        long sourceMapStartNanos = System.nanoTime();
+                        try (Writer mapFileOut = fileNameToOutputWriter2(sourceMapFilename)) {
+                          chunkSourceMap.appendTo(mapFileOut, chunkFilename);
+                        }
+                        return System.nanoTime() - sourceMapStartNanos;
+                      }));
+        }
+      }
+
+      codeExecutor.shutdown();
+      if (sourceMapExecutor != null) {
+        sourceMapExecutor.shutdown();
+      }
+      for (Future<Long> sourceMapOutput : sourceMapOutputs) {
+        try {
+          outputPhaseNanos[1] += sourceMapOutput.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while writing source maps", e);
+        } catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          if (cause instanceof IOException ioException) {
+            throw ioException;
+          }
+          throw new RuntimeException(cause);
+        }
+      }
+      outputPhaseNanos[2] = 1;
+      outputCompleted = true;
+      return null;
+    } finally {
+      if (!outputCompleted) {
+        codeExecutor.shutdownNow();
+        if (sourceMapExecutor != null) {
+          sourceMapExecutor.shutdownNow();
+        }
+      }
+    }
+  }
+
+  private PendingChunkOutput submitConcurrentChunkOutput(
+      ExecutorService codeExecutor,
+      JSChunk chunk,
+      @Nullable SourceMap sourceMapTemplate,
+      ImmutableSet<String> licensedSources) {
+    Compiler.PreparedChunkOutput prepared = compiler.prepareChunkOutput(chunk);
+    SourceMap sourceMap = sourceMapTemplate == null ? null : sourceMapTemplate.snapshot();
+    return new PendingChunkOutput(
+        chunk,
+        codeExecutor.submit(
+            () -> {
+              Compiler.GeneratedChunkOutput generated =
+                  compiler.generatePreparedChunkOutput(prepared, licensedSources);
+              String preassembledCode =
+                  generated.hasLicenseNodes()
+                      ? null
+                      : compiler.assembleGeneratedChunkOutput(
+                          generated, NO_LICENSE_TRACKER, sourceMap);
+              return new ConcurrentChunkOutput(
+                  preassembledCode == null ? generated : null, preassembledCode, sourceMap);
+            }));
   }
 
   /** Given an output chunk, convert it to a JSONFileSpec with associated sourcemap */

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -1320,10 +1320,15 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
 
     // We won't want to process results for cases where compilation is only partially done.
     boolean shouldProcessResults = config.getSaveCompilationStateToFilename() == null;
-    int exitStatus =
-        shouldProcessResults
-            ? processResults(result, chunks, options)
-            : getExitStatusForResult(result);
+    int exitStatus;
+    try {
+      exitStatus =
+          shouldProcessResults
+              ? processResults(result, chunks, options)
+              : getExitStatusForResult(result);
+    } finally {
+      compiler.outputTracerReport();
+    }
     metricsRecorder.recordResultMetrics(compiler, result);
     return exitStatus;
   }
@@ -1341,8 +1346,9 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     if (!compiler.hasErrors()) {
       saveState();
     }
-    // Perform post-compilation tasks even if compiler.hasErrors()
-    compiler.performPostCompilationTasks();
+    // Perform post-compilation tasks even if compiler.hasErrors(). The command-line runner emits
+    // normal outputs afterward, so delay its tracer report until those outputs are recorded too.
+    compiler.performPostCompilationTasksWithoutTracerReport();
   }
 
   private void runCompilerPasses(CompileMetricsRecorderInterface metricsRecorder) {
@@ -1543,7 +1549,15 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
           outputSourceMap(options, config.jsOutputFile);
         }
       } else {
-        DiagnosticType error = outputChunkBinaryAndSourceMaps(compiler.getChunkGraph(), options);
+        long outputStartNanos = System.nanoTime();
+        DiagnosticType error;
+        try {
+          error = outputChunkBinaryAndSourceMaps(compiler.getChunkGraph(), options);
+        } finally {
+          compiler.recordPassRuntime(
+              "outputChunkBinaryAndSourceMaps",
+              (System.nanoTime() - outputStartNanos) / 1_000_000);
+        }
         if (error != null) {
           compiler.report(JSError.make(error));
           return 1;

--- a/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/AbstractCommandLineRunner.java
@@ -83,6 +83,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
@@ -1550,7 +1554,7 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
         }
       } else {
         long outputStartNanos = System.nanoTime();
-        long[] outputPhaseNanos = new long[2];
+        long[] outputPhaseNanos = new long[3];
         DiagnosticType error;
         try {
           error =
@@ -1558,11 +1562,16 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
                   compiler.getChunkGraph(), options, outputPhaseNanos);
         } finally {
           long outputNanos = System.nanoTime() - outputStartNanos;
-          compiler.recordPassRuntime("outputChunkCode", outputPhaseNanos[0] / 1_000_000);
-          compiler.recordPassRuntime("outputChunkSourceMaps", outputPhaseNanos[1] / 1_000_000);
-          compiler.recordPassRuntime(
-              "outputChunkIoAndSetup",
-              (outputNanos - outputPhaseNanos[0] - outputPhaseNanos[1]) / 1_000_000);
+          if (outputPhaseNanos[2] != 0) {
+            // The code and source map phases overlap, so report their non-overlapping wall time.
+            compiler.recordPassRuntime("outputChunksParallel", outputNanos / 1_000_000);
+          } else {
+            compiler.recordPassRuntime("outputChunkCode", outputPhaseNanos[0] / 1_000_000);
+            compiler.recordPassRuntime("outputChunkSourceMaps", outputPhaseNanos[1] / 1_000_000);
+            compiler.recordPassRuntime(
+                "outputChunkIoAndSetup",
+                (outputNanos - outputPhaseNanos[0] - outputPhaseNanos[1]) / 1_000_000);
+          }
         }
         if (error != null) {
           compiler.report(JSError.make(error));
@@ -1686,11 +1695,6 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
       maybeCreateDirsForPath(config.chunkOutputPathPrefix + "dummy");
     }
 
-    // If the source map path is in fact a pattern for each
-    // chunk, create a stream per-chunk. Otherwise, create
-    // a single source map.
-    Writer mapFileOut = null;
-
     // When the json_streams flag is specified, sourcemaps are always generated
     // per chunk
     if (!(shouldGenerateMapPerChunk(options)
@@ -1702,44 +1706,92 @@ public abstract class AbstractCommandLineRunner<A extends Compiler, B extends Co
     }
 
     ChunkGraphAwareLicenseTracker mlicenseTracker = new ChunkGraphAwareLicenseTracker(compiler);
-    for (JSChunk m : chunks) {
-      if (m.getName().equals(JSChunk.WEAK_CHUNK_NAME)) {
-        // Skip the weak chunk, which is always empty.
-        continue;
-      }
-      if (isOutputInJson()) {
-        this.filesToStreamOut.add(createJsonFileFromChunk(m));
-      } else {
-        if (shouldGenerateMapPerChunk(options)) {
-          mapFileOut = fileNameToOutputWriter2(expandSourceMapPath(options, m));
+    // Code generation mutates shared compiler state, but completed source maps can be serialized
+    // independently while the main thread generates the next chunk.
+    boolean parallelSourceMaps =
+        options.shouldGatherSourceMapInfo()
+            && !isOutputInJson()
+            && options.getNumParallelThreads() > 1;
+    ExecutorService sourceMapExecutor =
+        parallelSourceMaps
+            ? Executors.newFixedThreadPool(
+                options.getNumParallelThreads(),
+                runnable -> {
+                  Thread thread = new Thread(runnable, "jscompiler-SourceMapOutput");
+                  thread.setDaemon(true);
+                  return thread;
+                })
+            : null;
+    List<Future<Long>> sourceMapOutputs = new ArrayList<>();
+    boolean outputCompleted = false;
+    try {
+      for (JSChunk m : chunks) {
+        if (m.getName().equals(JSChunk.WEAK_CHUNK_NAME)) {
+          // Skip the weak chunk, which is always empty.
+          continue;
         }
-
-        String chunkFilename = getChunkOutputFileName(m);
-        maybeCreateDirsForPath(chunkFilename);
-        try (Writer writer = fileNameToLegacyOutputWriter(chunkFilename)) {
-          if (options.shouldGatherSourceMapInfo()) {
-            compiler.resetAndIntitializeSourceMap();
+        if (isOutputInJson()) {
+          this.filesToStreamOut.add(createJsonFileFromChunk(m));
+        } else {
+          String chunkFilename = getChunkOutputFileName(m);
+          maybeCreateDirsForPath(chunkFilename);
+          try (Writer writer = fileNameToLegacyOutputWriter(chunkFilename)) {
+            if (options.shouldGatherSourceMapInfo()) {
+              compiler.resetAndIntitializeSourceMap();
+            }
+            mlicenseTracker.setCurrentChunkContext(m);
+            long codeStartNanos = System.nanoTime();
+            writeChunkOutput(chunkFilename, writer, mlicenseTracker, m);
+            outputPhaseNanos[0] += System.nanoTime() - codeStartNanos;
+            if (options.shouldGatherSourceMapInfo()) {
+              String sourceMapFilename = expandSourceMapPath(options, m);
+              if (parallelSourceMaps) {
+                SourceMap sourceMap = compiler.snapshotSourceMap();
+                sourceMapOutputs.add(
+                    checkNotNull(sourceMapExecutor)
+                        .submit(
+                            () -> {
+                              long sourceMapStartNanos = System.nanoTime();
+                              try (Writer mapFileOut =
+                                  fileNameToOutputWriter2(sourceMapFilename)) {
+                                sourceMap.appendTo(mapFileOut, chunkFilename);
+                              }
+                              return System.nanoTime() - sourceMapStartNanos;
+                            }));
+              } else {
+                long sourceMapStartNanos = System.nanoTime();
+                try (Writer mapFileOut = fileNameToOutputWriter2(sourceMapFilename)) {
+                  compiler.getSourceMap().appendTo(mapFileOut, chunkFilename);
+                }
+                outputPhaseNanos[1] += System.nanoTime() - sourceMapStartNanos;
+              }
+            }
           }
-          mlicenseTracker.setCurrentChunkContext(m);
-          long codeStartNanos = System.nanoTime();
-          writeChunkOutput(chunkFilename, writer, mlicenseTracker, m);
-          outputPhaseNanos[0] += System.nanoTime() - codeStartNanos;
-          if (options.shouldGatherSourceMapInfo()) {
-            long sourceMapStartNanos = System.nanoTime();
-            compiler.getSourceMap().appendTo(mapFileOut, chunkFilename);
-            outputPhaseNanos[1] += System.nanoTime() - sourceMapStartNanos;
-          }
-        }
-
-        if (shouldGenerateMapPerChunk(options) && mapFileOut != null) {
-          mapFileOut.close();
-          mapFileOut = null;
         }
       }
-    }
-
-    if (mapFileOut != null) {
-      mapFileOut.close();
+      if (sourceMapExecutor != null) {
+        sourceMapExecutor.shutdown();
+        for (Future<Long> sourceMapOutput : sourceMapOutputs) {
+          try {
+            outputPhaseNanos[1] += sourceMapOutput.get();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while writing source maps", e);
+          } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException ioException) {
+              throw ioException;
+            }
+            throw new RuntimeException(cause);
+          }
+        }
+        outputPhaseNanos[2] = 1;
+      }
+      outputCompleted = true;
+    } finally {
+      if (sourceMapExecutor != null && !outputCompleted) {
+        sourceMapExecutor.shutdownNow();
+      }
     }
     return null;
   }

--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -509,6 +509,9 @@ public abstract class AbstractCompiler implements SourceExcerptProvider, Compile
 
   public abstract String getBase64SourceMapContents(String sourceFileName);
 
+  /** Returns the path of a separate input source map, or null if none is registered. */
+  public abstract @Nullable String getSourceMapPath(String sourceFileName);
+
   abstract void addComments(String filename, List<Comment> comments);
 
   /**

--- a/src/com/google/javascript/jscomp/AbstractCompiler.java
+++ b/src/com/google/javascript/jscomp/AbstractCompiler.java
@@ -40,6 +40,7 @@ import com.google.javascript.rhino.jstype.JSTypeRegistry;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
@@ -506,6 +507,11 @@ public abstract class AbstractCompiler implements SourceExcerptProvider, Compile
    * reporting and source map combining.
    */
   public abstract void addInputSourceMap(String name, SourceMapInput sourceMap);
+
+  /** Adds multiple input source maps, allowing implementations to prepare them concurrently. */
+  public void addInputSourceMaps(Map<String, SourceMapInput> sourceMaps) {
+    sourceMaps.forEach(this::addInputSourceMap);
+  }
 
   public abstract String getBase64SourceMapContents(String sourceFileName);
 

--- a/src/com/google/javascript/jscomp/AbstractScope.java
+++ b/src/com/google/javascript/jscomp/AbstractScope.java
@@ -147,13 +147,21 @@ public abstract class AbstractScope<S extends AbstractScope<S, V>, V extends Abs
 
   final void declareInternal(String name, V var) {
     checkState(hasOwnSlot(name) || canDeclare(name), "Illegal shadow: %s", var.getNode());
+    initializeVarsIfNeeded();
+    vars.put(name, var);
+  }
 
-    // For memory savings, only initialize the map once it needs to add its first element
+  private void initializeVarsIfNeeded() {
     ImmutableMap<String, V> emptySentinel = ImmutableMap.of();
     if (vars == emptySentinel) {
       vars = Maps.newLinkedHashMapWithExpectedSize(1);
     }
-    vars.put(name, var);
+  }
+
+  /** Adds a variable after the caller has verified that the declaration is valid and absent. */
+  final void declareInternalWithoutChecks(String name, V var) {
+    initializeVarsIfNeeded();
+    checkState(vars.put(name, var) == null, "Duplicate declaration: %s", name);
   }
 
   final void clearVarsInternal() {

--- a/src/com/google/javascript/jscomp/ChangeTracker.java
+++ b/src/com/google/javascript/jscomp/ChangeTracker.java
@@ -20,7 +20,9 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.javascript.rhino.Node;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /** Tracks various kind of changes during a single compilation */
 public final class ChangeTracker {
@@ -32,6 +34,37 @@ public final class ChangeTracker {
   private final Timeline<Node> changeTimeline = new Timeline<>();
   private final RecentChange recentChange = new RecentChange();
   private final List<CodeChangeHandler> codeChangeHandlers = new ArrayList<>();
+  private final ThreadLocal<BufferedChanges> threadBufferedChanges = new ThreadLocal<>();
+
+  /** Changes recorded by one worker and later applied by the compiler thread. */
+  static final class BufferedChanges {
+    private final Set<Node> changedScopes = new LinkedHashSet<>();
+    private final Set<Node> deletedFunctions = new LinkedHashSet<>();
+  }
+
+  BufferedChanges beginBufferingChanges() {
+    checkState(threadBufferedChanges.get() == null, "Already buffering changes on this thread");
+    BufferedChanges changes = new BufferedChanges();
+    threadBufferedChanges.set(changes);
+    return changes;
+  }
+
+  void endBufferingChanges(BufferedChanges changes) {
+    checkState(threadBufferedChanges.get() == changes, "Ending the wrong buffered change set");
+    threadBufferedChanges.remove();
+  }
+
+  /** Applies worker changes in caller-selected deterministic order. */
+  void applyBufferedChanges(BufferedChanges changes) {
+    checkState(threadBufferedChanges.get() == null, "Cannot apply changes while buffering");
+    for (Node deletedFunction : changes.deletedFunctions) {
+      changeTimeline.remove(deletedFunction);
+    }
+    for (Node changedScope : changes.changedScopes) {
+      recordChange(changedScope);
+      notifyChangeHandlers();
+    }
+  }
 
   /** Registers a listener for code change events. */
   void addChangeHandler(CodeChangeHandler handler) {
@@ -52,13 +85,24 @@ public final class ChangeTracker {
    * #isChangeScopeRoot(Node)}
    */
   public void reportChangeToEnclosingScope(Node n) {
-    recordChange(getChangeScopeForNode(n));
+    Node changedScope = getChangeScopeForNode(n);
+    BufferedChanges bufferedChanges = threadBufferedChanges.get();
+    if (bufferedChanges != null) {
+      bufferedChanges.changedScopes.add(changedScope);
+      return;
+    }
+    recordChange(changedScope);
     notifyChangeHandlers();
   }
 
   /** Marks modifications to a function or script node */
   public void reportChangeToChangeScope(Node changeScopeRoot) {
     checkState(changeScopeRoot.isScript() || changeScopeRoot.isFunction());
+    BufferedChanges bufferedChanges = threadBufferedChanges.get();
+    if (bufferedChanges != null) {
+      bufferedChanges.changedScopes.add(changeScopeRoot);
+      return;
+    }
     recordChange(changeScopeRoot);
     notifyChangeHandlers();
   }
@@ -80,6 +124,11 @@ public final class ChangeTracker {
   public void reportFunctionDeleted(Node n) {
     checkState(n.isFunction());
     n.setDeleted(true);
+    BufferedChanges bufferedChanges = threadBufferedChanges.get();
+    if (bufferedChanges != null) {
+      bufferedChanges.deletedFunctions.add(n);
+      return;
+    }
     changeTimeline.remove(n);
   }
 

--- a/src/com/google/javascript/jscomp/CoalesceVariableNames.java
+++ b/src/com/google/javascript/jscomp/CoalesceVariableNames.java
@@ -141,6 +141,9 @@ class CoalesceVariableNames extends NodeTraversal.AbstractCfgCallback implements
       return;
     }
     shouldOptimizeScopeStack.push(true);
+    @Nullable OptimizationWorkReporter workReporter =
+        compiler.getOptions().getOptimizationWorkReporter();
+    long workStartNanos = workReporter != null ? System.nanoTime() : 0;
 
     Scope scope = t.getScope();
     checkState(scope.isFunctionScope(), scope);
@@ -178,6 +181,16 @@ class CoalesceVariableNames extends NodeTraversal.AbstractCfgCallback implements
         new GreedyGraphColoring<>(interferenceGraph, coloringTieBreaker);
     coloring.color();
     colorings.push(coloring);
+    if (workReporter != null) {
+      workReporter.recordFunction(
+          PassNames.COALESCE_VARIABLE_NAMES,
+          scope.getRootNode(),
+          allVarsDeclaredInFunction.getAllVariablesInOrder().size(),
+          cfg.getNodes().size(),
+          interferenceGraph.getNodes().size(),
+          0,
+          System.nanoTime() - workStartNanos);
+    }
   }
 
   @Override

--- a/src/com/google/javascript/jscomp/CoalesceVariableNames.java
+++ b/src/com/google/javascript/jscomp/CoalesceVariableNames.java
@@ -42,9 +42,14 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.Deque;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -76,6 +81,8 @@ class CoalesceVariableNames extends NodeTraversal.AbstractCfgCallback implements
   private final Deque<LiveVariablesAnalysis> liveAnalyses;
   private final boolean usePseudoNames;
   private final AstFactory astFactory;
+  // Worker traversals collect changes locally because the compiler's ChangeTracker is mutable.
+  private final Set<Node> changedScopes = new LinkedHashSet<>();
   private LiveVariablesAnalysis liveness;
 
   private final Comparator<Var> coloringTieBreaker =
@@ -106,12 +113,92 @@ class CoalesceVariableNames extends NodeTraversal.AbstractCfgCallback implements
   public void process(Node externs, Node root) {
     checkNotNull(externs);
     checkNotNull(root);
+    int parallelism = compiler.getOptions().getNumParallelThreads();
+    // Detailed work reporting preserves traversal order and uses a mutable writer, so keep that
+    // diagnostic mode serial.
+    if (parallelism > 1
+        && root.isRoot()
+        && root.hasMoreThanOneChild()
+        && compiler.getOptions().getOptimizationWorkReporter() == null) {
+      processScriptsConcurrently(root, parallelism);
+    } else {
+      traverse(root);
+    }
+    for (Node changedScope : changedScopes) {
+      compiler.reportChangeToChangeScope(changedScope);
+    }
+    compiler.setLifeCycleStage(LifeCycleStage.RAW);
+  }
+
+  private void traverse(Node root) {
     NodeTraversal.builder()
         .setCompiler(compiler)
         .setCallback(this)
         .setScopeCreator(this.scopeCreator)
         .traverse(root);
-    compiler.setLifeCycleStage(LifeCycleStage.RAW);
+  }
+
+  private void traverseWithScope(Node root, AbstractScope<?, ?> scope) {
+    NodeTraversal.builder()
+        .setCompiler(compiler)
+        .setCallback(this)
+        .setScopeCreator(this.scopeCreator)
+        .traverseWithScope(root, scope);
+  }
+
+  private void processScriptsConcurrently(Node root, int parallelism) {
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        traverse(root);
+        return;
+      }
+      scripts.add(script);
+    }
+    // Function-local CFGs and rewrites in different scripts touch disjoint AST subtrees. Build the
+    // whole-program global scope once so every traversal still resolves names exactly as the serial
+    // root traversal does, then treat that scope as read-only in the workers.
+    AbstractScope<?, ?> globalScope = scopeCreator.createScope(root, null);
+
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(parallelism, scripts.size()),
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-CoalesceVariableNames");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<Set<Node>>> futures = new ArrayList<>(scripts.size());
+    boolean completed = false;
+    try {
+      for (Node script : scripts) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  CoalesceVariableNames worker =
+                      new CoalesceVariableNames(compiler, usePseudoNames);
+                  worker.traverseWithScope(script, globalScope);
+                  return worker.changedScopes;
+                }));
+      }
+      executor.shutdown();
+      for (Future<Set<Node>> future : futures) {
+        try {
+          changedScopes.addAll(future.get());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while coalescing variable names", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException(
+              "Cannot coalesce variable names concurrently", e.getCause());
+        }
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
   }
 
   /** Returns populated AllVarsDeclaredInFunction object iff shouldOptimizeScope is true. */
@@ -226,7 +313,7 @@ class CoalesceVariableNames extends NodeTraversal.AbstractCfgCallback implements
 
       // Rename.
       n.setString(coalescedVar.getName());
-      compiler.reportChangeToEnclosingScope(n);
+      changedScopes.add(checkNotNull(ChangeTracker.getEnclosingChangeScopeRoot(n)));
       updateDeclarationsPostCoalescing(n, coalescedVar, parent);
     } else {
       // This code block is slow but since usePseudoName is for debugging,
@@ -255,7 +342,7 @@ class CoalesceVariableNames extends NodeTraversal.AbstractCfgCallback implements
 
       // Rename.
       n.setString(pseudoName);
-      compiler.reportChangeToEnclosingScope(n);
+      changedScopes.add(checkNotNull(ChangeTracker.getEnclosingChangeScopeRoot(n)));
 
       if (vNode.getValue().equals(coalescedVar)) {
         return;

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -531,6 +531,15 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private int optimizationMotionLoopMaxIterations = 0;
 
     @Option(
+        name = "--run_final_flow_sensitive_inline_variables",
+        hidden = true,
+        handler = BooleanOptionHandler.class,
+        usage =
+            "Repeat flow-sensitive variable inlining and its unused-code cleanup during final "
+                + "optimizations.")
+    private boolean runFinalFlowSensitiveInlineVariables = true;
+
+    @Option(
         name = "--checks_only",
         aliases = {"--checks-only"},
         handler = BooleanOptionHandler.class,
@@ -1911,6 +1920,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     options.setOptimizationLoopSizeThreshold(flags.optimizationLoopSizeThreshold);
     options.setMaxOptimizationLoopIterations(flags.optimizationLoopMaxIterations);
     options.setMaxOptimizationMotionLoopIterations(flags.optimizationMotionLoopMaxIterations);
+    options.setFinalFlowSensitiveInlineVariables(flags.runFinalFlowSensitiveInlineVariables);
 
     options.setEnvironment(flags.environment);
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -598,6 +598,12 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private @Nullable String typedAstOutputFile = null;
 
     @Option(
+        name = "--typed_ast_input_file__INTERNAL_USE_ONLY",
+        usage = "Reads an in-progress typedAST list produced by a checks-only compilation.",
+        hidden = true)
+    private @Nullable String typedAstInputFile = null;
+
+    @Option(
         name = "--generate_exports",
         handler = BooleanOptionHandler.class,
         usage = "Generates export code for those marked with @export")
@@ -1824,6 +1830,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
           .setBrowserFeaturesetYear(flags.browserFeaturesetYear)
           .setCharset(flags.charset)
           .setDependencyOptions(dependencyOptions)
+          .setTypedAstListInputFilename(flags.typedAstInputFile)
           .setOutputInputReductionReport(flags.outputInputReductionReport)
           .setOutputOptimizationWorkReport(flags.outputOptimizationWorkReport)
           .setOutputManifest(ImmutableList.of(flags.outputManifest))

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -515,6 +515,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private double optimizationLoopSizeThreshold = 0.1;
 
     @Option(
+        name = "--optimization_loop_max_iterations",
+        hidden = true,
+        usage =
+            "Run at most this many iterations of each code-removal optimization loop. A value of "
+                + "zero uses the compiler default limit.")
+    private int optimizationLoopMaxIterations = 0;
+
+    @Option(
         name = "--checks_only",
         aliases = {"--checks-only"},
         handler = BooleanOptionHandler.class,
@@ -1893,6 +1901,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
 
     options.setNumParallelThreads(flags.numParallelThreads);
     options.setOptimizationLoopSizeThreshold(flags.optimizationLoopSizeThreshold);
+    options.setMaxOptimizationLoopIterations(flags.optimizationLoopMaxIterations);
 
     options.setEnvironment(flags.environment);
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -647,6 +647,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private String outputManifest = "";
 
     @Option(
+        name = "--output_input_reduction_report",
+        usage =
+            "Writes a tab-separated report of input AST sizes before and after compilation. "
+                + "This is intended to identify source files whose code the optimizer completely "
+                + "or mostly removes.")
+    private String outputInputReductionReport = "";
+
+    @Option(
         name = "--output_chunk_dependencies",
         usage = "Prints out a JSON file of dependencies between chunks.")
     private String outputChunkDependencies = "";
@@ -1053,6 +1061,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 "Reports",
                 ImmutableList.of(
                     "create_source_map",
+                    "output_input_reduction_report",
                     "output_manifest",
                     "output_chunk_dependencies",
                     "property_renaming_report",
@@ -1765,6 +1774,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
           .setBrowserFeaturesetYear(flags.browserFeaturesetYear)
           .setCharset(flags.charset)
           .setDependencyOptions(dependencyOptions)
+          .setOutputInputReductionReport(flags.outputInputReductionReport)
           .setOutputManifest(ImmutableList.of(flags.outputManifest))
           .setOutputBundle(bundleFiles)
           .setSkipNormalOutputs(skipNormalOutputs)
@@ -2244,6 +2254,24 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
   }
 
   private static final Logger phaseLogger = Logger.getLogger(PhaseOptimizer.class.getName());
+
+  /**
+   * Runs one command-line compilation without terminating the JVM.
+   *
+   * <p>This entry point is intended for persistent build workers that reuse a JVM while creating a
+   * fresh compiler and command-line configuration for every request.
+   */
+  public static int runCompiler(String[] args, PrintStream out, PrintStream err) throws IOException {
+    if (phaseLogger != null) {
+      phaseLogger.setLevel(Level.OFF);
+    }
+    CommandLineRunner runner = new CommandLineRunner(args, out, err);
+    if (!runner.shouldRunCompiler()) {
+      return runner.hasErrors() ? -1 : 0;
+    }
+    int exitCode = runner.doRun();
+    return runner.hasErrors() ? -1 : exitCode;
+  }
 
   /** Runs the Compiler. Exits cleanly in the event of an error. */
   public static void main(String[] args) {

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -663,6 +663,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private String outputInputReductionReport = "";
 
     @Option(
+        name = "--output_remove_unused_code_report",
+        usage =
+            "Writes a directory of tab-separated RemoveUnusedCode logs. Each entry identifies an "
+                + "unused variable, property, polyfill, or function argument removed by an "
+                + "optimization pass. This diagnostic can substantially increase output volume.")
+    private String outputRemoveUnusedCodeReport = "";
+
+    @Option(
         name = "--output_chunk_dependencies",
         usage = "Prints out a JSON file of dependencies between chunks.")
     private String outputChunkDependencies = "";
@@ -1070,6 +1078,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 ImmutableList.of(
                     "create_source_map",
                     "output_input_reduction_report",
+                    "output_remove_unused_code_report",
                     "output_manifest",
                     "output_chunk_dependencies",
                     "property_renaming_report",
@@ -1909,6 +1918,10 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
 
     if (flags.typedAstOutputFile != null) {
       options.setTypedAstOutputFile(Path.of(flags.typedAstOutputFile));
+    }
+    if (!flags.outputRemoveUnusedCodeReport.isEmpty()) {
+      options.setDebugLogDirectory(Path.of(flags.outputRemoveUnusedCodeReport));
+      options.setDebugLogFilter("removals.log");
     }
     options.setGenerateExports(flags.generateExports);
     options.setExportLocalPropertyDefinitions(flags.exportLocalPropertyDefinitions);

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -143,13 +143,13 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
   // I don't really care about unchecked warnings in this class.
   @SuppressWarnings("unchecked")
   private static class Flags {
-    // Some clients run a few copies of the compiler through CommandLineRunner
-    // on parallel threads (thankfully, with the same flags),
-    // so the access to these lists should be synchronized.
-    private static final List<FlagEntry<CheckLevel>> guardLevels =
-        Collections.synchronizedList(new ArrayList<FlagEntry<CheckLevel>>());
-    private static final List<FlagEntry<JsSourceType>> mixedJsSources =
-        Collections.synchronizedList(new ArrayList<FlagEntry<JsSourceType>>());
+    // Option handlers are constructed reflectively and therefore cannot receive their owning
+    // Flags instance. Keep their ordering state per compilation thread so independent command-line
+    // runners can parse different inputs concurrently.
+    private static final ThreadLocal<List<FlagEntry<CheckLevel>>> guardLevels =
+        ThreadLocal.withInitial(ArrayList::new);
+    private static final ThreadLocal<List<FlagEntry<JsSourceType>>> mixedJsSources =
+        ThreadLocal.withInitial(ArrayList::new);
 
     @Option(
         name = "--browser_featureset_year",
@@ -1308,7 +1308,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
         throws CmdLineException, IOException {
       List<FlagEntry<JsSourceType>> mixedSources = new ArrayList<>();
       Set<String> excludes = new HashSet<>();
-      for (FlagEntry<JsSourceType> source : Flags.mixedJsSources) {
+      for (FlagEntry<JsSourceType> source : Flags.mixedJsSources.get()) {
         if (source.getValue().endsWith(".zip")) {
           mixedSources.add(source);
         } else if (source.getValue().startsWith("!")) {
@@ -1328,7 +1328,9 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       for (String filename : fromArguments) {
         mixedSources.add(new FlagEntry<>(JsSourceType.JS, filename));
       }
-      if (!Flags.mixedJsSources.isEmpty() && !arguments.isEmpty() && mixedSources.isEmpty()) {
+      if (!Flags.mixedJsSources.get().isEmpty()
+          && !arguments.isEmpty()
+          && mixedSources.isEmpty()) {
         throw new CmdLineException(parser, "No inputs matched");
       }
       return mixedSources;
@@ -1424,7 +1426,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       @Keep
       public WarningGuardErrorOptionHandler(
           CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
-        super(parser, option, new MultiFlagSetter<>(setter, CheckLevel.ERROR, guardLevels));
+        super(parser, option, new MultiFlagSetter<>(setter, CheckLevel.ERROR, guardLevels.get()));
       }
     }
 
@@ -1433,7 +1435,8 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       @Keep
       public WarningGuardWarningOptionHandler(
           CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
-        super(parser, option, new MultiFlagSetter<>(setter, CheckLevel.WARNING, guardLevels));
+        super(
+            parser, option, new MultiFlagSetter<>(setter, CheckLevel.WARNING, guardLevels.get()));
       }
     }
 
@@ -1442,7 +1445,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       @Keep
       public WarningGuardOffOptionHandler(
           CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
-        super(parser, option, new MultiFlagSetter<>(setter, CheckLevel.OFF, guardLevels));
+        super(parser, option, new MultiFlagSetter<>(setter, CheckLevel.OFF, guardLevels.get()));
       }
     }
 
@@ -1451,7 +1454,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       @Keep
       public JsOptionHandler(
           CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
-        super(parser, option, new MultiFlagSetter<>(setter, JsSourceType.JS, mixedJsSources));
+        super(parser, option, new MultiFlagSetter<>(setter, JsSourceType.JS, mixedJsSources.get()));
       }
     }
 
@@ -1460,7 +1463,10 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
       @Keep
       public JsZipOptionHandler(
           CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
-        super(parser, option, new MultiFlagSetter<>(setter, JsSourceType.JS_ZIP, mixedJsSources));
+        super(
+            parser,
+            option,
+            new MultiFlagSetter<>(setter, JsSourceType.JS_ZIP, mixedJsSources.get()));
       }
     }
 
@@ -1661,13 +1667,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
 
     // Command-line warning levels should override flag file settings,
     // which means they should go last.
-    List<FlagEntry<CheckLevel>> previousGuardLevels = new ArrayList<>(Flags.guardLevels);
-    List<FlagEntry<JsSourceType>> previousMixedJsSources = new ArrayList<>(Flags.mixedJsSources);
-    Flags.guardLevels.clear();
-    Flags.mixedJsSources.clear();
+    List<FlagEntry<CheckLevel>> previousGuardLevels = new ArrayList<>(Flags.guardLevels.get());
+    List<FlagEntry<JsSourceType>> previousMixedJsSources =
+        new ArrayList<>(Flags.mixedJsSources.get());
+    Flags.guardLevels.get().clear();
+    Flags.mixedJsSources.get().clear();
     flags.parse(tokens);
-    Flags.guardLevels.addAll(previousGuardLevels);
-    Flags.mixedJsSources.addAll(previousMixedJsSources);
+    Flags.guardLevels.get().addAll(previousGuardLevels);
+    Flags.mixedJsSources.get().addAll(previousMixedJsSources);
 
     // Currently we are not supporting this (prevent direct/indirect loops)
     if (!flags.flagFiles.isEmpty()) {
@@ -1690,8 +1697,8 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     errorStream = err;
     List<String> processedArgs = processArgs(args);
 
-    Flags.guardLevels.clear();
-    Flags.mixedJsSources.clear();
+    Flags.guardLevels.get().clear();
+    Flags.mixedJsSources.get().clear();
 
     List<FlagEntry<JsSourceType>> mixedSources = null;
     List<LocationMapping> mappings = null;
@@ -1825,7 +1832,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
           .setSourceMapInputFiles(sourceMapInputs)
           .setParseInlineSourceMaps(parseInlineSourceMaps)
           .setApplyInputSourceMaps(applyInputSourceMaps)
-          .setWarningGuards(Flags.guardLevels)
+          .setWarningGuards(Flags.guardLevels.get())
           .setDefine(flags.define)
           .setBrowserFeaturesetYear(flags.browserFeaturesetYear)
           .setCharset(flags.charset)
@@ -1871,6 +1878,8 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     }
 
     errorStream = null;
+    Flags.guardLevels.remove();
+    Flags.mixedJsSources.remove();
   }
 
   @Override

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -507,6 +507,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private int numParallelThreads = 1;
 
     @Option(
+        name = "--optimization_loop_size_threshold",
+        hidden = true,
+        usage =
+            "Stop code-removal fixed-point loops after two batches whose AST size changes by less"
+                + " than this percentage.")
+    private double optimizationLoopSizeThreshold = 0.1;
+
+    @Option(
         name = "--checks_only",
         aliases = {"--checks-only"},
         handler = BooleanOptionHandler.class,
@@ -1875,6 +1883,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     }
 
     options.setNumParallelThreads(flags.numParallelThreads);
+    options.setOptimizationLoopSizeThreshold(flags.optimizationLoopSizeThreshold);
 
     options.setEnvironment(flags.environment);
 

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -688,6 +688,13 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private String outputInputReductionReport = "";
 
     @Option(
+        name = "--output_optimization_work_report",
+        usage =
+            "Writes a tab-separated report attributing expensive optimization work to source "
+                + "functions. This diagnostic adds timing instrumentation to selected passes.")
+    private String outputOptimizationWorkReport = "";
+
+    @Option(
         name = "--output_remove_unused_code_report",
         usage =
             "Writes a directory of tab-separated RemoveUnusedCode logs. Each entry identifies an "
@@ -1103,6 +1110,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
                 ImmutableList.of(
                     "create_source_map",
                     "output_input_reduction_report",
+                    "output_optimization_work_report",
                     "output_remove_unused_code_report",
                     "output_manifest",
                     "output_chunk_dependencies",
@@ -1817,6 +1825,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
           .setCharset(flags.charset)
           .setDependencyOptions(dependencyOptions)
           .setOutputInputReductionReport(flags.outputInputReductionReport)
+          .setOutputOptimizationWorkReport(flags.outputOptimizationWorkReport)
           .setOutputManifest(ImmutableList.of(flags.outputManifest))
           .setOutputBundle(bundleFiles)
           .setSkipNormalOutputs(skipNormalOutputs)
@@ -1950,6 +1959,9 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     if (!flags.outputRemoveUnusedCodeReport.isEmpty()) {
       options.setDebugLogDirectory(Path.of(flags.outputRemoveUnusedCodeReport));
       options.setDebugLogFilter("removals.log");
+    }
+    if (!flags.outputOptimizationWorkReport.isEmpty()) {
+      options.setOptimizationWorkReporter(new OptimizationWorkReporter());
     }
     options.setGenerateExports(flags.generateExports);
     options.setExportLocalPropertyDefinitions(flags.exportLocalPropertyDefinitions);

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -593,14 +593,12 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
 
     @Option(
         name = "--typed_ast_output_file",
-        usage = "Sets file to output in-progress typedAST format. DO NOT USE!",
-        hidden = true)
+        usage = "Sets file to output in-progress typedAST format.")
     private @Nullable String typedAstOutputFile = null;
 
     @Option(
-        name = "--typed_ast_input_file__INTERNAL_USE_ONLY",
-        usage = "Reads an in-progress typedAST list produced by a checks-only compilation.",
-        hidden = true)
+        name = "--typed_ast_input_file",
+        usage = "Reads an in-progress typedAST list produced by a checks-only compilation.")
     private @Nullable String typedAstInputFile = null;
 
     @Option(

--- a/src/com/google/javascript/jscomp/CommandLineRunner.java
+++ b/src/com/google/javascript/jscomp/CommandLineRunner.java
@@ -523,6 +523,14 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     private int optimizationLoopMaxIterations = 0;
 
     @Option(
+        name = "--optimization_motion_loop_max_iterations",
+        hidden = true,
+        usage =
+            "Run at most this many iterations of fixed-point loops that move code without "
+                + "removing it. A value of zero uses the compiler default limit.")
+    private int optimizationMotionLoopMaxIterations = 0;
+
+    @Option(
         name = "--checks_only",
         aliases = {"--checks-only"},
         handler = BooleanOptionHandler.class,
@@ -1902,6 +1910,7 @@ public class CommandLineRunner extends AbstractCommandLineRunner<Compiler, Compi
     options.setNumParallelThreads(flags.numParallelThreads);
     options.setOptimizationLoopSizeThreshold(flags.optimizationLoopSizeThreshold);
     options.setMaxOptimizationLoopIterations(flags.optimizationLoopMaxIterations);
+    options.setMaxOptimizationMotionLoopIterations(flags.optimizationMotionLoopMaxIterations);
 
     options.setEnvironment(flags.environment);
 

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -4696,6 +4696,10 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     }
   }
 
+  SourceMap snapshotSourceMap() {
+    return checkNotNull(sourceMap).snapshot();
+  }
+
   @CanIgnoreReturnValue
   @FormatMethod
   private static Node checkNotModule(Node script, String msg, Object... args) {

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -694,6 +694,16 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
             () -> {
               Tracer tracer = newTracer("deserializeTypedAst");
               try {
+                if (!deserializeTypes && options.getNumParallelThreads() > 1) {
+                  return TypedAstDeserializer.deserializeFullAstConcurrently(
+                      this,
+                      SYNTHETIC_EXTERNS_FILE,
+                      requiredInputFiles,
+                      typedAstListStream,
+                      options.getResolveSourceMapAnnotations(),
+                      options.getParseInlineSourceMaps(),
+                      options.getNumParallelThreads());
+                }
                 return TypedAstDeserializer.deserializeFullAst(
                     this,
                     SYNTHETIC_EXTERNS_FILE,

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -3583,6 +3583,15 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     return null;
   }
 
+  @Override
+  public @Nullable String getSourceMapPath(String sourceFileName) {
+    SourceMapInput sourceMapInput = inputSourceMaps.getOrDefault(sourceFileName, null);
+    String sourceMapPath = sourceMapInput != null ? sourceMapInput.getOriginalPath() : null;
+    return sourceMapPath != null && !sourceMapPath.endsWith(".inline.map")
+        ? sourceMapPath
+        : null;
+  }
+
   /**
    * Adds file name to content mappings for all sources found in a source map. This is used to
    * populate sourcesContent array in the output source map even for sources embedded in the input

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -221,6 +221,12 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   /** Configured {@link SourceMapInput}s, plus any source maps discovered in source files. */
   ConcurrentHashMap<String, SourceMapInput> inputSourceMaps = new ConcurrentHashMap<>();
 
+  /** Resolved source names and contents, cached because outputting each chunk resets the map. */
+  private final ConcurrentHashMap<SourceMapInput, ImmutableList<SourceMapSourceFile>>
+      sourceMapSourceFiles = new ConcurrentHashMap<>();
+
+  private record SourceMapSourceFile(String name, String code) {}
+
   // Map from filenames to lists of all the comments in each file.
   private Map<String, List<Comment>> commentsPerFile = new ConcurrentHashMap<>();
 
@@ -3564,6 +3570,14 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
    */
   private synchronized void addSourceMapSourceFiles(SourceMapInput inputSourceMap) {
     // synchronized annotation guards concurrent access to sourceMap during parsing.
+    ImmutableList<SourceMapSourceFile> sourceFiles = sourceMapSourceFiles.get(inputSourceMap);
+    if (sourceFiles != null) {
+      for (SourceMapSourceFile sourceFile : sourceFiles) {
+        sourceMap.addSourceFile(sourceFile.name(), sourceFile.code());
+      }
+      return;
+    }
+
     SourceMapConsumerV3 consumer = inputSourceMap.getSourceMap(errorManager);
     if (consumer == null) {
       return;
@@ -3574,17 +3588,24 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     }
     Iterator<String> content = sourcesContent.iterator();
     Iterator<String> sources = consumer.getOriginalSources().iterator();
+    ImmutableList.Builder<SourceMapSourceFile> sourceFilesBuilder = ImmutableList.builder();
     while (sources.hasNext() && content.hasNext()) {
       String code = content.next();
       SourceFile source =
           SourceMapResolver.getRelativePath(inputSourceMap.getOriginalPath(), sources.next());
       if (source != null) {
-        sourceMap.addSourceFile(source.getName(), code);
+        sourceFilesBuilder.add(new SourceMapSourceFile(source.getName(), code));
       }
     }
     if (sources.hasNext() || content.hasNext()) {
       throw new RuntimeException(
           "Source map's \"sources\" and \"sourcesContent\" lengths do not match.");
+    }
+
+    sourceFiles = sourceFilesBuilder.build();
+    sourceMapSourceFiles.put(inputSourceMap, sourceFiles);
+    for (SourceMapSourceFile sourceFile : sourceFiles) {
+      sourceMap.addSourceFile(sourceFile.name(), sourceFile.code());
     }
   }
 

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -306,10 +306,9 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     String relativePath;
   }
 
-  /**
-   * There is exactly one cached resolvedSourceMap, which you can think of as a cache of size one.
-   */
-  private final ResolvedSourceMap resolvedSourceMap = new ResolvedSourceMap();
+  /** One cached source-map resolution per output thread. */
+  private final ThreadLocal<ResolvedSourceMap> resolvedSourceMap =
+      ThreadLocal.withInitial(ResolvedSourceMap::new);
 
   /** Creates a Compiler that reports errors and warnings to its logger. */
   public Compiler() {
@@ -2724,6 +2723,142 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
         });
   }
 
+  /** Immutable input roots captured on the compiler thread for concurrent code generation. */
+  static final class PreparedChunkOutput {
+    final ImmutableList<Node> roots;
+
+    PreparedChunkOutput(ImmutableList<Node> roots) {
+      this.roots = roots;
+    }
+  }
+
+  /** Code, source mappings, and the license-relevant node order for one input. */
+  private static final class GeneratedInput {
+    final Node root;
+    final CodePrinter.SourceAndMappings sourceAndMappings;
+    final ImmutableList<Node> licenseNodes;
+
+    GeneratedInput(
+        Node root,
+        CodePrinter.SourceAndMappings sourceAndMappings,
+        ImmutableList<Node> licenseNodes) {
+      this.root = root;
+      this.sourceAndMappings = sourceAndMappings;
+      this.licenseNodes = licenseNodes;
+    }
+  }
+
+  /** Immutable result of generating one chunk's code without mutating compiler state. */
+  static final class GeneratedChunkOutput {
+    final ImmutableList<GeneratedInput> inputs;
+
+    GeneratedChunkOutput(ImmutableList<GeneratedInput> inputs) {
+      this.inputs = inputs;
+    }
+
+    boolean hasLicenseNodes() {
+      for (GeneratedInput input : inputs) {
+        if (!input.licenseNodes.isEmpty()) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  ImmutableSet<String> getLicensedSourceNamesForOutput() {
+    ImmutableSet.Builder<String> licensedSources = ImmutableSet.builder();
+    for (CompilerInput input : getInputsInOrder()) {
+      Node script = input.getAstRoot(this);
+      if (script == null) {
+        continue;
+      }
+      JSDocInfo info = script.getJSDocInfo();
+      if (info != null && info.getLicense() != null) {
+        licensedSources.add(checkNotNull(script.getSourceFileName()));
+      }
+    }
+    return licensedSources.build();
+  }
+
+  PreparedChunkOutput prepareChunkOutput(JSChunk chunk) {
+    ImmutableList.Builder<Node> roots = ImmutableList.builder();
+    for (CompilerInput input : chunk.getInputs()) {
+      Node scriptNode = input.getAstRoot(this);
+      if (scriptNode == null) {
+        throw new IllegalArgumentException("Bad chunk: " + chunk.getName());
+      }
+      roots.add(scriptNode);
+    }
+    return new PreparedChunkOutput(roots.build());
+  }
+
+  /**
+   * Prints a prepared chunk using only immutable AST and option state. This method may be called
+   * concurrently after all compiler passes have finished.
+   */
+  GeneratedChunkOutput generatePreparedChunkOutput(
+      PreparedChunkOutput prepared, ImmutableSet<String> licensedSources) {
+    ImmutableList.Builder<GeneratedInput> generated = ImmutableList.builder();
+    for (int i = 0; i < prepared.roots.size(); i++) {
+      RecordingLicenseTracker recordingTracker = new RecordingLicenseTracker(licensedSources);
+      generated.add(
+          new GeneratedInput(
+              prepared.roots.get(i),
+              toSourceAndMappings(prepared.roots.get(i), i == 0, recordingTracker),
+              recordingTracker.licenseNodes()));
+    }
+    return new GeneratedChunkOutput(generated.build());
+  }
+
+  /** Replays license decisions in chunk order and assembles code and mappings deterministically. */
+  String assembleGeneratedChunkOutput(
+      GeneratedChunkOutput generated, LicenseTracker licenseTracker, @Nullable SourceMap outputMap) {
+    CodeBuilder cb = new CodeBuilder();
+    for (int i = 0; i < generated.inputs.size(); i++) {
+      GeneratedInput input = generated.inputs.get(i);
+      appendInputDelimiter(cb, i, input.root);
+      for (Node node : input.licenseNodes) {
+        licenseTracker.trackLicensesForNode(node);
+      }
+      appendGeneratedSource(cb, licenseTracker, input.sourceAndMappings, outputMap);
+    }
+    return cb.toString();
+  }
+
+  private static final class RecordingLicenseTracker implements LicenseTracker {
+    private final ImmutableSet<String> licensedSources;
+    private final ImmutableList.Builder<Node> licenseNodes = ImmutableList.builder();
+    private @Nullable String lastSourceFile;
+
+    RecordingLicenseTracker(ImmutableSet<String> licensedSources) {
+      this.licensedSources = licensedSources;
+    }
+
+    @Override
+    public void trackLicensesForNode(Node node) {
+      if (node.isRoot() || node.isScript()) {
+        return;
+      }
+      String sourceFile = node.getSourceFileName();
+      if (sourceFile != null
+          && licensedSources.contains(sourceFile)
+          && !sourceFile.equals(lastSourceFile)) {
+        licenseNodes.add(node);
+        lastSourceFile = sourceFile;
+      }
+    }
+
+    @Override
+    public ImmutableSet<String> emitLicenses() {
+      return ImmutableSet.of();
+    }
+
+    ImmutableList<Node> licenseNodes() {
+      return licenseNodes.build();
+    }
+  }
+
   /**
    * Writes out JS code from a root node. If printing input delimiters, this method will attach a
    * comment to the start of the text indicating which input the output derived from. If there were
@@ -2741,75 +2876,71 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       final Node root) {
     runInCompilerThread(
         () -> {
-          if (options.shouldPrintInputDelimiter()) {
-            if ((cb.getLength() > 0) && !cb.endsWith("\n")) {
-              cb.append("\n"); // Make sure that the label starts on a new line
-            }
-            checkState(root.isScript());
+          appendInputDelimiter(cb, inputSeqNum, root);
 
-            String delimiter = options.getInputDelimiter();
-
-            String inputName = root.getInputId().getIdName();
-            String sourceName = root.getSourceFileName();
-            checkState(sourceName != null);
-            checkState(!sourceName.isEmpty());
-
-            delimiter =
-                delimiter
-                    .replace("%name%", inputName)
-                    .replace("%num%", String.valueOf(inputSeqNum))
-                    .replace("%n%", "\n");
-
-            cb.append(delimiter).append("\n");
-          }
-
-          CodePrinter.SourceAndMappings sourceAndMappings =
-              toSourceAndMappings(root, inputSeqNum == 0, licenseTracker);
-          String code = sourceAndMappings.source;
-
-          // Check whether there is any license information that should be emitted.
-          for (String license : licenseTracker.emitLicenses()) {
-            cb.append("/*\n").append(license).append("*/\n");
-          }
-
-          // Check whether there's any actual code to emit.
-          // This is deliberately done after the license tracker is given an opportunity to emit
-          // licenses, as some trackers might want to emit license info from this Node's tree
-          // regardless of whether it emits visible code. One example of this would be the case
-          // where inlining has moved the contents from this file to another file, but the license
-          // tracker can't be sure if the license for this code will ever be emitted.
-          if (code.isEmpty()) {
-            // Nothing to do.
-            return null;
-          }
-
-          // If there is a valid source map, then indicate to it that the current
-          // root node's mappings are offset by the given string builder buffer.
-          // This offset is a result of licenses being added to the output buffer.
-          if (options.shouldGatherSourceMapInfo()) {
-            sourceMap.setStartingPosition(cb.getLineIndex(), cb.getColumnIndex());
-          }
-
-          cb.append(code);
-
-          // In order to avoid parse ambiguity when files are concatenated
-          // together, all files should end in a semi-colon. Do a quick
-          // heuristic check if there's an obvious semi-colon already there.
-          int length = code.length();
-          char lastChar = code.charAt(length - 1);
-          char secondLastChar = length >= 2 ? code.charAt(length - 2) : '\0';
-          boolean hasSemiColon = lastChar == ';' || (lastChar == '\n' && secondLastChar == ';');
-          if (!hasSemiColon) {
-            cb.append(";");
-          }
-
-          if (options.shouldGatherSourceMapInfo()) {
-            for (SourceMap.Mapping mapping : sourceAndMappings.mappings) {
-              sourceMap.addMapping(mapping);
-            }
-          }
+          appendGeneratedSource(
+              cb,
+              licenseTracker,
+              toSourceAndMappings(root, inputSeqNum == 0, licenseTracker),
+              sourceMap);
           return null;
         });
+  }
+
+  private void appendInputDelimiter(CodeBuilder cb, int inputSeqNum, Node root) {
+    if (!options.shouldPrintInputDelimiter()) {
+      return;
+    }
+    if ((cb.getLength() > 0) && !cb.endsWith("\n")) {
+      cb.append("\n");
+    }
+    checkState(root.isScript());
+    String inputName = root.getInputId().getIdName();
+    String sourceName = root.getSourceFileName();
+    checkState(sourceName != null);
+    checkState(!sourceName.isEmpty());
+    cb.append(
+            options
+                .getInputDelimiter()
+                .replace("%name%", inputName)
+                .replace("%num%", String.valueOf(inputSeqNum))
+                .replace("%n%", "\n"))
+        .append("\n");
+  }
+
+  private static void appendGeneratedSource(
+      CodeBuilder cb,
+      LicenseTracker licenseTracker,
+      CodePrinter.SourceAndMappings sourceAndMappings,
+      @Nullable SourceMap outputMap) {
+    String code = sourceAndMappings.source;
+
+    // Emit licenses before checking for visible code: a tracker may retain a license for content
+    // that was moved to another input during optimization.
+    for (String license : licenseTracker.emitLicenses()) {
+      cb.append("/*\n").append(license).append("*/\n");
+    }
+    if (code.isEmpty()) {
+      return;
+    }
+
+    if (outputMap != null) {
+      outputMap.setStartingPosition(cb.getLineIndex(), cb.getColumnIndex());
+    }
+    cb.append(code);
+
+    int length = code.length();
+    char lastChar = code.charAt(length - 1);
+    char secondLastChar = length >= 2 ? code.charAt(length - 2) : '\0';
+    if (lastChar != ';' && (lastChar != '\n' || secondLastChar != ';')) {
+      cb.append(";");
+    }
+
+    if (outputMap != null) {
+      for (SourceMap.Mapping mapping : checkNotNull(sourceAndMappings.mappings)) {
+        outputMap.addMapping(mapping);
+      }
+    }
   }
 
   /** Generates JavaScript source code for an AST, doesn't generate source map info. */
@@ -3640,7 +3771,13 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     if (consumer == null) {
       return null;
     }
-    OriginalMapping result = consumer.getMappingForLine(lineNumber, columnNumber + 1);
+    // SourceMapConsumerV3 uses a mutable cursor while looking up mappings. Code generation for
+    // different chunks may query the same input source map concurrently, so serialize lookups per
+    // consumer. Different input source maps can still be queried in parallel.
+    final OriginalMapping result;
+    synchronized (consumer) {
+      result = consumer.getMappingForLine(lineNumber, columnNumber + 1);
+    }
     if (result == null) {
       return OriginalMapping.getDefaultInstance();
     }
@@ -3649,6 +3786,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     String sourceMapOriginalPath = sourceMap.getOriginalPath();
     String resultOriginalPath = result.getOriginalFile();
     final String relativePath;
+    ResolvedSourceMap resolvedSourceMap = this.resolvedSourceMap.get();
 
     // Resolving the paths to a source file is expensive, so check the cache first.
     if (sourceMapOriginalPath.equals(resolvedSourceMap.originalPath)

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1159,15 +1159,23 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
    * <p>DO call it even when {@code hasErrors()} returns true.
    */
   public void performPostCompilationTasks() {
+    performPostCompilationTasks(/* outputTracerReport= */ true);
+  }
+
+  void performPostCompilationTasksWithoutTracerReport() {
+    performPostCompilationTasks(/* outputTracerReport= */ false);
+  }
+
+  private void performPostCompilationTasks(boolean outputTracerReport) {
     runInCompilerThread(
         () -> {
-          performPostCompilationTasksInternal();
+          performPostCompilationTasksInternal(outputTracerReport);
           return null;
         });
   }
 
   /** Performs all the bookkeeping required at the end of a compilation. */
-  private void performPostCompilationTasksInternal() {
+  private void performPostCompilationTasksInternal(boolean outputTracerReport) {
     if (options.getDevMode() == DevMode.START_AND_END) {
       runValidityCheck();
     }
@@ -1177,15 +1185,22 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     // more maintainable.
     ManageClosureUnawareCode.unwrap(this).process(externsRoot, jsRoot);
 
-    if (tracker != null) {
-      if (options.getTracerOutput() == null) {
-        tracker.outputTracerReport(this.outStream);
-      } else {
-        try (PrintStream out = new PrintStream(Files.newOutputStream(options.getTracerOutput()))) {
-          tracker.outputTracerReport(out);
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
+    if (outputTracerReport) {
+      outputTracerReport();
+    }
+  }
+
+  void outputTracerReport() {
+    if (tracker == null) {
+      return;
+    }
+    if (options.getTracerOutput() == null) {
+      tracker.outputTracerReport(this.outStream);
+    } else {
+      try (PrintStream out = new PrintStream(Files.newOutputStream(options.getTracerOutput()))) {
+        tracker.outputTracerReport(out);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
       }
     }
   }
@@ -1723,6 +1738,13 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     long result = t.stop();
     if (options.getTracerMode().isOn() && tracker != null) {
       tracker.recordPassStop(passName, result);
+    }
+  }
+
+  void recordPassRuntime(String passName, long runtime) {
+    if (options.getTracerMode().isOn() && tracker != null) {
+      tracker.recordPassStart(passName, true);
+      tracker.recordPassStop(passName, runtime);
     }
   }
 

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -221,17 +221,14 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
   /** Configured {@link SourceMapInput}s, plus any source maps discovered in source files. */
   ConcurrentHashMap<String, SourceMapInput> inputSourceMaps = new ConcurrentHashMap<>();
 
-  /** Resolved source names and contents, cached because outputting each chunk resets the map. */
-  private final ConcurrentHashMap<SourceMapInput, ImmutableList<SourceMapSourceFile>>
-      sourceMapSourceFiles = new ConcurrentHashMap<>();
-
-  private record SourceMapSourceFile(String name, String code) {}
-
   // Map from filenames to lists of all the comments in each file.
   private Map<String, List<Comment>> commentsPerFile = new ConcurrentHashMap<>();
 
   /** The source code map */
   private SourceMap sourceMap;
+
+  /** Whether all input and compilation source contents have been added to {@link #sourceMap}. */
+  private boolean sourceMapSourcesContentInitialized = false;
 
   /** Extra context appended to the "print source after each pass" output. */
   private String debugMessage;
@@ -844,6 +841,7 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     // Create the source map if necessary.
     if (options.shouldGatherSourceMapInfo()) {
       sourceMap = options.getSourceMapFormat().getInstance();
+      sourceMapSourcesContentInitialized = false;
       sourceMap.setPrefixMappings(options.getSourceMapLocationMappings());
       if (options.getApplyInputSourceMaps()) {
         sourceMap.setSourceFileMapping(this);
@@ -3570,14 +3568,6 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
    */
   private synchronized void addSourceMapSourceFiles(SourceMapInput inputSourceMap) {
     // synchronized annotation guards concurrent access to sourceMap during parsing.
-    ImmutableList<SourceMapSourceFile> sourceFiles = sourceMapSourceFiles.get(inputSourceMap);
-    if (sourceFiles != null) {
-      for (SourceMapSourceFile sourceFile : sourceFiles) {
-        sourceMap.addSourceFile(sourceFile.name(), sourceFile.code());
-      }
-      return;
-    }
-
     SourceMapConsumerV3 consumer = inputSourceMap.getSourceMap(errorManager);
     if (consumer == null) {
       return;
@@ -3588,24 +3578,17 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     }
     Iterator<String> content = sourcesContent.iterator();
     Iterator<String> sources = consumer.getOriginalSources().iterator();
-    ImmutableList.Builder<SourceMapSourceFile> sourceFilesBuilder = ImmutableList.builder();
     while (sources.hasNext() && content.hasNext()) {
       String code = content.next();
       SourceFile source =
           SourceMapResolver.getRelativePath(inputSourceMap.getOriginalPath(), sources.next());
       if (source != null) {
-        sourceFilesBuilder.add(new SourceMapSourceFile(source.getName(), code));
+        sourceMap.addSourceFile(source.getName(), code);
       }
     }
     if (sources.hasNext() || content.hasNext()) {
       throw new RuntimeException(
           "Source map's \"sources\" and \"sourcesContent\" lengths do not match.");
-    }
-
-    sourceFiles = sourceFilesBuilder.build();
-    sourceMapSourceFiles.put(inputSourceMap, sourceFiles);
-    for (SourceMapSourceFile sourceFile : sourceFiles) {
-      sourceMap.addSourceFile(sourceFile.name(), sourceFile.code());
     }
   }
 
@@ -4663,15 +4646,16 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       return;
     }
     sourceMap.reset();
-    if (options.getSourceMapIncludeSourcesContent()) {
+    if (!sourceMapSourcesContentInitialized && options.getSourceMapIncludeSourcesContent()) {
       if (options.getApplyInputSourceMaps()) {
-        // Add any input source map content files to the source map as potential sources
+        // Add any input source map content files to the source map as potential sources.
         for (SourceMapInput inputSourceMap : inputSourceMaps.values()) {
           addSourceMapSourceFiles(inputSourceMap);
         }
       }
 
-      // Add all the compilation sources to the source map as potential sources
+      // Add all compilation sources to the map. SourceMapGeneratorV3 retains source contents across
+      // reset(), so this only needs to happen once for each newly created source map generator.
       Iterable<JSChunk> allChunks = getChunks();
       if (allChunks != null) {
         List<SourceFile> sourceFiles = new ArrayList<>();
@@ -4679,14 +4663,14 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
           for (CompilerInput input : chunk.getInputs()) {
             SourceFile sourceFile = input.getSourceFile();
             if (sourceFile.isStubSourceFileForAlreadyProvidedInput()) {
-              // do not add stub source files to the source map
               continue;
             }
-            sourceFiles.add(input.getSourceFile());
+            sourceFiles.add(sourceFile);
           }
         }
         addFilesToSourceMap(sourceFiles);
       }
+      sourceMapSourcesContentInitialized = true;
     }
   }
 

--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -121,6 +121,10 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -3705,6 +3709,71 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
     }
   }
 
+  @Override
+  public void addInputSourceMaps(Map<String, SourceMapInput> sourceMaps) {
+    inputSourceMaps.putAll(sourceMaps);
+    if (!options.getSourceMapIncludeSourcesContent() || sourceMap == null) {
+      return;
+    }
+
+    ArrayList<SourceMapInput> inputs = new ArrayList<>(sourceMaps.values());
+    int parallelism = Math.min(options.getNumParallelThreads(), inputs.size());
+    if (parallelism <= 1) {
+      for (SourceMapInput input : inputs) {
+        addSourceMapSourceFiles(input);
+      }
+      return;
+    }
+
+    int batchCount = Math.min(inputs.size(), parallelism * 4);
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            parallelism,
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-InputSourceMaps");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<ArrayList<SourceMapSourceContent>>> futures =
+        new ArrayList<>(batchCount);
+    boolean completed = false;
+    try {
+      for (int batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+        int firstInput = inputs.size() * batchIndex / batchCount;
+        int afterLastInput = inputs.size() * (batchIndex + 1) / batchCount;
+        futures.add(
+            executor.submit(
+                () -> {
+                  ArrayList<SourceMapSourceContent> contents = new ArrayList<>();
+                  for (int i = firstInput; i < afterLastInput; i++) {
+                    contents.addAll(getSourceMapSourceFiles(inputs.get(i)));
+                  }
+                  return contents;
+                }));
+      }
+      executor.shutdown();
+      for (Future<ArrayList<SourceMapSourceContent>> future : futures) {
+        ArrayList<SourceMapSourceContent> contents;
+        try {
+          contents = future.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while reading input source maps", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException("Cannot read input source maps", e.getCause());
+        }
+        for (SourceMapSourceContent content : contents) {
+          sourceMap.addSourceFile(content.name, content.code);
+        }
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
   /**
    * Returns the <encoded_source_map> from a `//#
    * sourceMappingURL=data:application/json;base64,<encoded_source_map>` comment. This
@@ -3738,16 +3807,23 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
    * populate sourcesContent array in the output source map even for sources embedded in the input
    * source map.
    */
-  private synchronized void addSourceMapSourceFiles(SourceMapInput inputSourceMap) {
-    // synchronized annotation guards concurrent access to sourceMap during parsing.
+  private void addSourceMapSourceFiles(SourceMapInput inputSourceMap) {
+    for (SourceMapSourceContent content : getSourceMapSourceFiles(inputSourceMap)) {
+      sourceMap.addSourceFile(content.name, content.code);
+    }
+  }
+
+  private ArrayList<SourceMapSourceContent> getSourceMapSourceFiles(
+      SourceMapInput inputSourceMap) {
     SourceMapConsumerV3 consumer = inputSourceMap.getSourceMap(errorManager);
     if (consumer == null) {
-      return;
+      return new ArrayList<>();
     }
     Collection<String> sourcesContent = consumer.getOriginalSourcesContent();
     if (sourcesContent == null) {
-      return;
+      return new ArrayList<>();
     }
+    ArrayList<SourceMapSourceContent> result = new ArrayList<>(sourcesContent.size());
     Iterator<String> content = sourcesContent.iterator();
     Iterator<String> sources = consumer.getOriginalSources().iterator();
     while (sources.hasNext() && content.hasNext()) {
@@ -3755,12 +3831,23 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       SourceFile source =
           SourceMapResolver.getRelativePath(inputSourceMap.getOriginalPath(), sources.next());
       if (source != null) {
-        sourceMap.addSourceFile(source.getName(), code);
+        result.add(new SourceMapSourceContent(source.getName(), code));
       }
     }
     if (sources.hasNext() || content.hasNext()) {
       throw new RuntimeException(
           "Source map's \"sources\" and \"sourcesContent\" lengths do not match.");
+    }
+    return result;
+  }
+
+  private static final class SourceMapSourceContent {
+    final String name;
+    final String code;
+
+    SourceMapSourceContent(String name, String code) {
+      this.name = name;
+      this.code = code;
     }
   }
 

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -416,6 +416,9 @@ public class CompilerOptions {
   // TODO(bradfordcsmith): Investigate how can we use multi-threads as default.
   private int numParallelThreads = 1;
 
+  /** Optional sink for detailed per-function optimization diagnostics. */
+  private @Nullable OptimizationWorkReporter optimizationWorkReporter;
+
   /**
    * Sets the level of parallelism for compilation passes that can exploit multi-threading.
    *
@@ -431,6 +434,14 @@ public class CompilerOptions {
 
   int getNumParallelThreads() {
     return numParallelThreads;
+  }
+
+  void setOptimizationWorkReporter(OptimizationWorkReporter reporter) {
+    this.optimizationWorkReporter = reporter;
+  }
+
+  @Nullable OptimizationWorkReporter getOptimizationWorkReporter() {
+    return optimizationWorkReporter;
   }
 
   // --------------------------------

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -504,6 +504,9 @@ public class CompilerOptions {
   // Remove this.
   private boolean flowSensitiveInlineVariables;
 
+  /** Whether to repeat flow-sensitive variable inlining during finalizations. */
+  private boolean finalFlowSensitiveInlineVariables = true;
+
   /** Removes code associated with unused global names */
   private boolean smartNameRemoval;
 
@@ -2446,6 +2449,14 @@ public class CompilerOptions {
     return flowSensitiveInlineVariables;
   }
 
+  public void setFinalFlowSensitiveInlineVariables(boolean enabled) {
+    this.finalFlowSensitiveInlineVariables = enabled;
+  }
+
+  boolean getFinalFlowSensitiveInlineVariables() {
+    return finalFlowSensitiveInlineVariables;
+  }
+
   public void setSmartNameRemoval(boolean smartNameRemoval) {
     // TODO(bradfordcsmith): Remove the smart name removal option.
     this.smartNameRemoval = smartNameRemoval;
@@ -3481,6 +3492,7 @@ public class CompilerOptions {
         .add("extractPrototypeMemberDeclarations", extractPrototypeMemberDeclarations)
         .add("filesToPrintAfterEachPassRegexList", filesToPrintAfterEachPassRegexList)
         .add("flowSensitiveInlineVariables", flowSensitiveInlineVariables)
+        .add("finalFlowSensitiveInlineVariables", finalFlowSensitiveInlineVariables)
         .add("foldConstants", foldConstants)
         .add("forceLibraryInjection", forceLibraryInjection)
         .add("gatherCssNames", gatherCssNames)

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -560,6 +560,9 @@ public class CompilerOptions {
 
   private boolean useSizeHeuristicToStopOptimizationLoop = true;
 
+  /** Minimum percentage AST-size change considered significant in optimization fixed-point loops. */
+  private double optimizationLoopSizeThreshold = 0.1;
+
   /**
    * Do up to this many iterations of the optimization loop. Setting this field to some small
    * number, say 3 or 4, allows a large project to build faster, but sacrifice some code size.
@@ -3373,6 +3376,15 @@ public class CompilerOptions {
 
   boolean shouldUseSizeHeuristicToStopOptimizationLoop() {
     return this.useSizeHeuristicToStopOptimizationLoop;
+  }
+
+  public void setOptimizationLoopSizeThreshold(double threshold) {
+    checkArgument(threshold >= 0 && threshold <= 100, "invalid threshold: %s", threshold);
+    this.optimizationLoopSizeThreshold = threshold;
+  }
+
+  double getOptimizationLoopSizeThreshold() {
+    return this.optimizationLoopSizeThreshold;
   }
 
   public void setMaxOptimizationLoopIterations(int maxIterations) {

--- a/src/com/google/javascript/jscomp/CompilerOptions.java
+++ b/src/com/google/javascript/jscomp/CompilerOptions.java
@@ -569,6 +569,9 @@ public class CompilerOptions {
    */
   private int optimizationLoopMaxIterations;
 
+  /** Maximum iterations for fixed-point loops that move code without removing it. */
+  private int optimizationMotionLoopMaxIterations;
+
   // --------------------------------
   // Renaming
   // --------------------------------
@@ -3393,6 +3396,14 @@ public class CompilerOptions {
 
   int getMaxOptimizationLoopIterations() {
     return this.optimizationLoopMaxIterations;
+  }
+
+  public void setMaxOptimizationMotionLoopIterations(int maxIterations) {
+    this.optimizationMotionLoopMaxIterations = maxIterations;
+  }
+
+  int getMaxOptimizationMotionLoopIterations() {
+    return this.optimizationMotionLoopMaxIterations;
   }
 
   public ChunkOutputType getChunkOutputType() {

--- a/src/com/google/javascript/jscomp/DeadAssignmentsElimination.java
+++ b/src/com/google/javascript/jscomp/DeadAssignmentsElimination.java
@@ -28,8 +28,15 @@ import com.google.javascript.jscomp.graph.DiGraph.DiGraphNode;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * Removes local variable assignments that are useless based on information from {@link
@@ -42,6 +49,8 @@ class DeadAssignmentsElimination extends NodeTraversal.AbstractCfgCallback imple
   private final AbstractCompiler compiler;
   private LiveVariablesAnalysis liveness;
   private final Deque<BailoutInformation> functionStack;
+  // Worker traversals collect changes locally because the compiler's ChangeTracker is mutable.
+  private final Set<Node> changedScopes = new LinkedHashSet<>();
 
   private static final class BailoutInformation {
     boolean containsFunction;
@@ -58,7 +67,81 @@ class DeadAssignmentsElimination extends NodeTraversal.AbstractCfgCallback imple
     checkNotNull(externs);
     checkNotNull(root);
     checkState(compiler.getLifeCycleStage().isNormalized());
+    int parallelism = compiler.getOptions().getNumParallelThreads();
+    if (parallelism > 1 && root.isRoot() && root.hasMoreThanOneChild()) {
+      processScriptsConcurrently(root, parallelism);
+    } else {
+      traverse(root);
+    }
+    for (Node changedScope : changedScopes) {
+      compiler.reportChangeToChangeScope(changedScope);
+    }
+  }
+
+  private void traverse(Node root) {
     NodeTraversal.traverse(compiler, root, this);
+  }
+
+  private void traverseWithScope(Node root, AbstractScope<?, ?> scope) {
+    NodeTraversal.builder()
+        .setCompiler(compiler)
+        .setCallback(this)
+        .traverseWithScope(root, scope);
+  }
+
+  private void processScriptsConcurrently(Node root, int parallelism) {
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        traverse(root);
+        return;
+      }
+      scripts.add(script);
+    }
+    // Each function's liveness analysis and rewrites are independent. Use one read-only global
+    // scope for serial-equivalent name resolution while workers mutate disjoint script subtrees.
+    AbstractScope<?, ?> globalScope =
+        new SyntacticScopeCreator(compiler).createScope(root, null);
+
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(parallelism, scripts.size()),
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-DeadAssignmentsElimination");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<Set<Node>>> futures = new ArrayList<>(scripts.size());
+    boolean completed = false;
+    try {
+      for (Node script : scripts) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  DeadAssignmentsElimination worker =
+                      new DeadAssignmentsElimination(compiler);
+                  worker.traverseWithScope(script, globalScope);
+                  return worker.changedScopes;
+                }));
+      }
+      executor.shutdown();
+      for (Future<Set<Node>> future : futures) {
+        try {
+          changedScopes.addAll(future.get());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while removing dead assignments", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException(
+              "Cannot remove dead assignments concurrently", e.getCause());
+        }
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
   }
 
   @Override
@@ -261,7 +344,7 @@ class DeadAssignmentsElimination extends NodeTraversal.AbstractCfgCallback imple
       if (rhs != null && rhs.isName() && rhs.getString().equals(var.getName()) && n.isAssign()) {
         rhs.detach();
         n.replaceWith(rhs);
-        compiler.reportChangeToEnclosingScope(rhs);
+        changedScopes.add(checkNotNull(ChangeTracker.getEnclosingChangeScopeRoot(rhs)));
         return;
       }
 
@@ -314,7 +397,7 @@ class DeadAssignmentsElimination extends NodeTraversal.AbstractCfgCallback imple
         throw new IllegalStateException("Unknown statement");
       }
 
-      compiler.reportChangeToEnclosingScope(parent);
+      changedScopes.add(checkNotNull(ChangeTracker.getEnclosingChangeScopeRoot(parent)));
       return;
     } else {
       for (Node c = n.getFirstChild(); c != null;) {

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -112,6 +112,10 @@ public final class DefaultPassConfig extends PassConfig {
   private final transient PreprocessorSymbolTable.CachedInstanceFactory
       preprocessorSymbolTableFactory = new PreprocessorSymbolTable.CachedInstanceFactory();
 
+  /** Shared across the fixed-point instances of RemoveUnusedCode. */
+  private final RemoveUnusedCode.GuardedPolyfillUsageCache guardedPolyfillUsageCache =
+      new RemoveUnusedCode.GuardedPolyfillUsageCache();
+
   public DefaultPassConfig(CompilerOptions options) {
     super(options);
   }
@@ -2425,6 +2429,7 @@ public final class DefaultPassConfig extends PassConfig {
                           options.getForceLibraryInjectionList().isEmpty()
                               && options.getInjectPolyfillsNewerThan() == null)
                       .assumeGettersArePure(options.getAssumeGettersArePure())
+                      .guardedPolyfillUsageCache(guardedPolyfillUsageCache)
                       .build())
           .build();
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -1693,18 +1693,22 @@ public final class DefaultPassConfig extends PassConfig {
       PassFactory.builder()
           .setName("earlyPeepholeOptimizations")
           .setInternalFactory(
-              (compiler) -> {
-                boolean useTypesForOptimization =
-                    compiler.getOptions().shouldUseTypesForLocalOptimization();
-                List<AbstractPeepholeOptimization> peepholeOptimizations = new ArrayList<>();
-                peepholeOptimizations.add(new PeepholeRemoveDeadCode());
-                if (compiler.getOptions().getJ2clPass().shouldAddJ2clPasses()) {
-                  peepholeOptimizations.add(
-                      new J2clEqualitySameRewriterPass(useTypesForOptimization));
-                }
-                return new PeepholeOptimizationsPass(
-                    compiler, "earlyPeepholeOptimizations", peepholeOptimizations);
-              })
+              (compiler) ->
+                  new PeepholeOptimizationsPass(
+                      compiler,
+                      "earlyPeepholeOptimizations",
+                      () -> {
+                        boolean useTypesForOptimization =
+                            compiler.getOptions().shouldUseTypesForLocalOptimization();
+                        List<AbstractPeepholeOptimization> peepholeOptimizations =
+                            new ArrayList<>();
+                        peepholeOptimizations.add(new PeepholeRemoveDeadCode());
+                        if (compiler.getOptions().getJ2clPass().shouldAddJ2clPasses()) {
+                          peepholeOptimizations.add(
+                              new J2clEqualitySameRewriterPass(useTypesForOptimization));
+                        }
+                        return peepholeOptimizations;
+                      }))
           .build();
 
   private final PassFactory earlyInlineVariables =
@@ -1730,6 +1734,14 @@ public final class DefaultPassConfig extends PassConfig {
     checkArgument(
         expectAstIsNormalized == compiler.getLifeCycleStage().isNormalized(),
         compiler.getLifeCycleStage());
+    return new PeepholeOptimizationsPass(
+        compiler,
+        passName,
+        () -> createPeepholeOptimizations(compiler, expectAstIsNormalized));
+  }
+
+  private static List<AbstractPeepholeOptimization> createPeepholeOptimizations(
+      AbstractCompiler compiler, boolean expectAstIsNormalized) {
     final boolean late = false;
     final boolean useTypesForOptimization =
         compiler.getOptions().shouldUseTypesForLocalOptimization();
@@ -1749,7 +1761,7 @@ public final class DefaultPassConfig extends PassConfig {
     }
     optimizations.add(new PeepholeFoldConstants(late, useTypesForOptimization));
     optimizations.add(new PeepholeCollectPropertyAssignments());
-    return new PeepholeOptimizationsPass(compiler, passName, optimizations);
+    return optimizations;
   }
 
   /** Various peephole optimizations. */
@@ -1798,12 +1810,14 @@ public final class DefaultPassConfig extends PassConfig {
                 return new PeepholeOptimizationsPass(
                     compiler,
                     "latePeepholeOptimizations",
-                    new StatementFusion(),
-                    new PeepholeRemoveDeadCode(),
-                    new PeepholeMinimizeConditions(late),
-                    new PeepholeSubstituteAlternateSyntax(late),
-                    new PeepholeReplaceKnownMethods(late, useTypesForOptimization),
-                    new PeepholeFoldConstants(late, useTypesForOptimization));
+                    () ->
+                        List.of(
+                            new StatementFusion(),
+                            new PeepholeRemoveDeadCode(),
+                            new PeepholeMinimizeConditions(late),
+                            new PeepholeSubstituteAlternateSyntax(late),
+                            new PeepholeReplaceKnownMethods(late, useTypesForOptimization),
+                            new PeepholeFoldConstants(late, useTypesForOptimization)));
               })
           .build();
 

--- a/src/com/google/javascript/jscomp/DefaultPassConfig.java
+++ b/src/com/google/javascript/jscomp/DefaultPassConfig.java
@@ -553,7 +553,8 @@ public final class DefaultPassConfig extends PassConfig {
       passes.maybeAdd(peepholeOptimizationsOnceNormalized);
     }
 
-    if (options.shouldInlineVariables() || options.shouldInlineLocalVariables()) {
+    if (options.getFinalFlowSensitiveInlineVariables()
+        && (options.shouldInlineVariables() || options.shouldInlineLocalVariables())) {
       passes.maybeAdd(flowSensitiveInlineVariables);
 
       // After inlining variable uses, some variables may be unused.

--- a/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
+++ b/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
@@ -33,12 +33,17 @@ import com.google.javascript.jscomp.graph.DiGraph.DiGraphEdge;
 import com.google.javascript.jscomp.graph.DiGraph.DiGraphNode;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -73,6 +78,9 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
   private final AbstractCompiler compiler;
 
   private final SideEffectPredicate sideEffectPredicate;
+
+  // Worker traversals collect changes locally because the compiler's ChangeTracker is mutable.
+  private final Set<Node> changedScopes = new LinkedHashSet<>();
 
   // These two pieces of data is persistent in the whole execution of enter
   // scope.
@@ -320,10 +328,90 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
 
   @Override
   public void process(Node externs, Node root) {
+    int parallelism = compiler.getOptions().getNumParallelThreads();
+    if (parallelism > 1
+        && root.isRoot()
+        && root.hasMoreThanOneChild()
+        && compiler.getOptions().getOptimizationWorkReporter() == null) {
+      processScriptsConcurrently(externs, root, parallelism);
+    } else {
+      traverseRoots(externs, root);
+    }
+    for (Node changedScope : changedScopes) {
+      compiler.reportChangeToChangeScope(changedScope);
+    }
+  }
+
+  private void traverseRoots(Node externs, Node root) {
     NodeTraversal.builder()
         .setCompiler(compiler)
         .setCallback(this)
         .traverseRoots(externs, root);
+  }
+
+  private void traverseWithScope(Node root, AbstractScope<?, ?> scope) {
+    NodeTraversal.builder()
+        .setCompiler(compiler)
+        .setCallback(this)
+        .traverseWithScope(root, scope);
+  }
+
+  private void processScriptsConcurrently(Node externs, Node root, int parallelism) {
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        traverseRoots(externs, root);
+        return;
+      }
+      scripts.add(script);
+    }
+    Node globalRoot = checkNotNull(externs.getParent());
+    checkState(root.getParent() == globalRoot);
+    // Function-local analyses and rewrites in different scripts touch disjoint AST subtrees. Give
+    // every worker the same read-only whole-program scope so name resolution remains identical to
+    // the serial traversal.
+    AbstractScope<?, ?> globalScope =
+        new SyntacticScopeCreator(compiler).createScope(globalRoot, null);
+
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(parallelism, scripts.size()),
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-FlowSensitiveInlineVariables");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<Set<Node>>> futures = new ArrayList<>(scripts.size());
+    boolean completed = false;
+    try {
+      for (Node script : scripts) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  FlowSensitiveInlineVariables worker =
+                      new FlowSensitiveInlineVariables(compiler);
+                  worker.traverseWithScope(script, globalScope);
+                  return worker.changedScopes;
+                }));
+      }
+      executor.shutdown();
+      for (Future<Set<Node>> future : futures) {
+        try {
+          changedScopes.addAll(future.get());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while inlining variables", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException(
+              "Cannot inline variables concurrently", e.getCause());
+        }
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
   }
 
   @Override
@@ -557,7 +645,7 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
         while (defParent.getParent().isLabel()) {
           defParent = defParent.getParent();
         }
-        compiler.reportChangeToEnclosingScope(defParent);
+        changedScopes.add(checkNotNull(ChangeTracker.getEnclosingChangeScopeRoot(defParent)));
         defParent.detach();
         use.replaceWith(rhs);
       } else if (NodeUtil.isNameDeclaration(defParent)) {
@@ -573,7 +661,7 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       } else {
         throw new IllegalStateException("No other definitions can be inlined.");
       }
-      compiler.reportChangeToEnclosingScope(useParent);
+      changedScopes.add(checkNotNull(ChangeTracker.getEnclosingChangeScopeRoot(useParent)));
     }
 
     /**

--- a/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
+++ b/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
@@ -413,6 +413,13 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
         return false;
       }
 
+      // Reject multiply-used definitions before doing the more expensive AST and path checks
+      // below. Large generated functions may have hundreds of uses that share the same reaching
+      // definition, none of which can be inlined without increasing code size.
+      if (!hasExactlyOne(reachingUses.getUses(varName, getDefCfgNode()))) {
+        return false;
+      }
+
       getDefinition(getDefCfgNode());
       getNumUseInUseCfgNode(useCfgNode);
 
@@ -468,10 +475,6 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
 
       // Make sure that the name is not within a loop
       if (NodeUtil.isWithinLoop(use)) {
-        return false;
-      }
-
-      if (!hasExactlyOne(reachingUses.getUses(varName, getDefCfgNode()))) {
         return false;
       }
 

--- a/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
+++ b/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
@@ -275,11 +275,16 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       return false;
     }
 
-    if (NodeUtil.isNameDeclaration(n) || isAssignmentToName(n)) {
-      // if it is a simple assignment
-      if (n.getFirstChild().isName()) {
-        return true;
+    if (NodeUtil.isNameDeclaration(n)) {
+      for (Node name = n.getFirstChild(); name != null; name = name.getNext()) {
+        if (name.isName() && name.hasChildren() && isInlineableRhsShape(name.getFirstChild())) {
+          return true;
+        }
       }
+    } else if (n.isAssign()
+        && n.getFirstChild().isName()
+        && isInlineableRhsShape(n.getLastChild())) {
+      return true;
     }
 
     for (Node c = n.getFirstChild(); c != null; c = c.getNext()) {
@@ -290,12 +295,24 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
     return false;
   }
 
-  private static boolean isAssignmentToName(Node n) {
-    if (NodeUtil.isAssignmentOp(n) || n.isDec() || n.isInc()) {
-      // if it is a simple assignment
-      return (n.getFirstChild().isName());
-    }
-    return false;
+  private static boolean isInlineableRhsShape(Node rhs) {
+    return !NodeUtil.has(
+        rhs,
+        (Node input) -> {
+          return switch (input.getToken()) {
+            case GETELEM,
+                GETPROP,
+                OPTCHAIN_GETPROP,
+                OPTCHAIN_GETELEM,
+                CLASS,
+                ARRAYLIT,
+                OBJECTLIT,
+                REGEXP,
+                NEW -> true;
+            default -> false;
+          };
+        },
+        (Node input) -> !input.isFunction());
   }
 
   @Override
@@ -671,28 +688,7 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       // Example:
       // var x = a.b.c; j.c = 1; print(x);
       // Inlining print(a.b.c) is not safe - consider if j were an alias to a.b.
-      if (NodeUtil.has(
-          def.getLastChild(),
-          (Node input) -> {
-            switch (input.getToken()) {
-              case GETELEM,
-                  GETPROP,
-                  OPTCHAIN_GETPROP,
-                  OPTCHAIN_GETELEM,
-                  CLASS,
-                  ARRAYLIT,
-                  OBJECTLIT,
-                  REGEXP,
-                  NEW -> {
-                return true;
-                // unsafe to inline.
-              }
-              default -> {}
-            }
-            return false;
-          },
-          // Recurse if the node is not a function.
-          (Node input) -> !input.isFunction())) {
+      if (!isInlineableRhsShape(def.getLastChild())) {
         return false;
       }
 

--- a/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
+++ b/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
@@ -33,6 +33,8 @@ import com.google.javascript.jscomp.graph.DiGraph.DiGraphEdge;
 import com.google.javascript.jscomp.graph.DiGraph.DiGraphNode;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -78,6 +80,8 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
   private Set<Candidate> candidates;
   private MustBeReachingVariableDef reachingDef;
   private MaybeReachingVariableUse reachingUses;
+  private Map<Node, Integer> candidateCountsByUseCfgNode;
+  private Map<Node, Map<String, Integer>> useCountsByCfgNode;
 
   private class SideEffectPredicate implements Predicate<Node> {
     // Check if there are side effects affecting the value of any of these names
@@ -214,11 +218,17 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
     // Compute the backward reaching use. The CFG and per-function variable info can be reused.
     reachingUses = new MaybeReachingVariableUse(cfg, escaped, allVarsInFn);
     reachingUses.analyze();
+    candidateCountsByUseCfgNode = new IdentityHashMap<>();
+    for (Candidate candidate : candidates) {
+      candidateCountsByUseCfgNode.merge(candidate.useCfgNode, 1, Integer::sum);
+    }
+    useCountsByCfgNode = new IdentityHashMap<>();
     while (!candidates.isEmpty()) {
       Candidate c = candidates.iterator().next();
       Var candidateVar = checkNotNull(allVarsInFn.get(c.varName));
       if (c.canInline(candidateVar.getScope())) {
         c.inlineVariable();
+        useCountsByCfgNode.clear();
         inlinedCount++;
         candidates.remove(c);
 
@@ -421,7 +431,7 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       }
 
       getDefinition(getDefCfgNode());
-      getNumUseInUseCfgNode(useCfgNode);
+      numUsesWithinCfgNode = getNumUsesInCfgNode(useCfgNode);
 
       // Definition was not found.
       if (def == null) {
@@ -581,19 +591,22 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       NodeTraversal.traverse(compiler, n, gatherCb);
     }
 
-    /**
-     * Computes the number of uses of the variable varName and store it in
-     * numUseWithinUseCfgNode.
-     */
-    private void getNumUseInUseCfgNode(final Node cfgNode) {
-
-      numUsesWithinCfgNode = 0;
+    /** Counts name uses, sharing a single traversal when many candidates occupy one CFG node. */
+    private int getNumUsesInCfgNode(final Node cfgNode) {
+      if (candidateCountsByUseCfgNode.getOrDefault(cfgNode, 0) < 4) {
+        return countUsesInCfgNode(cfgNode, varName);
+      }
+      Map<String, Integer> cached = useCountsByCfgNode.get(cfgNode);
+      if (cached != null) {
+        return cached.getOrDefault(varName, 0);
+      }
+      Map<String, Integer> useCounts = new HashMap<>();
       AbstractCfgNodeTraversalCallback gatherCb =
           new AbstractCfgNodeTraversalCallback() {
 
             @Override
             public void visit(NodeTraversal t, Node n, Node parent) {
-              if (n.isName() && n.getString().equals(varName)) {
+              if (n.isName()) {
                 // We make a special exception when the entire cfgNode is a chain
                 // of assignments, since in that case the assignment statements
                 // will happen after the inlining of the right hand side.
@@ -603,23 +616,44 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
                     && isAssignChain(parent, cfgNode)) {
                   // Don't count lhs of top-level assignment chain
                   return;
-                } else {
-                  numUsesWithinCfgNode++;
                 }
+                useCounts.merge(n.getString(), 1, Integer::sum);
               }
-            }
-
-            private boolean isAssignChain(Node child, Node ancestor) {
-              for (Node n = child; n != ancestor; n = n.getParent()) {
-                if (!n.isAssign()) {
-                  return false;
-                }
-              }
-              return true;
             }
           };
 
       NodeTraversal.traverse(compiler, cfgNode, gatherCb);
+      useCountsByCfgNode.put(cfgNode, useCounts);
+      return useCounts.getOrDefault(varName, 0);
+    }
+
+    private int countUsesInCfgNode(final Node cfgNode, String name) {
+      numUsesWithinCfgNode = 0;
+      NodeTraversal.traverse(
+          compiler,
+          cfgNode,
+          new AbstractCfgNodeTraversalCallback() {
+            @Override
+            public void visit(NodeTraversal t, Node n, Node parent) {
+              if (n.isName()
+                  && n.getString().equals(name)
+                  && !(parent.isAssign()
+                      && parent.getFirstChild() == n
+                      && isAssignChain(parent, cfgNode))) {
+                numUsesWithinCfgNode++;
+              }
+            }
+          });
+      return numUsesWithinCfgNode;
+    }
+
+    private boolean isAssignChain(Node child, Node ancestor) {
+      for (Node n = child; n != ancestor; n = n.getParent()) {
+        if (!n.isAssign()) {
+          return false;
+        }
+      }
+      return true;
     }
 
     /**

--- a/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
+++ b/src/com/google/javascript/jscomp/FlowSensitiveInlineVariables.java
@@ -179,6 +179,10 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       return;
     }
 
+    @Nullable OptimizationWorkReporter workReporter =
+        compiler.getOptions().getOptimizationWorkReporter();
+    long workStartNanos = workReporter != null ? System.nanoTime() : 0;
+
     SyntacticScopeCreator scopeCreator = (SyntacticScopeCreator) t.getScopeCreator();
 
     // Compute the forward reaching definition.
@@ -204,6 +208,8 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
     // Using the forward reaching definition search to find all the inline
     // candidates
     NodeTraversal.traverse(compiler, t.getScopeRoot(), new GatherCandidates());
+    int candidateCount = candidates.size();
+    int inlinedCount = 0;
 
     // Compute the backward reaching use. The CFG and per-function variable info can be reused.
     reachingUses = new MaybeReachingVariableUse(cfg, escaped, allVarsInFn);
@@ -213,6 +219,7 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       Var candidateVar = checkNotNull(allVarsInFn.get(c.varName));
       if (c.canInline(candidateVar.getScope())) {
         c.inlineVariable();
+        inlinedCount++;
         candidates.remove(c);
 
         // If candidate "c" has dependencies, then inlining it may have introduced new dependencies
@@ -233,6 +240,17 @@ class FlowSensitiveInlineVariables implements CompilerPass, ScopedCallback {
       } else {
         candidates.remove(c);
       }
+    }
+
+    if (workReporter != null) {
+      workReporter.recordFunction(
+          PassNames.FLOW_SENSITIVE_INLINE_VARIABLES,
+          functionScopeRoot,
+          t.getScope().getVarCount(),
+          cfg.getNodes().size(),
+          candidateCount,
+          inlinedCount,
+          System.nanoTime() - workStartNanos);
     }
   }
 

--- a/src/com/google/javascript/jscomp/GuardedCallback.java
+++ b/src/com/google/javascript/jscomp/GuardedCallback.java
@@ -167,8 +167,9 @@ abstract class GuardedCallback<T> implements NodeTraversal.Callback {
     //    a. the installed {`if`: "x"} guard is removed.
     //    c. pop the final empty context from the stack.
 
-    if (parent == null) {
-      // The first node gets an empty context.
+    if (contextStack.isEmpty()) {
+      // The first node gets an empty context. Its parent may be non-null when NodeTraversal is
+      // traversing the contents of an existing scope root.
       contextStack.push(Context.EMPTY);
     } else {
       // Before traversing any children, we update the stack

--- a/src/com/google/javascript/jscomp/InferConsts.java
+++ b/src/com/google/javascript/jscomp/InferConsts.java
@@ -44,7 +44,7 @@ class InferConsts implements CompilerPass {
     ReferenceCollector collector =
         new ReferenceCollector(
             compiler, ReferenceCollector.DO_NOTHING_BEHAVIOR, new SyntacticScopeCreator(compiler));
-    collector.process(js);
+    collector.processScriptsConcurrently(js);
 
     for (Var v : collector.getAllSymbols()) {
       considerVar(v, collector.getReferences(v));

--- a/src/com/google/javascript/jscomp/OptimizationWorkReporter.java
+++ b/src/com/google/javascript/jscomp/OptimizationWorkReporter.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.javascript.jscomp;
+
+import com.google.javascript.rhino.Node;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/** Collects opt-in diagnostics attributing expensive optimization work to source functions. */
+final class OptimizationWorkReporter {
+
+  private record Entry(
+      String pass,
+      String source,
+      int line,
+      int column,
+      String function,
+      int variables,
+      int cfgNodes,
+      int candidates,
+      int changes,
+      long runtimeNanos) {}
+
+  private static final class SourceSummary {
+    long runtimeNanos;
+    int calls;
+    int variables;
+    int cfgNodes;
+    int candidates;
+    int changes;
+
+    void add(Entry entry) {
+      runtimeNanos += entry.runtimeNanos;
+      calls++;
+      variables += entry.variables;
+      cfgNodes += entry.cfgNodes;
+      candidates += entry.candidates;
+      changes += entry.changes;
+    }
+  }
+
+  private final List<Entry> entries = new ArrayList<>();
+
+  synchronized void recordFunction(
+      String pass,
+      Node function,
+      int variables,
+      int cfgNodes,
+      int candidates,
+      int changes,
+      long runtimeNanos) {
+    String source = function.getSourceFileName();
+    @Nullable String functionName = NodeUtil.getNearestFunctionName(function);
+    entries.add(
+        new Entry(
+            pass,
+            source != null ? source : "<unknown>",
+            function.getLineno(),
+            function.getCharno(),
+            functionName != null ? functionName : "<anonymous>",
+            variables,
+            cfgNodes,
+            candidates,
+            changes,
+            runtimeNanos));
+  }
+
+  synchronized void write(Writer writer) throws IOException {
+    Map<String, SourceSummary> sourceSummaries = new LinkedHashMap<>();
+    for (Entry entry : entries) {
+      sourceSummaries.computeIfAbsent(entry.source, unused -> new SourceSummary()).add(entry);
+    }
+
+    writer.append(
+        "kind\truntime_us\tcalls\tvariables\tcfg_nodes\tcandidates\tchanges\tpass\tsource"
+            + "\tline\tcolumn\tfunction\n");
+    List<Map.Entry<String, SourceSummary>> sortedSourceSummaries =
+        new ArrayList<>(sourceSummaries.entrySet());
+    sortedSourceSummaries.sort(
+        Comparator.<Map.Entry<String, SourceSummary>>comparingLong(
+                entry -> entry.getValue().runtimeNanos)
+            .reversed()
+            .thenComparing(Map.Entry::getKey));
+    for (Map.Entry<String, SourceSummary> entry : sortedSourceSummaries) {
+      SourceSummary summary = entry.getValue();
+      appendRow(
+          writer,
+          "source",
+          summary.runtimeNanos,
+          summary.calls,
+          summary.variables,
+          summary.cfgNodes,
+          summary.candidates,
+          summary.changes,
+          "*",
+          entry.getKey(),
+          0,
+          0,
+          "*");
+    }
+
+    List<Entry> sortedEntries = new ArrayList<>(entries);
+    sortedEntries.sort(
+        Comparator.comparingLong(Entry::runtimeNanos)
+            .reversed()
+            .thenComparing(Entry::source)
+            .thenComparingInt(Entry::line)
+            .thenComparingInt(Entry::column));
+    for (Entry entry : sortedEntries) {
+      appendRow(
+          writer,
+          "function",
+          entry.runtimeNanos,
+          1,
+          entry.variables,
+          entry.cfgNodes,
+          entry.candidates,
+          entry.changes,
+          entry.pass,
+          entry.source,
+          entry.line,
+          entry.column,
+          entry.function);
+    }
+  }
+
+  private static void appendRow(
+      Writer writer,
+      String kind,
+      long runtimeNanos,
+      int calls,
+      int variables,
+      int cfgNodes,
+      int candidates,
+      int changes,
+      String pass,
+      String source,
+      int line,
+      int column,
+      String function)
+      throws IOException {
+    writer
+        .append(kind)
+        .append('\t')
+        .append(Long.toString(runtimeNanos / 1_000))
+        .append('\t')
+        .append(Integer.toString(calls))
+        .append('\t')
+        .append(Integer.toString(variables))
+        .append('\t')
+        .append(Integer.toString(cfgNodes))
+        .append('\t')
+        .append(Integer.toString(candidates))
+        .append('\t')
+        .append(Integer.toString(changes))
+        .append('\t')
+        .append(sanitize(pass))
+        .append('\t')
+        .append(sanitize(source))
+        .append('\t')
+        .append(Integer.toString(line))
+        .append('\t')
+        .append(Integer.toString(column))
+        .append('\t')
+        .append(sanitize(function))
+        .append('\n');
+  }
+
+  private static String sanitize(String value) {
+    return value.replace('\t', ' ').replace('\n', ' ').replace('\r', ' ');
+  }
+}

--- a/src/com/google/javascript/jscomp/OptimizeCalls.java
+++ b/src/com/google/javascript/jscomp/OptimizeCalls.java
@@ -31,6 +31,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -120,13 +124,106 @@ class OptimizeCalls implements CompilerPass {
     }
 
     final ReferenceMap references = new ReferenceMap();
-    NodeTraversal.traverseRoots(
-        compiler, new ReferenceMapBuildingCallback(references), externs, root);
+    buildReferenceMap(externs, root, references);
     eliminateAccessorsFrom(references);
 
     for (CallGraphCompilerPass pass : passes) {
       pass.process(externs, root, references);
     }
+  }
+
+  private void buildReferenceMap(Node externs, Node root, ReferenceMap references) {
+    int parallelism = compiler.getOptions().getNumParallelThreads();
+    if (parallelism <= 1 || !root.isRoot() || !root.hasMoreThanOneChild()) {
+      NodeTraversal.traverseRoots(
+          compiler, new ReferenceMapBuildingCallback(references), externs, root);
+      return;
+    }
+
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        NodeTraversal.traverseRoots(
+            compiler, new ReferenceMapBuildingCallback(references), externs, root);
+        return;
+      }
+      scripts.add(script);
+    }
+
+    Node scopeRoot = checkNotNull(externs.getParent());
+    checkState(root.getParent() == scopeRoot);
+    Scope globalScope = new SyntacticScopeCreator(compiler).createScope(scopeRoot, null);
+    traverseReferenceMapRoot(
+        externs,
+        globalScope,
+        new ReferenceMapBuildingCallback(references),
+        new SyntacticScopeCreator(compiler));
+
+    int batchCount = Math.min(scripts.size(), parallelism * 4);
+    ReferenceMap[] batchResults = new ReferenceMap[batchCount];
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(parallelism, batchCount),
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-OptimizeCalls");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<?>> futures = new ArrayList<>(batchCount);
+    boolean completed = false;
+    try {
+      for (int batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+        int index = batchIndex;
+        int firstScript = scripts.size() * index / batchCount;
+        int afterLastScript = scripts.size() * (index + 1) / batchCount;
+        futures.add(
+            executor.submit(
+                () -> {
+                  ReferenceMap batchReferences = new ReferenceMap();
+                  SyntacticScopeCreator scopeCreator = new SyntacticScopeCreator(compiler);
+                  ReferenceMapBuildingCallback callback =
+                      new ReferenceMapBuildingCallback(batchReferences);
+                  for (int i = firstScript; i < afterLastScript; i++) {
+                    traverseReferenceMapRoot(
+                        scripts.get(i), globalScope, callback, scopeCreator);
+                  }
+                  batchResults[index] = batchReferences;
+                }));
+      }
+      executor.shutdown();
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while collecting call references", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException(
+              "Cannot collect call references concurrently", e.getCause());
+        }
+      }
+      for (ReferenceMap batchReferences : batchResults) {
+        references.mergeFrom(batchReferences);
+      }
+      references.globalScope = globalScope;
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private void traverseReferenceMapRoot(
+      Node root,
+      Scope globalScope,
+      ReferenceMapBuildingCallback callback,
+      SyntacticScopeCreator scopeCreator) {
+    NodeTraversal.builder()
+        .setCompiler(compiler)
+        .setCallback(callback)
+        .setScopeCreator(scopeCreator)
+        .traverseWithScope(root, globalScope);
   }
 
   /**
@@ -170,6 +267,21 @@ class OptimizeCalls implements CompilerPass {
 
     void addPropReference(String name, Node n) {
       addReference(props, name, n);
+    }
+
+    void mergeFrom(ReferenceMap other) {
+      mergeReferences(names, other.names);
+      mergeReferences(props, other.props);
+    }
+
+    private static void mergeReferences(
+        LinkedHashMap<String, ArrayList<Node>> destination,
+        LinkedHashMap<String, ArrayList<Node>> source) {
+      for (Map.Entry<String, ArrayList<Node>> entry : source.entrySet()) {
+        destination
+            .computeIfAbsent(entry.getKey(), unused -> new ArrayList<>())
+            .addAll(entry.getValue());
+      }
     }
 
     Scope getGlobalScope() {

--- a/src/com/google/javascript/jscomp/PeepholeOptimizationsPass.java
+++ b/src/com/google/javascript/jscomp/PeepholeOptimizationsPass.java
@@ -20,8 +20,15 @@ package com.google.javascript.jscomp;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.javascript.jscomp.parsing.parser.FeatureSet;
 import com.google.javascript.rhino.Node;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A compiler pass to run various peephole optimizations (e.g. constant folding,
@@ -34,6 +41,7 @@ class PeepholeOptimizationsPass implements CompilerPass {
   // NOTE: Use a native array rather than a List to avoid creating iterators for every node in the
   // AST.
   private final AbstractPeepholeOptimization[] peepholeOptimizations;
+  private final @Nullable Supplier<List<AbstractPeepholeOptimization>> parallelOptimizationFactory;
   private boolean retraverseOnChange;
 
   /** Creates a peephole optimization pass that runs the given optimizations. */
@@ -46,9 +54,25 @@ class PeepholeOptimizationsPass implements CompilerPass {
       AbstractCompiler compiler,
       String passName,
       List<AbstractPeepholeOptimization> optimizations) {
+    this(compiler, passName, optimizations, null);
+  }
+
+  PeepholeOptimizationsPass(
+      AbstractCompiler compiler,
+      String passName,
+      Supplier<List<AbstractPeepholeOptimization>> optimizationFactory) {
+    this(compiler, passName, optimizationFactory.get(), optimizationFactory);
+  }
+
+  private PeepholeOptimizationsPass(
+      AbstractCompiler compiler,
+      String passName,
+      List<AbstractPeepholeOptimization> optimizations,
+      @Nullable Supplier<List<AbstractPeepholeOptimization>> parallelOptimizationFactory) {
     this.compiler = compiler;
     this.passName = passName;
     this.peepholeOptimizations = optimizations.toArray(new AbstractPeepholeOptimization[0]);
+    this.parallelOptimizationFactory = parallelOptimizationFactory;
     this.retraverseOnChange = true;
   }
 
@@ -67,12 +91,17 @@ class PeepholeOptimizationsPass implements CompilerPass {
         changedScopeNodes == null || !changedScopeNodes.isEmpty();
         changedScopeNodes = compiler.getChangeTracker().getChangedScopeNodesForPass(passName)) {
 
-      if (changedScopeNodes == null) {
+      if (changedScopeNodes == null && canTraverseScriptsConcurrently(root)) {
+        traverseScriptsConcurrently(root);
+      } else if (changedScopeNodes == null) {
         // changedScopeNodes is null if this is the first run of peepholeOptimizationsPass.
-        NodeTraversal.traverse(compiler, root, new PeepCallback());
+        NodeTraversal.traverse(compiler, root, new PeepCallback(peepholeOptimizations));
       } else {
         NodeTraversal.traverseScopeRoots(
-            compiler, changedScopeNodes, new PeepCallback(), /* traverseNested= */ false);
+            compiler,
+            changedScopeNodes,
+            new PeepCallback(peepholeOptimizations),
+            /* traverseNested= */ false);
       }
 
       // Cancel the fixed point if requested.
@@ -84,11 +113,105 @@ class PeepholeOptimizationsPass implements CompilerPass {
     endTraversal();
   }
 
+  private boolean canTraverseScriptsConcurrently(Node root) {
+    if (parallelOptimizationFactory == null
+        || compiler.getOptions().getNumParallelThreads() <= 1
+        || !root.isRoot()
+        || !root.hasMoreThanOneChild()) {
+      return false;
+    }
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void traverseScriptsConcurrently(Node root) {
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      scripts.add(script);
+    }
+    int parallelism = Math.min(compiler.getOptions().getNumParallelThreads(), scripts.size());
+    ChangeTracker.BufferedChanges[] scriptChanges =
+        new ChangeTracker.BufferedChanges[scripts.size()];
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            parallelism,
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-PeepholeOptimizations");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<?>> futures = new ArrayList<>(parallelism);
+    boolean completed = false;
+    try {
+      for (int workerIndex = 0; workerIndex < parallelism; workerIndex++) {
+        int firstScript = workerIndex;
+        futures.add(
+            executor.submit(
+                () -> {
+                  AbstractPeepholeOptimization[] optimizations =
+                      parallelOptimizationFactory
+                          .get()
+                          .toArray(new AbstractPeepholeOptimization[0]);
+                  beginTraversal(optimizations);
+                  try {
+                    for (int scriptIndex = firstScript;
+                        scriptIndex < scripts.size();
+                        scriptIndex += parallelism) {
+                      ChangeTracker.BufferedChanges changes =
+                          compiler.getChangeTracker().beginBufferingChanges();
+                      try {
+                        NodeTraversal.traverse(
+                            compiler,
+                            scripts.get(scriptIndex),
+                            new PeepCallback(optimizations));
+                      } finally {
+                        compiler.getChangeTracker().endBufferingChanges(changes);
+                      }
+                      scriptChanges[scriptIndex] = changes;
+                    }
+                  } finally {
+                    endTraversal(optimizations);
+                  }
+                }));
+      }
+      executor.shutdown();
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while running peephole optimizations", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException(
+              "Cannot run peephole optimizations concurrently", e.getCause());
+        }
+      }
+      for (ChangeTracker.BufferedChanges changes : scriptChanges) {
+        compiler.getChangeTracker().applyBufferedChanges(changes);
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
   private class PeepCallback extends NodeTraversal.AbstractScopedCallback {
+    private final AbstractPeepholeOptimization[] optimizations;
+
+    PeepCallback(AbstractPeepholeOptimization[] optimizations) {
+      this.optimizations = optimizations;
+    }
+
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
       Node currentNode = n;
-      for (AbstractPeepholeOptimization optim : peepholeOptimizations) {
+      for (AbstractPeepholeOptimization optim : optimizations) {
         currentNode = optim.optimizeSubtree(currentNode);
         if (currentNode == null) {
           return;
@@ -109,7 +232,7 @@ class PeepholeOptimizationsPass implements CompilerPass {
     }
 
     private void updateFeatures(NodeTraversal t) {
-      for (AbstractPeepholeOptimization optim : peepholeOptimizations) {
+      for (AbstractPeepholeOptimization optim : optimizations) {
         var newFeatures = optim.getNewFeatures();
         if (!newFeatures.isEmpty()) {
           NodeUtil.addFeaturesToScript(
@@ -122,14 +245,22 @@ class PeepholeOptimizationsPass implements CompilerPass {
 
   /** Make sure that all the optimizations have the current compiler so they can report errors. */
   private void beginTraversal() {
-    for (AbstractPeepholeOptimization optimization : peepholeOptimizations) {
+    beginTraversal(peepholeOptimizations);
+  }
+
+  private void beginTraversal(AbstractPeepholeOptimization[] optimizations) {
+    for (AbstractPeepholeOptimization optimization : optimizations) {
       optimization.beginTraversal(compiler);
     }
   }
 
   /** End the traversal. */
   private void endTraversal() {
-    for (AbstractPeepholeOptimization optimization : peepholeOptimizations) {
+    endTraversal(peepholeOptimizations);
+  }
+
+  private void endTraversal(AbstractPeepholeOptimization[] optimizations) {
+    for (AbstractPeepholeOptimization optimization : optimizations) {
       optimization.endTraversal();
     }
   }

--- a/src/com/google/javascript/jscomp/PeepholeOptimizationsPass.java
+++ b/src/com/google/javascript/jscomp/PeepholeOptimizationsPass.java
@@ -22,6 +22,7 @@ import com.google.javascript.jscomp.parsing.parser.FeatureSet;
 import com.google.javascript.rhino.Node;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -96,6 +97,8 @@ class PeepholeOptimizationsPass implements CompilerPass {
       } else if (changedScopeNodes == null) {
         // changedScopeNodes is null if this is the first run of peepholeOptimizationsPass.
         NodeTraversal.traverse(compiler, root, new PeepCallback(peepholeOptimizations));
+      } else if (canTraverseScopesConcurrently(changedScopeNodes)) {
+        traverseScopesConcurrently(changedScopeNodes);
       } else {
         NodeTraversal.traverseScopeRoots(
             compiler,
@@ -179,17 +182,7 @@ class PeepholeOptimizationsPass implements CompilerPass {
                 }));
       }
       executor.shutdown();
-      for (Future<?> future : futures) {
-        try {
-          future.get();
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new IllegalStateException("Interrupted while running peephole optimizations", e);
-        } catch (ExecutionException e) {
-          throw new IllegalStateException(
-              "Cannot run peephole optimizations concurrently", e.getCause());
-        }
-      }
+      awaitParallelTraversals(futures);
       for (ChangeTracker.BufferedChanges changes : scriptChanges) {
         compiler.getChangeTracker().applyBufferedChanges(changes);
       }
@@ -197,6 +190,109 @@ class PeepholeOptimizationsPass implements CompilerPass {
     } finally {
       if (!completed) {
         executor.shutdownNow();
+      }
+    }
+  }
+
+  private boolean canTraverseScopesConcurrently(List<Node> changedScopeNodes) {
+    if (parallelOptimizationFactory == null
+        || compiler.getOptions().getNumParallelThreads() <= 1
+        || changedScopeNodes.size() <= 1) {
+      return false;
+    }
+    Node firstScript = NodeUtil.getEnclosingScript(changedScopeNodes.get(0));
+    if (firstScript == null) {
+      return false;
+    }
+    for (int i = 1; i < changedScopeNodes.size(); i++) {
+      Node script = NodeUtil.getEnclosingScript(changedScopeNodes.get(i));
+      if (script == null) {
+        return false;
+      }
+      if (script != firstScript) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void traverseScopesConcurrently(List<Node> changedScopeNodes) {
+    LinkedHashMap<Node, ArrayList<Node>> scopesByScript = new LinkedHashMap<>();
+    for (Node changedScope : changedScopeNodes) {
+      scopesByScript
+          .computeIfAbsent(NodeUtil.getEnclosingScript(changedScope), unused -> new ArrayList<>())
+          .add(changedScope);
+    }
+    ArrayList<List<Node>> scopeGroups = new ArrayList<>(scopesByScript.values());
+    int parallelism = Math.min(compiler.getOptions().getNumParallelThreads(), scopeGroups.size());
+    ChangeTracker.BufferedChanges[] groupChanges =
+        new ChangeTracker.BufferedChanges[scopeGroups.size()];
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            parallelism,
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-PeepholeChangedScopes");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<?>> futures = new ArrayList<>(parallelism);
+    boolean completed = false;
+    try {
+      for (int workerIndex = 0; workerIndex < parallelism; workerIndex++) {
+        int firstGroup = workerIndex;
+        futures.add(
+            executor.submit(
+                () -> {
+                  AbstractPeepholeOptimization[] optimizations =
+                      parallelOptimizationFactory
+                          .get()
+                          .toArray(new AbstractPeepholeOptimization[0]);
+                  beginTraversal(optimizations);
+                  try {
+                    for (int groupIndex = firstGroup;
+                        groupIndex < scopeGroups.size();
+                        groupIndex += parallelism) {
+                      ChangeTracker.BufferedChanges changes =
+                          compiler.getChangeTracker().beginBufferingChanges();
+                      try {
+                        NodeTraversal.traverseScopeRoots(
+                            compiler,
+                            scopeGroups.get(groupIndex),
+                            new PeepCallback(optimizations),
+                            /* traverseNested= */ false);
+                      } finally {
+                        compiler.getChangeTracker().endBufferingChanges(changes);
+                      }
+                      groupChanges[groupIndex] = changes;
+                    }
+                  } finally {
+                    endTraversal(optimizations);
+                  }
+                }));
+      }
+      executor.shutdown();
+      awaitParallelTraversals(futures);
+      for (ChangeTracker.BufferedChanges changes : groupChanges) {
+        compiler.getChangeTracker().applyBufferedChanges(changes);
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private static void awaitParallelTraversals(List<Future<?>> futures) {
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("Interrupted while running peephole optimizations", e);
+      } catch (ExecutionException e) {
+        throw new IllegalStateException(
+            "Cannot run peephole optimizations concurrently", e.getCause());
       }
     }
   }

--- a/src/com/google/javascript/jscomp/PerformanceTracker.java
+++ b/src/com/google/javascript/jscomp/PerformanceTracker.java
@@ -244,7 +244,7 @@ public final class PerformanceTracker {
   }
 
   public boolean tracksAstManifest() {
-    return this.mode.isOn();
+    return this.mode != TracerMode.TIMING_ONLY;
   }
 
   public int getRuntime() {

--- a/src/com/google/javascript/jscomp/PhaseOptimizer.java
+++ b/src/com/google/javascript/jscomp/PhaseOptimizer.java
@@ -58,6 +58,7 @@ class PhaseOptimizer implements CompilerPass {
   private final Node jsRoot;
 
   private final boolean useSizeHeuristicToStopOptimizationLoop;
+  private final double optimizationLoopSizeThreshold;
 
   // Checks that passes have reported code changes correctly.
   private ChangeVerifier changeVerifier;
@@ -163,6 +164,7 @@ class PhaseOptimizer implements CompilerPass {
     this.lastChange = START_TIME;
     this.useSizeHeuristicToStopOptimizationLoop =
         comp.getOptions().shouldUseSizeHeuristicToStopOptimizationLoop();
+    this.optimizationLoopSizeThreshold = comp.getOptions().getOptimizationLoopSizeThreshold();
     int maxIterations = comp.getOptions().getMaxOptimizationLoopIterations();
     if (maxIterations > 0 && maxIterations <= MAX_LOOPS) {
       this.optimizationLoopMaxIterations = maxIterations;
@@ -490,10 +492,10 @@ class PhaseOptimizer implements CompilerPass {
     }
 
     /**
-     * If two loop batches in a row made the code less than 0.05% smaller than the previous batches,
-     * stop before the fixpoint. The 0.05% threshold is based on the following heuristic: 1% size
-     * difference matters to our users. 0.1% size difference is borderline relevant. 0.05%
-     * difference between loop batches is unlikely to grow the final output more than 0.1%.
+     * If two loop batches in a row made the code less than 0.1% smaller than the previous batches,
+     * stop before the fixpoint. The 0.1% threshold is based on the following heuristic: 1% size
+     * difference matters to our users, while 0.1% is borderline relevant. Requiring two
+     * consecutive batches below that threshold limits the likely final output difference.
      *
      * <p>Use this criterion only for the two code-removing loops. The code-motion loop may move
      * code around but not remove code, so this criterion is not correct for stopping early.
@@ -508,7 +510,7 @@ class PhaseOptimizer implements CompilerPass {
     private boolean isAstSufficientlyChanging(int oldAstSize, int newAstSize) {
       if (useSizeHeuristicToStopOptimizationLoop && this.isCodeRemovalLoop) {
         float percentChange = 100 * (Math.abs(newAstSize - oldAstSize) / (float) oldAstSize);
-        if (percentChange < 0.05) {
+        if (percentChange < optimizationLoopSizeThreshold) {
           this.howmanyIterationsUnderThreshold++;
         } else {
           this.howmanyIterationsUnderThreshold = 0;

--- a/src/com/google/javascript/jscomp/PhaseOptimizer.java
+++ b/src/com/google/javascript/jscomp/PhaseOptimizer.java
@@ -347,8 +347,8 @@ class PhaseOptimizer implements CompilerPass {
       State state = State.RUN_PASSES_NOT_RUN_IN_PREV_ITER;
       boolean lastIterMadeChanges;
       int count = 1;
-      int astSize = NodeUtil.countAstSize(root);
-      int previousAstSize = astSize;
+      boolean trackAstSize = useSizeHeuristicToStopOptimizationLoop && this.isCodeRemovalLoop;
+      int astSize = trackAstSize ? NodeUtil.countAstSize(root) : 0;
 
       // The loop starts at state RUN_PASSES_NOT_RUN_IN_PREV_ITER and runs all passes.
       // After that, it goes to state RUN_PASSES_THAT_CHANGED_STH_IN_PREV_ITER, and
@@ -396,8 +396,10 @@ class PhaseOptimizer implements CompilerPass {
             }
           }
 
-          previousAstSize = astSize;
-          astSize = NodeUtil.countAstSize(root);
+          int previousAstSize = astSize;
+          if (trackAstSize) {
+            astSize = NodeUtil.countAstSize(root);
+          }
           if (state == State.RUN_PASSES_NOT_RUN_IN_PREV_ITER) {
             if (lastIterMadeChanges && isAstSufficientlyChanging(previousAstSize, astSize)) {
               state = State.RUN_PASSES_THAT_CHANGED_STH_IN_PREV_ITER;

--- a/src/com/google/javascript/jscomp/PhaseOptimizer.java
+++ b/src/com/google/javascript/jscomp/PhaseOptimizer.java
@@ -397,7 +397,7 @@ class PhaseOptimizer implements CompilerPass {
           }
 
           int previousAstSize = astSize;
-          if (trackAstSize) {
+          if (trackAstSize && lastIterMadeChanges) {
             astSize = NodeUtil.countAstSize(root);
           }
           if (state == State.RUN_PASSES_NOT_RUN_IN_PREV_ITER) {

--- a/src/com/google/javascript/jscomp/PhaseOptimizer.java
+++ b/src/com/google/javascript/jscomp/PhaseOptimizer.java
@@ -16,6 +16,7 @@
 
 package com.google.javascript.jscomp;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -23,6 +24,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.javascript.rhino.Node;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -75,6 +78,71 @@ class PhaseOptimizer implements CompilerPass {
   static final int MAX_LOOPS = 100;
   static final String OPTIMIZE_LOOP_ERROR =
       "Fixed point loop exceeded the maximum number of iterations.";
+
+  /** Maintains the AST size by recounting only scripts containing reported changes. */
+  @VisibleForTesting
+  static final class IncrementalAstSize {
+    private static final String CHANGE_TIMELINE_NAME = "PhaseOptimizer.IncrementalAstSize";
+
+    private final Node root;
+    private final ChangeTracker changeTracker;
+    private final IdentityHashMap<Node, Integer> sizesByScript = new IdentityHashMap<>();
+    private int astSize = 1;
+
+    IncrementalAstSize(Node root, ChangeTracker changeTracker) {
+      checkState(root.isRoot(), root);
+      this.root = root;
+      this.changeTracker = changeTracker;
+      for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+        int scriptSize = NodeUtil.countAstSize(script);
+        sizesByScript.put(script, scriptSize);
+        astSize += scriptSize;
+      }
+      // Establish our point in the change timeline. The initial counts already include older
+      // changes, so there is no need to inspect the returned nodes.
+      changeTracker.getChangedScopeNodesForPass(CHANGE_TIMELINE_NAME);
+    }
+
+    int getAstSize() {
+      return astSize;
+    }
+
+    int update() {
+      // Script additions and removals are uncommon in optimization loops, but accounting for them
+      // here keeps this exactly equivalent to recounting the entire root.
+      sizesByScript.entrySet().removeIf(
+          (entry) -> {
+            if (entry.getKey().getParent() == root) {
+              return false;
+            }
+            astSize -= entry.getValue();
+            return true;
+          });
+      for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+        if (!sizesByScript.containsKey(script)) {
+          int scriptSize = NodeUtil.countAstSize(script);
+          sizesByScript.put(script, scriptSize);
+          astSize += scriptSize;
+        }
+      }
+
+      Set<Node> changedScripts = Collections.newSetFromMap(new IdentityHashMap<>());
+      List<Node> changedScopes =
+          checkNotNull(changeTracker.getChangedScopeNodesForPass(CHANGE_TIMELINE_NAME));
+      for (Node changedScope : changedScopes) {
+        Node script =
+            changedScope.isScript() ? changedScope : NodeUtil.getEnclosingScript(changedScope);
+        if (script != null && sizesByScript.containsKey(script)) {
+          changedScripts.add(script);
+        }
+      }
+      for (Node script : changedScripts) {
+        int newSize = NodeUtil.countAstSize(script);
+        astSize += newSize - checkNotNull(sizesByScript.put(script, newSize));
+      }
+      return astSize;
+    }
+  }
 
   /**
    * @see CompilerOptions#optimizationLoopMaxIterations
@@ -348,7 +416,9 @@ class PhaseOptimizer implements CompilerPass {
       boolean lastIterMadeChanges;
       int count = 1;
       boolean trackAstSize = useSizeHeuristicToStopOptimizationLoop && this.isCodeRemovalLoop;
-      int astSize = trackAstSize ? NodeUtil.countAstSize(root) : 0;
+      IncrementalAstSize astSizeTracker =
+          trackAstSize ? new IncrementalAstSize(root, changeTracker) : null;
+      int astSize = trackAstSize ? astSizeTracker.getAstSize() : 0;
 
       // The loop starts at state RUN_PASSES_NOT_RUN_IN_PREV_ITER and runs all passes.
       // After that, it goes to state RUN_PASSES_THAT_CHANGED_STH_IN_PREV_ITER, and
@@ -398,7 +468,7 @@ class PhaseOptimizer implements CompilerPass {
 
           int previousAstSize = astSize;
           if (trackAstSize && lastIterMadeChanges) {
-            astSize = NodeUtil.countAstSize(root);
+            astSize = astSizeTracker.update();
           }
           if (state == State.RUN_PASSES_NOT_RUN_IN_PREV_ITER) {
             if (lastIterMadeChanges && isAstSufficientlyChanging(previousAstSize, astSize)) {

--- a/src/com/google/javascript/jscomp/PhaseOptimizer.java
+++ b/src/com/google/javascript/jscomp/PhaseOptimizer.java
@@ -149,6 +149,7 @@ class PhaseOptimizer implements CompilerPass {
    * @see CompilerOptions#optimizationLoopMaxIterations
    */
   private final int optimizationLoopMaxIterations;
+  private final int optimizationMotionLoopMaxIterations;
 
   /**
    * @param comp the compiler that owns/creates this.
@@ -170,6 +171,13 @@ class PhaseOptimizer implements CompilerPass {
       this.optimizationLoopMaxIterations = maxIterations;
     } else {
       this.optimizationLoopMaxIterations = MAX_LOOPS;
+    }
+    int maxMotionIterations = comp.getOptions().getMaxOptimizationMotionLoopIterations();
+    if (maxMotionIterations > 0 && maxMotionIterations <= MAX_LOOPS) {
+      this.optimizationMotionLoopMaxIterations = maxMotionIterations;
+    } else {
+      // Leave the safety check below in charge of uncapped loops so it still reports an error.
+      this.optimizationMotionLoopMaxIterations = MAX_LOOPS + 1;
     }
   }
 
@@ -434,7 +442,11 @@ class PhaseOptimizer implements CompilerPass {
 
       try {
         while (true) {
-          if (count > optimizationLoopMaxIterations && this.isCodeRemovalLoop) {
+          int maxIterations =
+              this.isCodeRemovalLoop
+                  ? optimizationLoopMaxIterations
+                  : optimizationMotionLoopMaxIterations;
+          if (count > maxIterations) {
             return;
           }
           if (count > MAX_LOOPS) {

--- a/src/com/google/javascript/jscomp/PolyfillUsageFinder.java
+++ b/src/com/google/javascript/jscomp/PolyfillUsageFinder.java
@@ -241,6 +241,23 @@ final class PolyfillUsageFinder {
         compiler, root, new Traverser(this.compiler, polyfillConsumer, Guard.ONLY_GUARDED));
   }
 
+  /**
+   * Passes guarded usages in the given change scopes to {@code polyfillConsumer}, without visiting
+   * scopes nested within them.
+   *
+   * <p>A guard cannot flow across a function boundary, so changed function and script scopes can
+   * be rescanned independently. Avoiding nested scopes is important when only an outer function or
+   * a script changed, since their nested functions may still have valid cached results.
+   */
+  void traverseOnlyGuardedScopeRoots(
+      List<Node> scopeRoots, Consumer<PolyfillUsage> polyfillConsumer) {
+    NodeTraversal.traverseScopeRoots(
+        compiler,
+        scopeRoots,
+        new Traverser(this.compiler, polyfillConsumer, Guard.ONLY_GUARDED),
+        /* traverseNested= */ false);
+  }
+
   private enum Guard {
     ONLY_GUARDED,
     ONLY_UNGUARDED,

--- a/src/com/google/javascript/jscomp/ReferenceCollector.java
+++ b/src/com/google/javascript/jscomp/ReferenceCollector.java
@@ -25,9 +25,14 @@ import com.google.javascript.jscomp.NodeTraversal.ScopedCallback;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.StaticSymbolTable;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -72,6 +77,8 @@ public final class ReferenceCollector implements CompilerPass, StaticSymbolTable
 
   private @Nullable Scope narrowScope;
 
+  private @Nullable BasicBlock sharedGlobalBlock;
+
   /** Constructor initializes block stack. */
   public ReferenceCollector(AbstractCompiler compiler, Behavior behavior, ScopeCreator creator) {
     this(compiler, behavior, creator, Predicates.alwaysTrue());
@@ -105,6 +112,92 @@ public final class ReferenceCollector implements CompilerPass, StaticSymbolTable
 
   public void process(Node root) {
     this.createTraversalBuilder().traverse(root);
+  }
+
+  /** Collects independent scripts concurrently, then merges references in source order. */
+  void processScriptsConcurrently(Node root) {
+    int parallelism = compiler.getOptions().getNumParallelThreads();
+    if (parallelism <= 1
+        || behavior != DO_NOTHING_BEHAVIOR
+        || !(scopeCreator instanceof SyntacticScopeCreator)
+        || !root.isRoot()
+        || !root.hasMoreThanOneChild()) {
+      process(root);
+      return;
+    }
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        process(root);
+        return;
+      }
+      scripts.add(script);
+    }
+
+    Scope globalScope = scopeCreator.createScope(root, null).untyped();
+    BasicBlock globalBlock = new BasicBlock(null, root);
+    int batchCount = Math.min(scripts.size(), parallelism * 4);
+    ReferenceCollector[] batchCollectors = new ReferenceCollector[batchCount];
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(parallelism, batchCount),
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-ReferenceCollector");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<?>> futures = new ArrayList<>(batchCount);
+    boolean completed = false;
+    try {
+      for (int batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+        int index = batchIndex;
+        int firstScript = scripts.size() * index / batchCount;
+        int afterLastScript = scripts.size() * (index + 1) / batchCount;
+        futures.add(
+            executor.submit(
+                () -> {
+                  ReferenceCollector collector =
+                      new ReferenceCollector(
+                          compiler,
+                          DO_NOTHING_BEHAVIOR,
+                          new SyntacticScopeCreator(compiler),
+                          varFilter);
+                  collector.sharedGlobalBlock = globalBlock;
+                  for (int i = firstScript; i < afterLastScript; i++) {
+                    collector
+                        .createTraversalBuilder()
+                        .traverseWithScope(scripts.get(i), globalScope);
+                  }
+                  batchCollectors[index] = collector;
+                }));
+      }
+      executor.shutdown();
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while collecting references", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException("Cannot collect references concurrently", e.getCause());
+        }
+      }
+      for (ReferenceCollector collector : batchCollectors) {
+        for (Map.Entry<Var, ReferenceCollection> entry : collector.referenceMap.entrySet()) {
+          ReferenceCollection references = referenceMap.get(entry.getKey());
+          if (references == null) {
+            referenceMap.put(entry.getKey(), entry.getValue());
+          } else {
+            references.references.addAll(entry.getValue().references);
+          }
+        }
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
   }
 
   /**
@@ -231,7 +324,11 @@ public final class ReferenceCollector implements CompilerPass, StaticSymbolTable
       // the ES5 scoping rules. Other nodes that ought to be considered the root of a BasicBlock
       // are added in shouldTraverse() or processScope() and removed in visit().
       if (t.isHoistScope()) {
-        pushNewBlock(t.getScopeRoot());
+        if (t.getScope().isGlobal() && sharedGlobalBlock != null) {
+          blockStack.addLast(sharedGlobalBlock);
+        } else {
+          pushNewBlock(t.getScopeRoot());
+        }
       }
     }
 

--- a/src/com/google/javascript/jscomp/RemoveUnusedCode.java
+++ b/src/com/google/javascript/jscomp/RemoveUnusedCode.java
@@ -41,8 +41,10 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
@@ -82,6 +84,61 @@ import org.jspecify.annotations.Nullable;
  * right before the moment an attempt to remove them would otherwise be made.
  */
 class RemoveUnusedCode implements CompilerPass {
+
+  /** Caches guarded polyfill usages across fixed-point iterations. */
+  static final class GuardedPolyfillUsageCache {
+    private static final AtomicInteger NEXT_ID = new AtomicInteger();
+
+    // ChangeTracker identifies clients by name, so every independently-created cache needs a
+    // distinct name. DefaultPassConfig shares one cache across all RemoveUnusedCode instances.
+    private final String changeTrackerName =
+        RemoveUnusedCode.class.getName() + ".guardedPolyfills." + NEXT_ID.getAndIncrement();
+    private final Map<Node, Set<Node>> usagesByChangeScope = new LinkedHashMap<>();
+    private final Set<Node> allUsages = new LinkedHashSet<>();
+    private @Nullable AbstractCompiler compiler;
+    private @Nullable Node root;
+    private boolean initialized = false;
+
+    Set<Node> getGuardedUsages(AbstractCompiler compiler, Polyfills polyfills, Node root) {
+      if (this.compiler != compiler || this.root != root) {
+        this.compiler = compiler;
+        this.root = root;
+        this.initialized = false;
+        this.usagesByChangeScope.clear();
+        this.allUsages.clear();
+      }
+
+      List<Node> changedScopeRoots =
+          compiler.getChangeTracker().getChangedScopeNodesForPass(changeTrackerName);
+      if (!initialized) {
+        usagesByChangeScope.clear();
+        allUsages.clear();
+        new PolyfillUsageFinder(compiler, polyfills).traverseOnlyGuarded(root, this::storeUsage);
+        initialized = true;
+      } else if (!checkNotNull(changedScopeRoots).isEmpty()) {
+        for (Node changedScopeRoot : changedScopeRoots) {
+          Set<Node> invalidatedUsages = usagesByChangeScope.remove(changedScopeRoot);
+          if (invalidatedUsages != null) {
+            allUsages.removeAll(invalidatedUsages);
+          }
+        }
+        new PolyfillUsageFinder(compiler, polyfills)
+            .traverseOnlyGuardedScopeRoots(changedScopeRoots, this::storeUsage);
+      }
+
+      return allUsages;
+    }
+
+    private void storeUsage(PolyfillUsage usage) {
+      Node changeScopeRoot = ChangeTracker.getEnclosingChangeScopeRoot(usage.node());
+      checkNotNull(changeScopeRoot);
+      Node usageNode = usage.node();
+      usagesByChangeScope
+          .computeIfAbsent(changeScopeRoot, unused -> new LinkedHashSet<>())
+          .add(usageNode);
+      allUsages.add(usageNode);
+    }
+  }
 
   // Properties that are implicitly used as part of the JS language.
   private static final ImmutableSet<String> IMPLICITLY_USED_PROPERTIES =
@@ -128,7 +185,9 @@ class RemoveUnusedCode implements CompilerPass {
    */
   private final Multimap<String, PolyfillInfo> polyfills = HashMultimap.create();
 
-  private final Set<Node> guardedUsages = new LinkedHashSet<>();
+  private Set<Node> guardedUsages = Set.of();
+
+  private final GuardedPolyfillUsageCache guardedPolyfillUsageCache;
 
   private final Polyfills polyfillsFromTable;
 
@@ -158,6 +217,7 @@ class RemoveUnusedCode implements CompilerPass {
     this.removeUnusedObjectDefinePropertiesDefinitions =
         builder.removeUnusedObjectDefinePropertiesDefinitions;
     this.removeUnusedPolyfills = builder.removeUnusedPolyfills;
+    this.guardedPolyfillUsageCache = builder.guardedPolyfillUsageCache;
     this.polyfillsFromTable =
         Polyfills.fromTable(
             ResourceLoader.loadTextResource(RemoveUnusedCode.class, "js/polyfills.txt"));
@@ -178,6 +238,8 @@ class RemoveUnusedCode implements CompilerPass {
     private boolean removeUnusedObjectDefinePropertiesDefinitions = false;
     private boolean removeUnusedPolyfills = false;
     private boolean assumeGettersArePure = false;
+    private GuardedPolyfillUsageCache guardedPolyfillUsageCache =
+        new GuardedPolyfillUsageCache();
 
     Builder(AbstractCompiler compiler) {
       this.compiler = compiler;
@@ -228,6 +290,12 @@ class RemoveUnusedCode implements CompilerPass {
     @CanIgnoreReturnValue
     Builder assumeGettersArePure(boolean value) {
       this.assumeGettersArePure = value;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    Builder guardedPolyfillUsageCache(GuardedPolyfillUsageCache value) {
+      this.guardedPolyfillUsageCache = value;
       return this;
     }
 
@@ -367,9 +435,12 @@ class RemoveUnusedCode implements CompilerPass {
           NodeUtil.JSC_PROPERTY_NAME_FN, /* no declaration node */ null, /* no input */ null);
     }
 
-    // Accumulate guarded usages of polyfills before removal starts.
-    new PolyfillUsageFinder(compiler, polyfillsFromTable)
-        .traverseOnlyGuarded(root, this::storePolyfill);
+    // Accumulate guarded usages of polyfills before removal starts. Most optimization iterations
+    // change only a small fraction of all scopes, so reuse results for every unchanged scope.
+    guardedUsages =
+        removeUnusedPolyfills
+            ? guardedPolyfillUsageCache.getGuardedUsages(compiler, polyfillsFromTable, root)
+            : Set.of();
 
     worklist.add(new Continuation(root, scope));
     while (!worklist.isEmpty()) {
@@ -382,10 +453,6 @@ class RemoveUnusedCode implements CompilerPass {
     for (Scope fparamScope : allFunctionParamScopes) {
       removeUnreferencedFunctionArgs(fparamScope);
     }
-  }
-
-  private void storePolyfill(PolyfillUsage polyfillUsage) {
-    this.guardedUsages.add(polyfillUsage.node());
   }
 
   private void removeIndependentlyRemovableProperties() {

--- a/src/com/google/javascript/jscomp/RenameVars.java
+++ b/src/com/google/javascript/jscomp/RenameVars.java
@@ -37,6 +37,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -85,12 +89,6 @@ final class RenameVars implements CompilerPass {
 
   /** Counter for each assignment */
   private int assignmentCount = 0;
-
-  // Logic for bleeding functions, where the name leaks into the outer
-  // scope on IE but not on other browsers.
-  private final Set<Var> localBleedingFunctions = new LinkedHashSet<>();
-  private final ListMultimap<Scope, Var> localBleedingFunctionsPerScope =
-      ArrayListMultimap.create();
 
   class Assignment {
     final boolean isLocal;
@@ -191,6 +189,19 @@ final class RenameVars implements CompilerPass {
    */
   class ProcessVars extends AbstractPostOrderCallback implements ScopedCallback {
 
+    final ArrayList<Node> globalNameNodes = new ArrayList<>();
+    final ArrayList<Node> localNameNodes = new ArrayList<>();
+    final Map<Node, String> originalNameByNode = new LinkedHashMap<>();
+    final @Nullable Map<Node, String> pseudoNameMap =
+        RenameVars.this.pseudoNameMap == null ? null : new LinkedHashMap<>();
+    final Set<String> reservedNames = new LinkedHashSet<>();
+    final Map<String, Integer> assignmentCounts = new LinkedHashMap<>();
+
+    // Logic for bleeding functions, where the name leaks into the outer scope on IE but not on
+    // other browsers. These scopes are private to one script traversal.
+    final Set<Var> localBleedingFunctions = new LinkedHashSet<>();
+    final ListMultimap<Scope, Var> localBleedingFunctionsPerScope = ArrayListMultimap.create();
+
     @Override
     public void enterScope(NodeTraversal t) {
       if (t.inGlobalHoistScope() || !shouldTemporarilyRenameLocalsInScope(t.getScope())) {
@@ -264,7 +275,7 @@ final class RenameVars implements CompilerPass {
       }
 
       if (pseudoNameMap != null) {
-        recordPseudoName(n);
+        pseudoNameMap.put(n, '$' + n.getString() + "$$");
       }
 
       if (local && shouldTemporarilyRenameLocalsInScope(var.getScope())) {
@@ -286,8 +297,31 @@ final class RenameVars implements CompilerPass {
 
     // Increment count of an assignment
     void incCount(String name) {
-      Assignment s = assignments.computeIfAbsent(name, Assignment::new);
-      s.count++;
+      assignmentCounts.merge(name, 1, Integer::sum);
+    }
+
+    private int getLocalVarIndex(Var v) {
+      int num = v.getIndex();
+      Scope s = v.getScope().getParent();
+      if (s == null) {
+        throw new IllegalArgumentException("Var is not local");
+      }
+
+      boolean isBleedingIntoScope = s.getParent() != null && localBleedingFunctions.contains(v);
+
+      while (s.getParent() != null) {
+        if (isBleedingIntoScope) {
+          num += localBleedingFunctionsPerScope.get(s).indexOf(v) + 1;
+          isBleedingIntoScope = false;
+        } else {
+          num += localBleedingFunctionsPerScope.get(s).size();
+        }
+        if (shouldTemporarilyRenameLocalsInScope(s)) {
+          num += s.getVarCount();
+        }
+        s = s.getParent();
+      }
+      return num;
     }
   }
 
@@ -314,8 +348,7 @@ final class RenameVars implements CompilerPass {
 
     originalNameByNode.clear();
 
-    // Do variable reference counting.
-    NodeTraversal.traverse(compiler, root, new ProcessVars());
+    collectVariableReferences(root);
 
     // Make sure that new names don't overlap with extern names.
     reservedNames.addAll(externNames);
@@ -340,6 +373,95 @@ final class RenameVars implements CompilerPass {
     // Rename the locals!
     for (Node n : localNameNodes) {
       setNameAndReport(n, getNewLocalName(n));
+    }
+  }
+
+  private void collectVariableReferences(Node root) {
+    int parallelism = compiler.getOptions().getNumParallelThreads();
+    if (parallelism <= 1 || !root.isRoot() || !root.hasMoreThanOneChild()) {
+      ProcessVars processVars = new ProcessVars();
+      NodeTraversal.traverse(compiler, root, processVars);
+      mergeProcessVars(processVars);
+      return;
+    }
+
+    ArrayList<Node> scripts = new ArrayList<>();
+    for (Node script = root.getFirstChild(); script != null; script = script.getNext()) {
+      if (!script.isScript()) {
+        ProcessVars processVars = new ProcessVars();
+        NodeTraversal.traverse(compiler, root, processVars);
+        mergeProcessVars(processVars);
+        return;
+      }
+      scripts.add(script);
+    }
+
+    Scope globalScope = new SyntacticScopeCreator(compiler).createScope(root, null);
+    int batchCount = Math.min(scripts.size(), parallelism * 4);
+    ProcessVars[] batchResults = new ProcessVars[batchCount];
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(parallelism, batchCount),
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-RenameVars");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<?>> futures = new ArrayList<>(batchCount);
+    boolean completed = false;
+    try {
+      for (int batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+        int index = batchIndex;
+        int firstScript = scripts.size() * index / batchCount;
+        int afterLastScript = scripts.size() * (index + 1) / batchCount;
+        futures.add(
+            executor.submit(
+                () -> {
+                  ProcessVars processVars = new ProcessVars();
+                  SyntacticScopeCreator scopeCreator = new SyntacticScopeCreator(compiler);
+                  for (int i = firstScript; i < afterLastScript; i++) {
+                    NodeTraversal.builder()
+                        .setCompiler(compiler)
+                        .setCallback(processVars)
+                        .setScopeCreator(scopeCreator)
+                        .traverseWithScope(scripts.get(i), globalScope);
+                  }
+                  batchResults[index] = processVars;
+                }));
+      }
+      executor.shutdown();
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while collecting variables", e);
+        } catch (ExecutionException e) {
+          throw new IllegalStateException("Cannot collect variables concurrently", e.getCause());
+        }
+      }
+      for (ProcessVars processVars : batchResults) {
+        mergeProcessVars(processVars);
+      }
+      completed = true;
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private void mergeProcessVars(ProcessVars processVars) {
+    globalNameNodes.addAll(processVars.globalNameNodes);
+    localNameNodes.addAll(processVars.localNameNodes);
+    originalNameByNode.putAll(processVars.originalNameByNode);
+    if (pseudoNameMap != null) {
+      pseudoNameMap.putAll(checkNotNull(processVars.pseudoNameMap));
+    }
+    reservedNames.addAll(processVars.reservedNames);
+    for (Map.Entry<String, Integer> entry : processVars.assignmentCounts.entrySet()) {
+      Assignment assignment = assignments.computeIfAbsent(entry.getKey(), Assignment::new);
+      assignment.count += entry.getValue();
     }
   }
 
@@ -385,12 +507,6 @@ final class RenameVars implements CompilerPass {
       return a.newName;
     }
     return null;
-  }
-
-  private void recordPseudoName(Node n) {
-    // Variable names should be in a different name space than
-    // property pseudo names.
-    pseudoNameMap.put(n, '$' + n.getString() + "$$");
   }
 
   /**
@@ -520,35 +636,6 @@ final class RenameVars implements CompilerPass {
    */
   private boolean okToRenameVar(String name, boolean isLocal) {
     return !compiler.getCodingConvention().isExported(name, /* local= */ isLocal);
-  }
-
-  /**
-   * Returns the index within the scope stack.
-   * e.g. function Foo(a) { var b; function c(d) { } }
-   * a = 0, b = 1, c = 2, d = 3
-   */
-  private int getLocalVarIndex(Var v) {
-    int num = v.getIndex();
-    Scope s = v.getScope().getParent();
-    if (s == null) {
-      throw new IllegalArgumentException("Var is not local");
-    }
-
-    boolean isBleedingIntoScope = s.getParent() != null && localBleedingFunctions.contains(v);
-
-    while (s.getParent() != null) {
-      if (isBleedingIntoScope) {
-        num += localBleedingFunctionsPerScope.get(s).indexOf(v) + 1;
-        isBleedingIntoScope = false;
-      } else {
-        num += localBleedingFunctionsPerScope.get(s).size();
-      }
-      if (shouldTemporarilyRenameLocalsInScope(s)) {
-        num += s.getVarCount();
-      }
-      s = s.getParent();
-    }
-    return num;
   }
 
   /**

--- a/src/com/google/javascript/jscomp/ReplaceCssNames.java
+++ b/src/com/google/javascript/jscomp/ReplaceCssNames.java
@@ -173,8 +173,8 @@ class ReplaceCssNames implements CompilerPass {
   @Override
   public void process(Node externs, Node root) {
     NodeTraversal.traverse(compiler, root, new FindSetCssNameTraversal());
-    List<GetCssNameInstance> getCssNameInstances = gatherGetCssNameInstances(root);
-    for (GetCssNameInstance getCssNameInstance : getCssNameInstances) {
+    GatherCssNamesTraversal gatheredCssNames = gatherCssNames(root);
+    for (GetCssNameInstance getCssNameInstance : gatheredCssNames.listOfCssNameInstances) {
       String cssClassName = getCssNameInstance.getCssClassName();
       if (getCssNameInstance.isCssClosureFileClassesMember()) {
         cssNamesBySymbol.put(getCssNameInstance.getCssClosureClassesMemberName(), cssClassName);
@@ -184,7 +184,7 @@ class ReplaceCssNames implements CompilerPass {
       }
       getCssNameInstance.replaceWithExpression();
     }
-    NodeTraversal.traverse(compiler, root, new CountCssNamesBySymbol());
+    countCssNamesBySymbol(gatheredCssNames.classesObjectReferences);
   }
 
   /**
@@ -197,10 +197,10 @@ class ReplaceCssNames implements CompilerPass {
    *   goog.getCssName(goog.getCssName('me-first'), 'me-second')
    * </code></pre>
    */
-  private List<GetCssNameInstance> gatherGetCssNameInstances(Node root) {
+  private GatherCssNamesTraversal gatherCssNames(Node root) {
     GatherCssNamesTraversal gatherCssNamesTraversal = new GatherCssNamesTraversal();
     NodeTraversal.traverse(compiler, root, gatherCssNamesTraversal);
-    return gatherCssNamesTraversal.listOfCssNameInstances;
+    return gatherCssNamesTraversal;
   }
 
   // This is used only for qualified name comparison, so it's OK to build it with IR instead of
@@ -228,6 +228,7 @@ class ReplaceCssNames implements CompilerPass {
 
   private class GatherCssNamesTraversal implements NodeTraversal.Callback {
     final List<GetCssNameInstance> listOfCssNameInstances = new ArrayList<>();
+    final List<Node> classesObjectReferences = new ArrayList<>();
     final TraversalState traversalState = new TraversalState();
 
     @Override
@@ -242,6 +243,7 @@ class ReplaceCssNames implements CompilerPass {
       if (n.isScript()) {
         traversalState.inSassGeneratedCssTsScript =
             sassGeneratedCssTsExpert.hasSassGeneratedCssTsJsDoc;
+        traversalState.collectClassesObjectReferences = isNotInCssClosureFile(n);
         traversalState.cssClosureClassesQualifiedName = null;
       } else if (traversalState.inSassGeneratedCssTsScript
           && sassGeneratedCssTsExpert.isCssClosureClassesAssignment) {
@@ -253,6 +255,13 @@ class ReplaceCssNames implements CompilerPass {
 
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
+      // A generated classes object always ends in `.classes`. Remember these few possible
+      // references now so that we don't need another traversal after discovering their symbols.
+      if (traversalState.collectClassesObjectReferences
+          && n.isGetProp()
+          && n.getString().equals("classes")) {
+        classesObjectReferences.add(n);
+      }
       if (isGetCssNameCall(n)) {
         GetCssNameInstance getCssNameInstance =
             createGetCssNameInstance(n, traversalState.cssClosureClassesQualifiedName);
@@ -312,6 +321,7 @@ class ReplaceCssNames implements CompilerPass {
 
     private static class TraversalState {
       boolean inSassGeneratedCssTsScript;
+      boolean collectClassesObjectReferences;
       String cssClosureClassesQualifiedName;
     }
   }
@@ -553,33 +563,22 @@ class ReplaceCssNames implements CompilerPass {
     }
   }
 
-  private class CountCssNamesBySymbol implements NodeTraversal.Callback {
-    @Override
-    public boolean shouldTraverse(NodeTraversal t, Node n, Node parent) {
-      if (n.isScript()) {
-        // Only descend into source files NOT named `*.css.closure.js`
-        return isNotInCssClosureFile(n);
-      } else {
-        return true; // descend into every other node
-      }
-    }
-
-    @Override
-    public void visit(NodeTraversal t, Node n, Node parent) {
+  private void countCssNamesBySymbol(List<Node> classesObjectReferences) {
+    for (Node n : classesObjectReferences) {
       String classesObjectQualifiedName = n.getQualifiedName();
       if (classesObjectQualifiedName == null
           || !classesObjectsQualifiedNames.contains(classesObjectQualifiedName)) {
-        return;
+        continue;
       }
       Node classNameNode = n.getParent();
-      if (!n.isGetProp() || !classNameNode.isGetProp()) {
+      if (!classNameNode.isGetProp()) {
         compiler.report(JSError.make(n, INVALID_USE_OF_CLASSES_OBJECT_ERROR));
-        return;
+        continue;
       }
       String classQualifiedName = classNameNode.getQualifiedName();
       if (classQualifiedName == null || !cssNamesBySymbol.containsKey(classQualifiedName)) {
         compiler.report(JSError.make(n, UNKNOWN_SYMBOL_ERROR, classNameNode.getString()));
-        return;
+        continue;
       }
       String className = cssNamesBySymbol.get(classQualifiedName);
       cssNameCollector.add(className);

--- a/src/com/google/javascript/jscomp/Scope.java
+++ b/src/com/google/javascript/jscomp/Scope.java
@@ -94,6 +94,21 @@ public final class Scope extends AbstractScope<Scope, Var> {
     return var;
   }
 
+  /** Declares a variable after the caller has checked for duplicates and illegal shadowing. */
+  Var declareWithoutSlotCheck(String name, Node nameNode, CompilerInput input) {
+    checkArgument(!name.isEmpty());
+    Var var =
+        new Var(
+            name,
+            nameNode,
+            this,
+            getVarCount(),
+            input,
+            /* implicitGoogNamespaceDefinition= */ null);
+    declareInternalWithoutChecks(name, var);
+    return var;
+  }
+
   /**
    * Declares an implicit goog.provide or goog.module namespace in this scope
    *

--- a/src/com/google/javascript/jscomp/SourceMap.java
+++ b/src/com/google/javascript/jscomp/SourceMap.java
@@ -291,6 +291,13 @@ public final class SourceMap {
     sourceLocationFixupCache.clear();
   }
 
+  SourceMap snapshot() {
+    SourceMap snapshot = new SourceMap(generator.snapshot());
+    snapshot.prefixMappings = this.prefixMappings;
+    snapshot.mapping = this.mapping;
+    return snapshot;
+  }
+
   public void setStartingPosition(int offsetLine, int offsetIndex) {
     generator.setStartingPosition(offsetLine, offsetIndex);
   }

--- a/src/com/google/javascript/jscomp/SourceMapInput.java
+++ b/src/com/google/javascript/jscomp/SourceMapInput.java
@@ -70,11 +70,15 @@ public final class SourceMapInput {
       } catch (IOException e) {
         JSError error =
             JSError.make(SourceMapInput.SOURCEMAP_RESOLVE_FAILED, sourceMapPath, e.getMessage());
-        errorManager.report(error.defaultLevel(), error);
+        synchronized (errorManager) {
+          errorManager.report(error.defaultLevel(), error);
+        }
       } catch (SourceMapParseException e) {
         JSError error =
             JSError.make(SourceMapInput.SOURCEMAP_PARSE_FAILED, sourceMapPath, e.getMessage());
-        errorManager.report(error.defaultLevel(), error);
+        synchronized (errorManager) {
+          errorManager.report(error.defaultLevel(), error);
+        }
       }
     }
     return parsedSourceMap;

--- a/src/com/google/javascript/jscomp/SyntacticScopeCreator.java
+++ b/src/com/google/javascript/jscomp/SyntacticScopeCreator.java
@@ -336,7 +336,9 @@ public final class SyntacticScopeCreator implements ScopeCreator {
               || s.isFunctionBlockScope()) && name.equals(ARGUMENTS))) {
         redeclarationHandler.onRedeclaration(s, name, n, input);
       } else {
-        s.declare(name, n, input);
+        // The checks above establish the same absence and shadowing invariants that Scope.declare()
+        // normally verifies. Avoid repeating those map lookups in this scope-building hot path.
+        s.declareWithoutSlotCheck(name, n, input);
       }
     }
 

--- a/src/com/google/javascript/jscomp/serialization/ScriptNodeDeserializer.java
+++ b/src/com/google/javascript/jscomp/serialization/ScriptNodeDeserializer.java
@@ -46,6 +46,7 @@ final class ScriptNodeDeserializer {
   private final SourceFile sourceFile;
   private final ByteString scriptBytes;
   private final String sourceMappingURL;
+  private final String sourceMapPath;
   private final Optional<ColorPool.ShardView> colorPoolShard;
   private final StringPool stringPool;
   private final ImmutableList<SourceFile> filePool;
@@ -58,6 +59,7 @@ final class ScriptNodeDeserializer {
     this.scriptBytes = ast.getScript();
     this.sourceFile = filePool.get(ast.getSourceFile() - 1);
     this.sourceMappingURL = ast.getSourceMappingUrl();
+    this.sourceMapPath = ast.getSourceMapPath();
     this.colorPoolShard = colorPoolShard;
     this.stringPool = stringPool;
     this.filePool = filePool;
@@ -175,6 +177,10 @@ final class ScriptNodeDeserializer {
 
   public String getSourceMappingURL() {
     return sourceMappingURL;
+  }
+
+  public String getSourceMapPath() {
+    return sourceMapPath;
   }
 
   public SourceFile getSourceFile() {

--- a/src/com/google/javascript/jscomp/serialization/TypedAstDeserializer.java
+++ b/src/com/google/javascript/jscomp/serialization/TypedAstDeserializer.java
@@ -216,7 +216,7 @@ public final class TypedAstDeserializer {
             return script;
           });
       completed = true;
-      inputSourceMaps.forEach(compiler::addInputSourceMap);
+      compiler.addInputSourceMaps(inputSourceMaps);
       return DeserializedAst.create(
           filesystem,
           Optional.absent(),
@@ -315,7 +315,7 @@ public final class TypedAstDeserializer {
 
     deserializeTypedAsts(
         typedAstStream, deserializer, compiler, resolveSourceMapAnnotations, parseInlineSourceMaps);
-    deserializer.inputSourceMaps.forEach(compiler::addInputSourceMap);
+    compiler.addInputSourceMaps(deserializer.inputSourceMaps);
 
     deserializer.typedAstFilesystem.put(
         syntheticExterns,

--- a/src/com/google/javascript/jscomp/serialization/TypedAstDeserializer.java
+++ b/src/com/google/javascript/jscomp/serialization/TypedAstDeserializer.java
@@ -34,6 +34,7 @@ import com.google.javascript.jscomp.colors.ColorRegistry;
 import com.google.javascript.jscomp.parsing.parser.FeatureSet;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
+import com.google.javascript.rhino.StaticSourceFile.SourceKind;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -358,8 +359,16 @@ public final class TypedAstDeserializer {
       boolean parseInlineSourceMaps) {
     SourceFile sourceFile = deserializer.getSourceFile();
     String sourceMappingURL = deserializer.getSourceMappingURL(); // This is the encoded source map.
+    String sourceMapPath = deserializer.getSourceMapPath();
 
-    if (sourceMappingURL != null && sourceMappingURL.length() > 0 && resolveSourceMapAnnotations) {
+    if (!resolveSourceMapAnnotations) {
+      return;
+    }
+    if (!sourceMapPath.isEmpty()) {
+      SourceFile sourceMapSourceFile =
+          SourceFile.builder().withPath(sourceMapPath).withKind(SourceKind.NON_CODE).build();
+      compiler.addInputSourceMap(sourceFile.getName(), new SourceMapInput(sourceMapSourceFile));
+    } else if (sourceMappingURL != null && sourceMappingURL.length() > 0) {
       // base64EncodedSourceMap adds "data:application/json;base64," prefix to the sourceMappingURL
       String base64EncodedSourceMap =
           SourceMapResolver.addBase64PrefixToEncodedSourceMap(sourceMappingURL);

--- a/src/com/google/javascript/jscomp/serialization/TypedAstDeserializer.java
+++ b/src/com/google/javascript/jscomp/serialization/TypedAstDeserializer.java
@@ -44,8 +44,14 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
@@ -63,6 +69,7 @@ public final class TypedAstDeserializer {
       new ConcurrentHashMap<>();
   private final ImmutableSet.Builder<String> externProperties = ImmutableSet.builder();
   private final ImmutableSet.Builder<String> runtimeLibraries = ImmutableSet.builder();
+  private final LinkedHashMap<String, SourceMapInput> inputSourceMaps = new LinkedHashMap<>();
   private final ArrayList<ScriptNodeDeserializer> syntheticExternsDeserializers = new ArrayList<>();
 
   private TypedAstDeserializer(
@@ -124,6 +131,133 @@ public final class TypedAstDeserializer {
   }
 
   /**
+   * Deserializes independent TypedAst messages concurrently when type information is not needed.
+   * The messages are merged in stream order to preserve the sequential deserializer's duplicate
+   * file and synthetic-extern behavior.
+   */
+  public static DeserializedAst deserializeFullAstConcurrently(
+      AbstractCompiler compiler,
+      SourceFile syntheticExterns,
+      ImmutableSet<SourceFile> requiredInputFiles,
+      InputStream typedAstsStream,
+      boolean resolveSourceMapAnnotations,
+      boolean parseInlineSourceMaps,
+      int numParallelThreads) {
+    ImmutableMap<String, SourceFile> sourceFilesByName =
+        requiredInputFiles.stream()
+            .collect(toImmutableMap(SourceFile::getName, Function.identity()));
+
+    // Runtime-library deserialization must initialize compiler state exactly once.
+    compiler.initRuntimeLibraryTypedAsts(Optional.absent());
+
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            numParallelThreads,
+            runnable -> {
+              Thread thread = new Thread(runnable, "jscompiler-TypedAstDeserialize");
+              thread.setDaemon(true);
+              return thread;
+            });
+    ArrayList<Future<DeserializedAst>> shards = new ArrayList<>();
+    boolean completed = false;
+    try {
+      forEachTypedAst(
+          typedAstsStream,
+          typedAst ->
+              shards.add(
+                  executor.submit(
+                      () ->
+                          deserializeFullAstMessage(
+                              compiler,
+                              syntheticExterns,
+                              requiredInputFiles,
+                              sourceFilesByName,
+                              typedAst,
+                              resolveSourceMapAnnotations,
+                              parseInlineSourceMaps))));
+      executor.shutdown();
+
+      ConcurrentMap<SourceFile, Supplier<Node>> filesystem = new ConcurrentHashMap<>();
+      ImmutableSet.Builder<String> externProperties = ImmutableSet.builder();
+      ImmutableSet.Builder<String> runtimeLibraries = ImmutableSet.builder();
+      LinkedHashMap<String, SourceMapInput> inputSourceMaps = new LinkedHashMap<>();
+      ArrayList<Supplier<Node>> syntheticExternSuppliers = new ArrayList<>();
+      for (Future<DeserializedAst> shardFuture : shards) {
+        DeserializedAst shard;
+        try {
+          shard = shardFuture.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while deserializing TypedAST", e);
+        } catch (ExecutionException e) {
+          throw new IllegalArgumentException("Cannot deserialize TypedAST input", e.getCause());
+        }
+        Supplier<Node> syntheticExternSupplier = shard.getFilesystem().get(syntheticExterns);
+        if (syntheticExternSupplier != null) {
+          syntheticExternSuppliers.add(syntheticExternSupplier);
+        }
+        for (Map.Entry<SourceFile, Supplier<Node>> entry : shard.getFilesystem().entrySet()) {
+          if (!identical(syntheticExterns, entry.getKey())) {
+            filesystem.putIfAbsent(entry.getKey(), entry.getValue());
+          }
+        }
+        externProperties.addAll(shard.getExternProperties());
+        runtimeLibraries.addAll(shard.getRuntimeLibraries());
+        inputSourceMaps.putAll(shard.getInputSourceMaps());
+      }
+      filesystem.put(
+          syntheticExterns,
+          () -> {
+            Node script = IR.script();
+            script.setStaticSourceFile(syntheticExterns);
+            for (Supplier<Node> supplier : syntheticExternSuppliers) {
+              script.addChildrenToBack(supplier.get().removeChildren());
+            }
+            return script;
+          });
+      completed = true;
+      inputSourceMaps.forEach(compiler::addInputSourceMap);
+      return DeserializedAst.create(
+          filesystem,
+          Optional.absent(),
+          externProperties.build(),
+          runtimeLibraries.build(),
+          ImmutableMap.copyOf(inputSourceMaps));
+    } finally {
+      if (!completed) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private static DeserializedAst deserializeFullAstMessage(
+      AbstractCompiler compiler,
+      SourceFile syntheticExterns,
+      ImmutableSet<SourceFile> requiredInputFiles,
+      ImmutableMap<String, SourceFile> sourceFilesByName,
+      TypedAst typedAst,
+      boolean resolveSourceMapAnnotations,
+      boolean parseInlineSourceMaps) {
+    TypedAstDeserializer deserializer =
+        new TypedAstDeserializer(
+            syntheticExterns,
+            Optional.absent(),
+            Optional.of(requiredInputFiles),
+            Mode.FULL_AST,
+            false);
+    deserializer.filePoolBuilder.put(syntheticExterns.getName(), syntheticExterns);
+    deserializer.filePoolBuilder.putAll(sourceFilesByName);
+    deserializer.deserializeTypedAst(
+        typedAst, compiler, resolveSourceMapAnnotations, parseInlineSourceMaps);
+    deserializer.typedAstFilesystem.put(
+        syntheticExterns,
+        new SyntheticExternsDeserializer(
+                syntheticExterns, deserializer.syntheticExternsDeserializers)
+            ::deserialize);
+    return deserializer.toDeserializedAst();
+  }
+
+  /**
    * Transforms the special runtime library TypedAst
    *
    * @param colorPool a ColorPool.Builder holding the colors on the full AST. We want to merge these
@@ -181,6 +315,7 @@ public final class TypedAstDeserializer {
 
     deserializeTypedAsts(
         typedAstStream, deserializer, compiler, resolveSourceMapAnnotations, parseInlineSourceMaps);
+    deserializer.inputSourceMaps.forEach(compiler::addInputSourceMap);
 
     deserializer.typedAstFilesystem.put(
         syntheticExterns,
@@ -231,7 +366,11 @@ public final class TypedAstDeserializer {
             ? Optional.absent()
             : Optional.of(colorPoolBuilder.get().build().getRegistry());
     return DeserializedAst.create(
-        typedAstFilesystem, registry, externProperties.build(), runtimeLibraries.build());
+        typedAstFilesystem,
+        registry,
+        externProperties.build(),
+        runtimeLibraries.build(),
+        ImmutableMap.copyOf(inputSourceMaps));
   }
 
   private void deserializeTypedAst(
@@ -297,7 +436,11 @@ public final class TypedAstDeserializer {
       SourceFile existingFile = filePoolBuilder.get(p.getFilename());
       if (existingFile != null) {
         // Merge the existing SourceFile with the information serialized in the TypedAST.
-        existingFile.restoreCachedStateFrom(p);
+        // Concurrent shard deserialization can encounter the same required input in more than one
+        // message. Those messages contain identical state, but SourceFile itself is mutable.
+        synchronized (existingFile) {
+          existingFile.restoreCachedStateFrom(p);
+        }
         fileShardBuilder.add(existingFile);
       } else {
         SourceFile protoFile = SourceFile.fromProto(p);
@@ -340,7 +483,7 @@ public final class TypedAstDeserializer {
       typedAstFilesystem.computeIfAbsent(file, (f) -> deserializer::deserializeNew);
     }
 
-    addInputSourceMap(deserializer, compiler, resolveSourceMapAnnotations, parseInlineSourceMaps);
+    addInputSourceMap(deserializer, resolveSourceMapAnnotations, parseInlineSourceMaps);
   }
 
   /**
@@ -352,9 +495,8 @@ public final class TypedAstDeserializer {
    * @param parseInlineSourceMaps Whether a given `//# sourceMappingURL` should be registered as a
    *     Base64 encoded source map.
    */
-  private static void addInputSourceMap(
+  private void addInputSourceMap(
       ScriptNodeDeserializer deserializer,
-      AbstractCompiler compiler,
       boolean resolveSourceMapAnnotations,
       boolean parseInlineSourceMaps) {
     SourceFile sourceFile = deserializer.getSourceFile();
@@ -367,7 +509,7 @@ public final class TypedAstDeserializer {
     if (!sourceMapPath.isEmpty()) {
       SourceFile sourceMapSourceFile =
           SourceFile.builder().withPath(sourceMapPath).withKind(SourceKind.NON_CODE).build();
-      compiler.addInputSourceMap(sourceFile.getName(), new SourceMapInput(sourceMapSourceFile));
+      inputSourceMaps.put(sourceFile.getName(), new SourceMapInput(sourceMapSourceFile));
     } else if (sourceMappingURL != null && sourceMappingURL.length() > 0) {
       // base64EncodedSourceMap adds "data:application/json;base64," prefix to the sourceMappingURL
       String base64EncodedSourceMap =
@@ -376,7 +518,7 @@ public final class TypedAstDeserializer {
           SourceMapResolver.extractSourceMap(
               sourceFile, base64EncodedSourceMap, parseInlineSourceMaps);
       if (sourceMapSourceFile != null) {
-        compiler.addInputSourceMap(sourceFile.getName(), new SourceMapInput(sourceMapSourceFile));
+        inputSourceMaps.put(sourceFile.getName(), new SourceMapInput(sourceMapSourceFile));
       }
     }
   }
@@ -401,6 +543,15 @@ public final class TypedAstDeserializer {
       AbstractCompiler compiler,
       boolean resolveSourceMapAnnotations,
       boolean parseInlineSourceMaps) {
+    forEachTypedAst(
+        typedAstsStream,
+        typedAst ->
+            deserializer.deserializeTypedAst(
+                typedAst, compiler, resolveSourceMapAnnotations, parseInlineSourceMaps));
+  }
+
+  private static void forEachTypedAst(
+      InputStream typedAstsStream, Consumer<TypedAst> consumer) {
     try {
       CodedInputStream codedInput = CodedInputStream.newInstance(typedAstsStream);
       // The typedAstsStream is an encoded 'TypedAst.List' message:
@@ -429,8 +580,7 @@ public final class TypedAstDeserializer {
         TypedAst typedAst = typedAstBuilder.build();
         typedAstBuilder.clear();
         codedInput.resetSizeCounter();
-        deserializer.deserializeTypedAst(
-            typedAst, compiler, resolveSourceMapAnnotations, parseInlineSourceMaps);
+        consumer.accept(typedAst);
       }
     } catch (IOException ex) {
       throw new IllegalArgumentException("Cannot read from TypedAST input stream", ex);
@@ -466,13 +616,16 @@ public final class TypedAstDeserializer {
 
     public abstract ImmutableSet<String> getRuntimeLibraries();
 
+    abstract ImmutableMap<String, SourceMapInput> getInputSourceMaps();
+
     private static DeserializedAst create(
         ConcurrentMap<SourceFile, Supplier<Node>> filesystem,
         Optional<ColorRegistry> colorRegistry,
         ImmutableSet<String> externProperties,
-        ImmutableSet<String> runtimeLibraries) {
+        ImmutableSet<String> runtimeLibraries,
+        ImmutableMap<String, SourceMapInput> inputSourceMaps) {
       return new AutoValue_TypedAstDeserializer_DeserializedAst(
-          filesystem, colorRegistry, externProperties, runtimeLibraries);
+          filesystem, colorRegistry, externProperties, runtimeLibraries, inputSourceMaps);
     }
   }
 }

--- a/src/com/google/javascript/jscomp/serialization/TypedAstSerializer.java
+++ b/src/com/google/javascript/jscomp/serialization/TypedAstSerializer.java
@@ -118,6 +118,7 @@ final class TypedAstSerializer {
     this.subtreeSourceFiles.clear();
 
     String encodedSourceMap = compiler.getBase64SourceMapContents(script.getSourceFileName());
+    String sourceMapPath = compiler.getSourceMapPath(script.getSourceFileName());
 
     LazyAst.Builder lazyAstBuilder =
         LazyAst.newBuilder().setScript(scriptProto.toByteString()).setSourceFile(sourceFile);
@@ -128,6 +129,9 @@ final class TypedAstSerializer {
       // E.g. We serialize "eyJ2ZXJzaW9uI..." from the "//# sourceMappingURL=
       // data:application/json;base64,eyJ2ZXJzaW9uI..." comment.
       lazyAstBuilder.setSourceMappingUrl(encodedSourceMap);
+    }
+    if (sourceMapPath != null) {
+      lazyAstBuilder.setSourceMapPath(sourceMapPath);
     }
 
     return lazyAstBuilder.build();

--- a/src/com/google/javascript/rhino/typed_ast/typed_ast.proto
+++ b/src/com/google/javascript/rhino/typed_ast/typed_ast.proto
@@ -44,6 +44,9 @@ message LazyAst {
   // "eyJ2ZXJzaW9uI..." in this LazyAst's source_mapping_url field. We'll attach
   // the "data:application/json;base64," prefix during deserialization.
   string source_mapping_url = 3;
+  // Path to a separate source map file referenced by this script. Unlike an inline source map,
+  // store only the path so large source maps do not get copied into the TypedAST.
+  string source_map_path = 4;
 }
 
 // Keep this in sync with the TypedAst proto.
@@ -74,6 +77,8 @@ message NonLazyAst {
   // The encoded source map taken from the inline sourcemap comment
   // (base64-encoded "data url" stored in `//# sourceMappingURL=` comment).
   string source_mapping_url = 3;
+  // Path to a separate source map file referenced by this script.
+  string source_map_path = 4;
 }
 
 message StringPoolProto {

--- a/test/com/google/debugging/sourcemap/SourceMapGeneratorV3Test.java
+++ b/test/com/google/debugging/sourcemap/SourceMapGeneratorV3Test.java
@@ -481,6 +481,32 @@ public final class SourceMapGeneratorV3Test extends SourceMapTestCase {
   }
 
   @Test
+  public void testSnapshotIsIndependentAndSharesSourceContentCopyOnWrite() throws IOException {
+    SourceMapGeneratorV3 generator = new SourceMapGeneratorV3();
+    generator.addSourcesContent("first.js", "const first = 1;");
+    generator.addMapping(
+        "first.js", null, new FilePosition(0, 0), new FilePosition(0, 0), new FilePosition(0, 5));
+
+    SourceMapGeneratorV3 snapshot = generator.snapshot();
+    generator.reset();
+    generator.addSourcesContent("second.js", "const second = 2;");
+    generator.addMapping(
+        "second.js", null, new FilePosition(0, 0), new FilePosition(0, 0), new FilePosition(0, 6));
+
+    StringWriter snapshotOutput = new StringWriter();
+    snapshot.appendTo(snapshotOutput, "first-output.js");
+    assertThat(snapshotOutput.toString()).contains("\"sources\":[\"first.js\"]");
+    assertThat(snapshotOutput.toString()).contains("const first = 1;");
+    assertThat(snapshotOutput.toString()).doesNotContain("second.js");
+
+    StringWriter currentOutput = new StringWriter();
+    generator.appendTo(currentOutput, "second-output.js");
+    assertThat(currentOutput.toString()).contains("\"sources\":[\"second.js\"]");
+    assertThat(currentOutput.toString()).contains("const second = 2;");
+    assertThat(currentOutput.toString()).doesNotContain("first.js");
+  }
+
+  @Test
   public void testWriteMetaMap2() throws IOException {
     StringWriter out = new StringWriter();
     String name = "./app.js";

--- a/test/com/google/javascript/jscomp/ChangeTrackerTest.java
+++ b/test/com/google/javascript/jscomp/ChangeTrackerTest.java
@@ -148,4 +148,25 @@ public class ChangeTrackerTest {
     // 'FunctionInliner' request.
     assertThat(changeTracker.getChangedScopeNodesForPass("FunctionInliner")).isEmpty();
   }
+
+  @Test
+  public void testBufferedChangesAreInvisibleUntilApplied() {
+    ChangeTracker changeTracker = new ChangeTracker();
+    Node function1 = IR.function(IR.name("foo"), IR.paramList(), IR.block());
+    Node function2 = IR.function(IR.name("bar"), IR.paramList(), IR.block());
+    IR.root(IR.script(function1, function2));
+
+    var unused = changeTracker.getChangedScopeNodesForPass("ParallelPass");
+    ChangeTracker.BufferedChanges changes = changeTracker.beginBufferingChanges();
+    changeTracker.reportChangeToChangeScope(function1);
+    changeTracker.reportChangeToChangeScope(function1);
+    changeTracker.reportChangeToChangeScope(function2);
+    changeTracker.reportFunctionDeleted(function2);
+    changeTracker.endBufferingChanges(changes);
+
+    assertThat(changeTracker.getChangedScopeNodesForPass("ParallelPass")).isEmpty();
+    changeTracker.applyBufferedChanges(changes);
+    assertThat(changeTracker.getChangedScopeNodesForPass("ParallelPass"))
+        .containsExactly(function1);
+  }
 }

--- a/test/com/google/javascript/jscomp/CoalesceVariableNamesTest.java
+++ b/test/com/google/javascript/jscomp/CoalesceVariableNamesTest.java
@@ -16,8 +16,12 @@
 
 package com.google.javascript.jscomp;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.rhino.Node;
+import java.io.IOException;
+import java.io.StringWriter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,12 +34,23 @@ public final class CoalesceVariableNamesTest extends CompilerTestCase {
   // picking out which variable names are merged.
 
   private boolean usePseudoName = false;
+  private OptimizationWorkReporter workReporter;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
     usePseudoName = false;
+    workReporter = null;
+  }
+
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    if (workReporter != null) {
+      options.setOptimizationWorkReporter(workReporter);
+    }
+    return options;
   }
 
   @Override
@@ -80,6 +95,16 @@ public final class CoalesceVariableNamesTest extends CompilerTestCase {
     inFunction("var y; var x=1; f(x = x + 1, y)");
 
     inFunction("var x; var y; y = y + 1, y, x = 1; x");
+  }
+
+  @Test
+  public void testOptimizationWorkReport() throws IOException {
+    workReporter = new OptimizationWorkReporter();
+    inFunction("var x = 1; var y = x + 1; return y", "var x = 1; x = x + 1; return x");
+
+    StringWriter writer = new StringWriter();
+    workReporter.write(writer);
+    assertThat(writer.toString()).contains("coalesceVariableNames");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/CoalesceVariableNamesTest.java
+++ b/test/com/google/javascript/jscomp/CoalesceVariableNamesTest.java
@@ -34,6 +34,7 @@ public final class CoalesceVariableNamesTest extends CompilerTestCase {
   // picking out which variable names are merged.
 
   private boolean usePseudoName = false;
+  private int parallelism;
   private OptimizationWorkReporter workReporter;
 
   @Override
@@ -41,12 +42,14 @@ public final class CoalesceVariableNamesTest extends CompilerTestCase {
   public void setUp() throws Exception {
     super.setUp();
     usePseudoName = false;
+    parallelism = 1;
     workReporter = null;
   }
 
   @Override
   protected CompilerOptions getOptions() {
     CompilerOptions options = super.getOptions();
+    options.setNumParallelThreads(parallelism);
     if (workReporter != null) {
       options.setOptimizationWorkReporter(workReporter);
     }
@@ -65,6 +68,18 @@ public final class CoalesceVariableNamesTest extends CompilerTestCase {
         new CoalesceVariableNames(compiler, usePseudoName).process(externs, root);
       }
     };
+  }
+
+  @Test
+  public void testParallelScripts() {
+    parallelism = 2;
+    test(
+        srcs(
+            "function f(){var x=1;var y=x+1;return y}",
+            "function g(){var a=2;var b=a+1;return b}"),
+        expected(
+            "function f(){var x=1;x=x+1;return x}",
+            "function g(){var a=2;a=a+1;return a}"));
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -64,6 +64,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.jspecify.annotations.Nullable;
@@ -3559,12 +3560,14 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
     args.add(outDir + "/");
     args.add("--chunk=a:1");
     args.add("--chunk=b:1");
+    args.add("--num_parallel_threads=2");
     args.add("--js");
     args.add(inputFile1.toString());
     args.add("--js");
     args.add(inputFile2.toString());
 
     List<Thread> codeGenerationThreads = new ArrayList<>();
+    CountDownLatch concurrentCodeGeneration = new CountDownLatch(2);
     CommandLineRunner runner =
         new CommandLineRunner(
             args.toArray(new String[] {}), new PrintStream(outReader), new PrintStream(errReader)) {
@@ -3572,9 +3575,19 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
           protected Compiler createCompiler() {
             return new Compiler(getErrorPrintStream()) {
               @Override
-              public String toSource(CodePrinter.LicenseTracker licenseTracker, JSChunk chunk) {
-                codeGenerationThreads.add(Thread.currentThread());
-                return super.toSource(licenseTracker, chunk);
+              Compiler.GeneratedChunkOutput generatePreparedChunkOutput(
+                  Compiler.PreparedChunkOutput prepared, ImmutableSet<String> licensedSources) {
+                synchronized (codeGenerationThreads) {
+                  codeGenerationThreads.add(Thread.currentThread());
+                }
+                concurrentCodeGeneration.countDown();
+                try {
+                  checkState(concurrentCodeGeneration.await(10, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new RuntimeException(e);
+                }
+                return super.generatePreparedChunkOutput(prepared, licensedSources);
               }
             };
           }
@@ -3592,7 +3605,7 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
     assertThat(Files.asCharSource(outputFile2, UTF_8).read()).isEqualTo(inputSource2);
     assertThat(weakFile.exists()).isFalse();
     assertThat(codeGenerationThreads).hasSize(2);
-    assertThat(codeGenerationThreads.stream().distinct().count()).isEqualTo(1);
+    assertThat(codeGenerationThreads.stream().distinct().count()).isEqualTo(2);
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2179,6 +2179,77 @@ public final class CommandLineRunnerTest {
   }
 
   @Test
+  public void testOutputInputReductionReport() throws IOException {
+    File removedInput = temporaryFolder.newFile("removed.js");
+    File retainedInput = temporaryFolder.newFile("retained.js");
+    File compiledOutput = temporaryFolder.newFile("compiled.js");
+    File reductionReport = temporaryFolder.newFile("input-reduction.tsv");
+    writeFile(removedInput, "function unused() { return 1; }");
+    writeFile(retainedInput, "throw 2;");
+
+    CommandLineRunner runner =
+        new CommandLineRunner(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--env=CUSTOM",
+              "--js=" + removedInput,
+              "--js=" + retainedInput,
+              "--js_output_file=" + compiledOutput,
+              "--output_input_reduction_report=" + reductionReport,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    int exitCode = runner.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(exitCode).isEqualTo(0);
+    List<String> reportLines = java.nio.file.Files.readAllLines(reductionReport.toPath());
+    assertThat(reportLines.get(0))
+        .isEqualTo(
+            "input_bytes\tinput_lines\tinitial_ast_nodes\tfinal_ast_nodes\t"
+                + "removed_ast_nodes\tinput");
+    String removedLine =
+        reportLines.stream().filter(line -> line.endsWith("\t" + removedInput)).findFirst().get();
+    String retainedLine =
+        reportLines.stream().filter(line -> line.endsWith("\t" + retainedInput)).findFirst().get();
+    assertThat(removedLine.split("\t")[3]).isEqualTo("0");
+    assertThat(Integer.parseInt(retainedLine.split("\t")[3])).isGreaterThan(0);
+  }
+
+  @Test
+  public void testRunCompilerCanRunTwiceInSameJvm() throws IOException {
+    File input = temporaryFolder.newFile("input.js");
+    File firstOutput = temporaryFolder.newFile("first-output.js");
+    File secondOutput = temporaryFolder.newFile("second-output.js");
+    writeFile(input, "throw 1 + 2;");
+
+    int firstExitCode =
+        CommandLineRunner.runCompiler(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--env=CUSTOM",
+              "--js=" + input,
+              "--js_output_file=" + firstOutput,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+    int secondExitCode =
+        CommandLineRunner.runCompiler(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--env=CUSTOM",
+              "--js=" + input,
+              "--js_output_file=" + secondOutput,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    assertWithMessage(errReader.toString(UTF_8)).that(firstExitCode).isEqualTo(0);
+    assertWithMessage(errReader.toString(UTF_8)).that(secondExitCode).isEqualTo(0);
+    assertThat(java.nio.file.Files.readString(firstOutput.toPath()))
+        .isEqualTo(java.nio.file.Files.readString(secondOutput.toPath()));
+  }
+
+  @Test
   public void testProcessCJS() {
     useStringComparison = true;
     args.add("--process_common_js_modules");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2216,6 +2216,64 @@ public final class CommandLineRunnerTest {
   }
 
   @Test
+  public void testTypedAstInputFile() throws IOException {
+    File input = temporaryFolder.newFile("input.js");
+    File typedAst = temporaryFolder.newFile("input.typedast.gz");
+    File directOutput = temporaryFolder.newFile("direct.js");
+    File restoredOutput = temporaryFolder.newFile("restored.js");
+    writeFile(
+        input,
+        "throw function(value) { const unused = 1; return value + 2; }(3);");
+
+    CommandLineRunner serializer =
+        new CommandLineRunner(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--checks_only",
+              "--dependency_mode=NONE",
+              "--env=CUSTOM",
+              "--js=" + input,
+              "--typed_ast_output_file__INTENRNAL_USE_ONLY=" + typedAst,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+    int serializerExitCode = serializer.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(serializerExitCode).isEqualTo(0);
+
+    CommandLineRunner direct =
+        new CommandLineRunner(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--dependency_mode=NONE",
+              "--env=CUSTOM",
+              "--js=" + input,
+              "--js_output_file=" + directOutput,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+    int directExitCode = direct.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(directExitCode).isEqualTo(0);
+
+    CommandLineRunner restored =
+        new CommandLineRunner(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--dependency_mode=NONE",
+              "--env=CUSTOM",
+              "--js=" + input,
+              "--typed_ast_input_file__INTERNAL_USE_ONLY=" + typedAst,
+              "--js_output_file=" + restoredOutput,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+    int restoredExitCode = restored.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(restoredExitCode).isEqualTo(0);
+
+    assertThat(java.nio.file.Files.readString(restoredOutput.toPath()))
+        .isEqualTo(java.nio.file.Files.readString(directOutput.toPath()));
+  }
+
+  @Test
   public void testOutputOptimizationWorkReport() throws IOException {
     File input = temporaryFolder.newFile("input.js");
     File compiledOutput = temporaryFolder.newFile("compiled.js");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -60,6 +60,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.jspecify.annotations.Nullable;
@@ -3589,6 +3593,70 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
     assertThat(weakFile.exists()).isFalse();
     assertThat(codeGenerationThreads).hasSize(2);
     assertThat(codeGenerationThreads.stream().distinct().count()).isEqualTo(1);
+  }
+
+  @Test
+  public void testConcurrentRunsKeepCommandLineInputsIsolated() throws Exception {
+    File inputDir = temporaryFolder.newFolder("concurrent-inputs");
+    File leftOutput = temporaryFolder.newFile("left-output.js");
+    File rightOutput = temporaryFolder.newFile("right-output.js");
+    List<String> leftArgs =
+        new ArrayList<>(
+            List.of(
+                "--compilation_level=WHITESPACE_ONLY",
+                "--js_output_file=" + leftOutput));
+    List<String> rightArgs =
+        new ArrayList<>(
+            List.of(
+                "--compilation_level=WHITESPACE_ONLY",
+                "--js_output_file=" + rightOutput));
+    for (int i = 0; i < 200; i++) {
+      File leftInput = new File(inputDir, "left-" + i + ".js");
+      File rightInput = new File(inputDir, "right-" + i + ".js");
+      Files.asCharSink(leftInput, UTF_8).write("var left" + i + ";\n");
+      Files.asCharSink(rightInput, UTF_8).write("var right" + i + ";\n");
+      leftArgs.add("--js=" + leftInput);
+      rightArgs.add("--js=" + rightInput);
+    }
+
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<Integer> leftResult =
+          executor.submit(
+              () -> {
+                ready.countDown();
+                start.await();
+                return CommandLineRunner.runCompiler(
+                    leftArgs.toArray(String[]::new),
+                    new PrintStream(new ByteArrayOutputStream()),
+                    new PrintStream(new ByteArrayOutputStream()));
+              });
+      Future<Integer> rightResult =
+          executor.submit(
+              () -> {
+                ready.countDown();
+                start.await();
+                return CommandLineRunner.runCompiler(
+                    rightArgs.toArray(String[]::new),
+                    new PrintStream(new ByteArrayOutputStream()),
+                    new PrintStream(new ByteArrayOutputStream()));
+              });
+      ready.await();
+      start.countDown();
+      assertThat(leftResult.get()).isEqualTo(0);
+      assertThat(rightResult.get()).isEqualTo(0);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    String leftCode = Files.asCharSource(leftOutput, UTF_8).read();
+    String rightCode = Files.asCharSource(rightOutput, UTF_8).read();
+    assertThat(leftCode).contains("left199");
+    assertThat(leftCode).doesNotContain("right");
+    assertThat(rightCode).contains("right199");
+    assertThat(rightCode).doesNotContain("left");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -3438,6 +3438,16 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
   }
 
   @Test
+  public void testOptimizationLoopMaxIterations() {
+    testSame("");
+    assertThat(lastCompiler.getOptions().getMaxOptimizationLoopIterations()).isEqualTo(0);
+
+    args.add("--optimization_loop_max_iterations=3");
+    testSame("");
+    assertThat(lastCompiler.getOptions().getMaxOptimizationLoopIterations()).isEqualTo(3);
+  }
+
+  @Test
   public void testParamModification1() {
     args.add("--compilation_level=ADVANCED");
     test(

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2239,7 +2239,7 @@ public final class CommandLineRunnerTest {
               "--dependency_mode=NONE",
               "--env=CUSTOM",
               "--js=" + input,
-              "--typed_ast_output_file__INTENRNAL_USE_ONLY=" + typedAst,
+              "--typed_ast_output_file=" + typedAst,
             },
             new PrintStream(outReader),
             new PrintStream(errReader));
@@ -2267,7 +2267,7 @@ public final class CommandLineRunnerTest {
               "--dependency_mode=NONE",
               "--env=CUSTOM",
               "--js=" + input,
-              "--typed_ast_input_file__INTERNAL_USE_ONLY=" + typedAst,
+              "--typed_ast_input_file=" + typedAst,
               "--js_output_file=" + restoredOutput,
             },
             new PrintStream(outReader),
@@ -2349,7 +2349,7 @@ public final class CommandLineRunnerTest {
     assertWithMessage(errReader.toString(UTF_8)).that(directExitCode).isEqualTo(0);
 
     ArrayList<String> restoredArguments = new ArrayList<>(List.of(commonArguments));
-    restoredArguments.add("--typed_ast_input_file__INTERNAL_USE_ONLY=" + combinedTypedAst);
+    restoredArguments.add("--typed_ast_input_file=" + combinedTypedAst);
     restoredArguments.add("--num_parallel_threads=2");
     restoredArguments.add("--js_output_file=" + restoredOutput);
     CommandLineRunner restored =

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -1503,6 +1503,15 @@ public final class CommandLineRunnerTest {
   }
 
   @Test
+  public void testParallelChunkSourceMaps() {
+    useChunks = ChunkPattern.CHAIN;
+    args.add("--create_source_map=%outname%.map");
+    args.add("--chunk_output_path_prefix=foo_");
+    args.add("--num_parallel_threads=2");
+    testSame(new String[] {"var x = 3;", "var y = 5;"});
+  }
+
+  @Test
   public void testInvalidSourceMapPattern() {
     useChunks = ChunkPattern.CHAIN;
     args.add("--create_source_map=out.map");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -50,6 +50,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -59,8 +60,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.jspecify.annotations.Nullable;
@@ -2317,11 +2316,9 @@ public final class CommandLineRunnerTest {
       int serializerExitCode = serializer.doRun();
       assertWithMessage(errReader.toString(UTF_8)).that(serializerExitCode).isEqualTo(0);
     }
-    try (GZIPOutputStream combinedOutput =
-        new GZIPOutputStream(new FileOutputStream(combinedTypedAst))) {
+    try (FileOutputStream combinedOutput = new FileOutputStream(combinedTypedAst)) {
       for (File shard : new File[] {firstTypedAst, secondTypedAst}) {
-        try (GZIPInputStream shardInput =
-            new GZIPInputStream(java.nio.file.Files.newInputStream(shard.toPath()))) {
+        try (InputStream shardInput = java.nio.file.Files.newInputStream(shard.toPath())) {
           shardInput.transferTo(combinedOutput);
         }
       }

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2216,6 +2216,35 @@ public final class CommandLineRunnerTest {
   }
 
   @Test
+  public void testOutputOptimizationWorkReport() throws IOException {
+    File input = temporaryFolder.newFile("input.js");
+    File compiledOutput = temporaryFolder.newFile("compiled.js");
+    File workReport = temporaryFolder.newFile("optimization-work.tsv");
+    writeFile(
+        input,
+        "window.f = function(p) { var x; if (p) { x = 1; } else { x = 2; } return x; };");
+
+    CommandLineRunner runner =
+        new CommandLineRunner(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--js=" + input,
+              "--js_output_file=" + compiledOutput,
+              "--output_optimization_work_report=" + workReport,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    int exitCode = runner.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(exitCode).isEqualTo(0);
+    String report = java.nio.file.Files.readString(workReport.toPath());
+    assertThat(report)
+        .startsWith(
+            "kind\truntime_us\tcalls\tvariables\tcfg_nodes\tcandidates\tchanges\tpass\t"
+                + "source\tline\tcolumn\tfunction\n");
+  }
+
+  @Test
   public void testOutputRemoveUnusedCodeReport() throws IOException {
     File input = temporaryFolder.newFile("input.js");
     File compiledOutput = temporaryFolder.newFile("compiled.js");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2216,6 +2216,46 @@ public final class CommandLineRunnerTest {
   }
 
   @Test
+  public void testOutputRemoveUnusedCodeReport() throws IOException {
+    File input = temporaryFolder.newFile("input.js");
+    File compiledOutput = temporaryFolder.newFile("compiled.js");
+    File removalReport = new File(temporaryFolder.getRoot(), "removal-report");
+    writeFile(input, "function unused() { return 1; } throw 2;");
+
+    CommandLineRunner runner =
+        new CommandLineRunner(
+            new String[] {
+              "--compilation_level=ADVANCED",
+              "--env=CUSTOM",
+              "--js=" + input,
+              "--js_output_file=" + compiledOutput,
+              "--output_remove_unused_code_report=" + removalReport,
+            },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+
+    int exitCode = runner.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(exitCode).isEqualTo(0);
+    List<Path> reportFiles;
+    try (var paths = java.nio.file.Files.walk(removalReport.toPath())) {
+      reportFiles = paths.filter(java.nio.file.Files::isRegularFile).toList();
+    }
+    assertThat(reportFiles).isNotEmpty();
+    String report =
+        reportFiles.stream()
+            .map(
+                path -> {
+                  try {
+                    return java.nio.file.Files.readString(path);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(java.util.stream.Collectors.joining());
+    assertThat(report).contains("var\tunused\t");
+  }
+
+  @Test
   public void testRunCompilerCanRunTwiceInSameJvm() throws IOException {
     File input = temporaryFolder.newFile("input.js");
     File firstOutput = temporaryFolder.newFile("first-output.js");

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -3458,6 +3458,16 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
   }
 
   @Test
+  public void testRunFinalFlowSensitiveInlineVariables() {
+    testSame("");
+    assertThat(lastCompiler.getOptions().getFinalFlowSensitiveInlineVariables()).isTrue();
+
+    args.add("--run_final_flow_sensitive_inline_variables=false");
+    testSame("");
+    assertThat(lastCompiler.getOptions().getFinalFlowSensitiveInlineVariables()).isFalse();
+  }
+
+  @Test
   public void testParamModification1() {
     args.add("--compilation_level=ADVANCED");
     test(

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -3448,6 +3448,16 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
   }
 
   @Test
+  public void testOptimizationMotionLoopMaxIterations() {
+    testSame("");
+    assertThat(lastCompiler.getOptions().getMaxOptimizationMotionLoopIterations()).isEqualTo(0);
+
+    args.add("--optimization_motion_loop_max_iterations=3");
+    testSame("");
+    assertThat(lastCompiler.getOptions().getMaxOptimizationMotionLoopIterations()).isEqualTo(3);
+  }
+
+  @Test
   public void testParamModification1() {
     args.add("--compilation_level=ADVANCED");
     test(

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -2350,6 +2350,7 @@ public final class CommandLineRunnerTest {
 
     ArrayList<String> restoredArguments = new ArrayList<>(List.of(commonArguments));
     restoredArguments.add("--typed_ast_input_file__INTERNAL_USE_ONLY=" + combinedTypedAst);
+    restoredArguments.add("--num_parallel_threads=2");
     restoredArguments.add("--js_output_file=" + restoredOutput);
     CommandLineRunner restored =
         new CommandLineRunner(

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -59,6 +59,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.jspecify.annotations.Nullable;
@@ -2264,6 +2266,92 @@ public final class CommandLineRunnerTest {
               "--typed_ast_input_file__INTERNAL_USE_ONLY=" + typedAst,
               "--js_output_file=" + restoredOutput,
             },
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+    int restoredExitCode = restored.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(restoredExitCode).isEqualTo(0);
+
+    assertThat(java.nio.file.Files.readString(restoredOutput.toPath()))
+        .isEqualTo(java.nio.file.Files.readString(directOutput.toPath()));
+  }
+
+  @Test
+  public void testTypedAstInputFileFromIndependentModuleShardsWithoutTypes() throws IOException {
+    File firstInput = temporaryFolder.newFile("first.js");
+    File secondInput = temporaryFolder.newFile("second.js");
+    File firstTypedAst = temporaryFolder.newFile("first.typedast.gz");
+    File secondTypedAst = temporaryFolder.newFile("second.typedast.gz");
+    File firstTypeSummary = temporaryFolder.newFile("first.i.js");
+    File combinedTypedAst = temporaryFolder.newFile("combined.typedast.gz");
+    File directOutput = temporaryFolder.newFile("direct.js");
+    File restoredOutput = temporaryFolder.newFile("restored.js");
+    writeFile(firstInput, "goog.module('lib.one'); exports.value = 2;");
+    writeFile(
+        secondInput,
+        "goog.module('lib.two'); const one = goog.require('lib.one'); globalThis.result = one.value;");
+    writeFile(firstTypeSummary, "/** @fileoverview @typeSummary */ goog.module('lib.one');");
+
+    for (File[] shard :
+        new File[][] {{firstInput, firstTypedAst}, {secondInput, secondTypedAst}}) {
+      ArrayList<String> serializerArguments =
+          new ArrayList<>(
+              List.of(
+                  "--compilation_level=ADVANCED",
+                  "--checks_only",
+                  "--dependency_mode=NONE",
+                  "--env=CUSTOM",
+                  "--jscomp_off=checkTypes",
+                  "--jscomp_off=checkVars",
+                  "--jscomp_off=missingSourcesWarnings",
+                  "--jscomp_off=strictModuleDepCheck"));
+      if (shard[0].equals(secondInput)) {
+        serializerArguments.add("--js=" + firstTypeSummary);
+      }
+      serializerArguments.add("--js=" + shard[0]);
+      serializerArguments.add("--typed_ast_output_file__INTENRNAL_USE_ONLY=" + shard[1]);
+      CommandLineRunner serializer =
+          new CommandLineRunner(
+              serializerArguments.toArray(String[]::new),
+              new PrintStream(outReader),
+              new PrintStream(errReader));
+      int serializerExitCode = serializer.doRun();
+      assertWithMessage(errReader.toString(UTF_8)).that(serializerExitCode).isEqualTo(0);
+    }
+    try (GZIPOutputStream combinedOutput =
+        new GZIPOutputStream(new FileOutputStream(combinedTypedAst))) {
+      for (File shard : new File[] {firstTypedAst, secondTypedAst}) {
+        try (GZIPInputStream shardInput =
+            new GZIPInputStream(java.nio.file.Files.newInputStream(shard.toPath()))) {
+          shardInput.transferTo(combinedOutput);
+        }
+      }
+    }
+
+    String[] commonArguments = {
+      "--compilation_level=ADVANCED",
+      "--dependency_mode=NONE",
+      "--env=CUSTOM",
+      "--jscomp_off=checkTypes",
+      "--jscomp_off=checkVars",
+      "--js=" + firstInput,
+      "--js=" + secondInput,
+    };
+    ArrayList<String> directArguments = new ArrayList<>(List.of(commonArguments));
+    directArguments.add("--js_output_file=" + directOutput);
+    CommandLineRunner direct =
+        new CommandLineRunner(
+            directArguments.toArray(String[]::new),
+            new PrintStream(outReader),
+            new PrintStream(errReader));
+    int directExitCode = direct.doRun();
+    assertWithMessage(errReader.toString(UTF_8)).that(directExitCode).isEqualTo(0);
+
+    ArrayList<String> restoredArguments = new ArrayList<>(List.of(commonArguments));
+    restoredArguments.add("--typed_ast_input_file__INTERNAL_USE_ONLY=" + combinedTypedAst);
+    restoredArguments.add("--js_output_file=" + restoredOutput);
+    CommandLineRunner restored =
+        new CommandLineRunner(
+            restoredArguments.toArray(String[]::new),
             new PrintStream(outReader),
             new PrintStream(errReader));
     int restoredExitCode = restored.doRun();

--- a/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
+++ b/test/com/google/javascript/jscomp/CommandLineRunnerTest.java
@@ -3560,9 +3560,21 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
     args.add("--js");
     args.add(inputFile2.toString());
 
+    List<Thread> codeGenerationThreads = new ArrayList<>();
     CommandLineRunner runner =
         new CommandLineRunner(
-            args.toArray(new String[] {}), new PrintStream(outReader), new PrintStream(errReader));
+            args.toArray(new String[] {}), new PrintStream(outReader), new PrintStream(errReader)) {
+          @Override
+          protected Compiler createCompiler() {
+            return new Compiler(getErrorPrintStream()) {
+              @Override
+              public String toSource(CodePrinter.LicenseTracker licenseTracker, JSChunk chunk) {
+                codeGenerationThreads.add(Thread.currentThread());
+                return super.toSource(licenseTracker, chunk);
+              }
+            };
+          }
+        };
 
     lastCompiler = runner.getCompiler();
     try {
@@ -3575,6 +3587,8 @@ Expected --production_instrumentation_array_name to be set when --instrument_for
     assertThat(Files.asCharSource(outputFile1, UTF_8).read()).isEqualTo(inputSource1);
     assertThat(Files.asCharSource(outputFile2, UTF_8).read()).isEqualTo(inputSource2);
     assertThat(weakFile.exists()).isFalse();
+    assertThat(codeGenerationThreads).hasSize(2);
+    assertThat(codeGenerationThreads.stream().distinct().count()).isEqualTo(1);
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -1670,6 +1670,14 @@ public final class CompilerTest {
     sourceMap.appendTo(sourceMapStringBuilder, outputJSFile);
     final String sourceMapString = sourceMapStringBuilder.toString();
     assertThat(sourceMapString).isEqualTo(RESULT_SOURCE_MAP_WITH_CONTENT);
+
+    // Outputting multiple chunks resets the source map before each chunk. Verify that the cached
+    // input sources content is restored identically after a reset.
+    compiler.resetAndIntitializeSourceMap();
+    compiler.toSource();
+    StringBuilder sourceMapAfterReset = new StringBuilder();
+    sourceMap.appendTo(sourceMapAfterReset, outputJSFile);
+    assertThat(sourceMapAfterReset.toString()).isEqualTo(RESULT_SOURCE_MAP_WITH_CONTENT);
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/CompilerTest.java
+++ b/test/com/google/javascript/jscomp/CompilerTest.java
@@ -65,6 +65,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -491,6 +492,54 @@ public final class CompilerTest {
     // Column 28 (0-based) is where the call site `a` appears in `alert(a());`.
     OriginalMapping callMapping = consumer.getMappingForLine(1, 29);
     assertThat(callMapping.getIdentifier()).isEqualTo("f");
+  }
+
+  @Test
+  public void testAddInputSourceMapsConcurrentlyPreservesSourcesContentOrder() throws Exception {
+    CompilerOptions options = new CompilerOptions();
+    options.setSourceMapOutputPath("output.js.map");
+    options.setApplyInputSourceMaps(true);
+    options.setSourceMapIncludeSourcesContent(true);
+    options.setNumParallelThreads(4);
+    Compiler compiler = new Compiler();
+    compiler.init(ImmutableList.of(), ImmutableList.of(), options);
+
+    LinkedHashMap<String, SourceMapInput> inputMaps = new LinkedHashMap<>();
+    for (int i = 0; i < 2; i++) {
+      SourceMapGeneratorV3 generator = new SourceMapGeneratorV3();
+      generator.addMapping(
+          "original" + i + ".ts",
+          null,
+          new FilePosition(0, 0),
+          new FilePosition(0, 0),
+          new FilePosition(0, 1));
+      generator.addSourcesContent("original" + i + ".ts", "content" + i);
+      StringWriter mapCode = new StringWriter();
+      generator.appendTo(mapCode, "generated" + i + ".js");
+      inputMaps.put(
+          "generated" + i + ".js",
+          new SourceMapInput(SourceFile.fromCode("generated" + i + ".js.map", mapCode.toString())));
+    }
+
+    compiler.addInputSourceMaps(inputMaps);
+    for (int i = 0; i < 2; i++) {
+      Node node = Node.newString(Token.NAME, "x");
+      node.setStaticSourceFile(SourceFile.fromCode("generated" + i + ".js", "x"));
+      node.setLinenoCharno(1, 0);
+      compiler
+          .getSourceMap()
+          .addMapping(node, new FilePosition(0, i), new FilePosition(0, i + 1));
+    }
+    StringWriter outputMapCode = new StringWriter();
+    compiler.getSourceMap().appendTo(outputMapCode, "output.js");
+    SourceMapConsumerV3 outputMap = new SourceMapConsumerV3();
+    outputMap.parse(outputMapCode.toString());
+    assertThat(outputMap.getOriginalSources())
+        .containsExactly("original0.ts", "original1.ts")
+        .inOrder();
+    assertThat(outputMap.getOriginalSourcesContent())
+        .containsExactly("content0", "content1")
+        .inOrder();
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/DeadAssignmentsEliminationTest.java
+++ b/test/com/google/javascript/jscomp/DeadAssignmentsEliminationTest.java
@@ -25,6 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class DeadAssignmentsEliminationTest extends CompilerTestCase {
 
+  private int parallelism;
+
   public DeadAssignmentsEliminationTest() {
     super("var extern;");
   }
@@ -32,12 +34,27 @@ public final class DeadAssignmentsEliminationTest extends CompilerTestCase {
   @Before
   public void customSetUp() throws Exception {
     enableNormalize();
+    parallelism = 1;
+  }
+
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    options.setNumParallelThreads(parallelism);
+    return options;
   }
 
   @Override
   protected CompilerPass getProcessor(final Compiler compiler) {
-    return (externs, js) ->
-        NodeTraversal.traverse(compiler, js, new DeadAssignmentsElimination(compiler));
+    return new DeadAssignmentsElimination(compiler);
+  }
+
+  @Test
+  public void testParallelScripts() {
+    parallelism = 2;
+    test(
+        srcs("function f(){var x;x=1}", "function g(){var y;y=2}"),
+        expected("function f(){var x;1}", "function g(){var y;2}"));
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
+++ b/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
@@ -16,7 +16,11 @@
 
 package com.google.javascript.jscomp;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.javascript.rhino.Node;
+import java.io.IOException;
+import java.io.StringWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,6 +28,8 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link FlowSensitiveInlineVariables}. */
 @RunWith(JUnit4.class)
 public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
+
+  private OptimizationWorkReporter workReporter;
 
   public static final String EXTERN_FUNCTIONS =
       """
@@ -48,6 +54,15 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
   }
 
   @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    if (workReporter != null) {
+      options.setOptimizationWorkReporter(workReporter);
+    }
+    return options;
+  }
+
+  @Override
   protected CompilerPass getProcessor(final Compiler compiler) {
     return new CompilerPass() {
       @Override
@@ -64,6 +79,17 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
     inline("var x; x = 1; x", "var x; 1");
     inline("var x; x = 1; var a = x", "var x; var a = 1");
     inline("var x; x = 1; x = x + 1", "var x; x = 1 + 1");
+  }
+
+  @Test
+  public void testOptimizationWorkReport() throws IOException {
+    workReporter = new OptimizationWorkReporter();
+    inline("var x; x = 1; print(x)", "var x; print(1)");
+
+    StringWriter writer = new StringWriter();
+    workReporter.write(writer);
+    assertThat(writer.toString()).contains("flowSensitiveInlineVariables");
+    assertThat(writer.toString()).contains("_func");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
+++ b/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
@@ -29,6 +29,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
 
+  private int parallelism;
   private OptimizationWorkReporter workReporter;
 
   public static final String EXTERN_FUNCTIONS =
@@ -45,6 +46,7 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
     enableNormalize();
     // TODO(bradfordcsmith): Stop normalizing the expected output or document why it is necessary.
     enableNormalizeExpectedOutput();
+    parallelism = 1;
   }
 
   @Override
@@ -56,6 +58,7 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
   @Override
   protected CompilerOptions getOptions() {
     CompilerOptions options = super.getOptions();
+    options.setNumParallelThreads(parallelism);
     if (workReporter != null) {
       options.setOptimizationWorkReporter(workReporter);
     }
@@ -71,6 +74,16 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
         new FlowSensitiveInlineVariables(compiler).process(externs, root);
       }
     };
+  }
+
+  @Test
+  public void testParallelScripts() {
+    parallelism = 2;
+    test(
+        srcs(
+            "function f(){var x;x=1;print(x)}",
+            "function g(){var y;y=2;print(y)}"),
+        expected("function f(){var x;print(1)}", "function g(){var y;print(2)}"));
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
+++ b/test/com/google/javascript/jscomp/FlowSensitiveInlineVariablesTest.java
@@ -93,6 +93,16 @@ public final class FlowSensitiveInlineVariablesTest extends CompilerTestCase {
   }
 
   @Test
+  public void testSkipsAnalysisWhenAllDefinitionsHaveUnsafeRhsShapes() throws IOException {
+    workReporter = new OptimizationWorkReporter();
+    noInline("const x = this.value; print(x)");
+
+    StringWriter writer = new StringWriter();
+    workReporter.write(writer);
+    assertThat(writer.toString()).doesNotContain("flowSensitiveInlineVariables");
+  }
+
+  @Test
   public void testSimpleVar() {
     inline("var x = 1; print(x)", "var x; print(1)");
     inline("var x = 1; x", "var x; 1");

--- a/test/com/google/javascript/jscomp/InferConstsTest.java
+++ b/test/com/google/javascript/jscomp/InferConstsTest.java
@@ -33,6 +33,14 @@ public final class InferConstsTest extends CompilerTestCase {
   private FindConstants constFinder;
 
   private ImmutableList<String> names;
+  private int parallelism = 1;
+
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    options.setNumParallelThreads(parallelism);
+    return options;
+  }
 
   @Override
   public CompilerPass getProcessor(final Compiler compiler) {
@@ -54,6 +62,20 @@ public final class InferConstsTest extends CompilerTestCase {
     assertConsts("var x = 3, y;", inferred("x"), notInferred("y"));
     assertConsts("var x = 3;  function f(){x;}", inferred("x"));
     assertConsts("var x = 3, y; y ||= 4;", inferred("x"), notInferred("y"));
+  }
+
+  @Test
+  public void testParallelScripts() {
+    parallelism = 2;
+    names = ImmutableList.of("x", "y", "a", "b");
+    testSame(
+        srcs(
+            "var x = 0; var y = 0; function first() { x; var a = 1; }",
+            "y = 1; function second() { x; var b = 2; }"));
+    assertWithMessage("inferred constant names")
+        .that(constFinder.inferredNodes)
+        .containsAtLeast("x", "a", "b");
+    assertWithMessage("inferred constant names").that(constFinder.inferredNodes).doesNotContain("y");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/OptimizeCallsTest.java
+++ b/test/com/google/javascript/jscomp/OptimizeCallsTest.java
@@ -38,6 +38,7 @@ public final class OptimizeCallsTest extends CompilerTestCase {
 
   // Whether to consider externs during the next collection. Must be explicitly set.
   private @Nullable Boolean considerExterns = null;
+  private int numParallelThreads = 1;
 
   @Override
   @Before
@@ -46,15 +47,37 @@ public final class OptimizeCallsTest extends CompilerTestCase {
     enableNormalize(); // Required for `OptimizeCalls`.
     // Even if we're ignoring externs we need to know their names to do that.
     enableGatherExternProperties();
+    numParallelThreads = 1;
   }
 
   @Override
   protected CompilerPass getProcessor(final Compiler compiler) {
+    compiler.getOptions().setNumParallelThreads(numParallelThreads);
     return OptimizeCalls.builder()
         .setCompiler(compiler)
         .setConsiderExterns(considerExterns)
         .addPass((externs, root, references) -> this.references = references)
         .build();
+  }
+
+  @Test
+  public void testReferenceCollectionAcrossScriptsConcurrently() {
+    considerExterns = false;
+    numParallelThreads = 4;
+
+    testSame(
+        srcs(
+            "var first = {}; first.alpha;",
+            "var second = {}; first.beta; second.alpha;"));
+
+    assertThat(references.getNameReferences())
+        .comparingElementsUsing(KEY_EQUALITY)
+        .containsExactly("first", "second")
+        .inOrder();
+    assertThat(references.getPropReferences())
+        .comparingElementsUsing(KEY_EQUALITY)
+        .containsExactly("alpha", "beta")
+        .inOrder();
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/PeepholeOptimizationsPassTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeOptimizationsPassTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import org.junit.Test;
@@ -62,8 +63,16 @@ public final class PeepholeOptimizationsPassTest extends CompilerTestCase {
   @Test
   public void testParallelScripts() {
     parallelism = 2;
-    parallelOptimizationFactory = () -> List.of(new RemoveNodesNamedXUnderVarOptimization());
+    AtomicInteger optimizationInstancesCreated = new AtomicInteger();
+    parallelOptimizationFactory =
+        () -> {
+          optimizationInstancesCreated.incrementAndGet();
+          return List.of(new RemoveNodesNamedXUnderVarOptimization());
+        };
     test(srcs("var x, a;", "var x, b;"), expected("var a;", "var b;"));
+    // One instance is owned by the pass, then each of the two workers gets an isolated instance for
+    // both the initial script traversal and the changed-scope fixed-point traversal.
+    assertThat(optimizationInstancesCreated.get()).isEqualTo(5);
   }
 
   /**

--- a/test/com/google/javascript/jscomp/PeepholeOptimizationsPassTest.java
+++ b/test/com/google/javascript/jscomp/PeepholeOptimizationsPassTest.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,11 +39,31 @@ import org.junit.runners.JUnit4;
 public final class PeepholeOptimizationsPassTest extends CompilerTestCase {
 
   private ImmutableList<AbstractPeepholeOptimization> currentPeepholePasses;
+  private int parallelism = 1;
+  private @Nullable Supplier<List<AbstractPeepholeOptimization>> parallelOptimizationFactory;
+
+  @Override
+  protected CompilerOptions getOptions() {
+    CompilerOptions options = super.getOptions();
+    options.setNumParallelThreads(parallelism);
+    return options;
+  }
 
   @Override
   protected CompilerPass getProcessor(final Compiler compiler) {
+    if (parallelOptimizationFactory != null) {
+      return new PeepholeOptimizationsPass(
+          compiler, getName(), parallelOptimizationFactory);
+    }
     return new PeepholeOptimizationsPass(
         compiler, getName(), currentPeepholePasses.toArray(new AbstractPeepholeOptimization[0]));
+  }
+
+  @Test
+  public void testParallelScripts() {
+    parallelism = 2;
+    parallelOptimizationFactory = () -> List.of(new RemoveNodesNamedXUnderVarOptimization());
+    test(srcs("var x, a;", "var x, b;"), expected("var a;", "var b;"));
   }
 
   /**

--- a/test/com/google/javascript/jscomp/PerformanceTrackerTest.java
+++ b/test/com/google/javascript/jscomp/PerformanceTrackerTest.java
@@ -118,7 +118,7 @@ public final class PerformanceTrackerTest {
                             IR.hook(IR.string("a"), IR.string("b"), IR.string("c")))),
                     IR.function(IR.name("name"), IR.paramList(), IR.block()))));
     PerformanceTracker tracker =
-        new PerformanceTracker(emptyExternRoot, main, TracerMode.TIMING_ONLY);
+        new PerformanceTracker(emptyExternRoot, main, TracerMode.RAW_SIZE);
 
     // When
     tracker.recordPassStart(PassNames.PARSE_INPUTS, true);
@@ -143,6 +143,18 @@ public final class PerformanceTrackerTest {
                 STRINGLIT,3
                 """,
                 Pattern.DOTALL));
+  }
+
+  @Test
+  public void testTimingOnlyOmitsAstManifest() {
+    Node main = IR.root(IR.script(IR.exprResult(IR.name("x"))));
+    PerformanceTracker tracker =
+        new PerformanceTracker(emptyExternRoot, main, TracerMode.TIMING_ONLY);
+
+    tracker.recordPassStart(PassNames.PARSE_INPUTS, true);
+    tracker.recordPassStop(PassNames.PARSE_INPUTS, 0);
+
+    assertThat(extractReport(tracker)).doesNotContain("Input AST Manifest:");
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/PhaseOptimizerTest.java
+++ b/test/com/google/javascript/jscomp/PhaseOptimizerTest.java
@@ -95,6 +95,55 @@ public final class PhaseOptimizerTest {
   }
 
   @Test
+  public void testOptimizationLoopSizeThresholdStopsSmallChangesEarly() {
+    for (int i = 0; i < 1_000; i++) {
+      dummyScript.addChildToBack(IR.empty());
+    }
+    compiler.getOptions().setOptimizationLoopSizeThreshold(0.1);
+    optimizer = new PhaseOptimizer(compiler, tracker);
+    Loop loop = optimizer.addFixedPointLoop();
+    loop.addLoopedPass(
+        createPassFactory(
+            PassNames.PEEPHOLE_OPTIMIZATIONS,
+            (externs, root) -> {
+              passesRun.add(PassNames.PEEPHOLE_OPTIMIZATIONS);
+              dummyScript.getLastChild().detach();
+              compiler.reportChangeToEnclosingScope(dummyScript);
+            },
+            false));
+
+    assertPasses(PassNames.PEEPHOLE_OPTIMIZATIONS, PassNames.PEEPHOLE_OPTIMIZATIONS);
+  }
+
+  @Test
+  public void testOptimizationLoopSizeThresholdCanPreserveSmallChanges() {
+    for (int i = 0; i < 1_000; i++) {
+      dummyScript.addChildToBack(IR.empty());
+    }
+    compiler.getOptions().setOptimizationLoopSizeThreshold(0.05);
+    optimizer = new PhaseOptimizer(compiler, tracker);
+    Loop loop = optimizer.addFixedPointLoop();
+    int[] remainingChanges = {3};
+    loop.addLoopedPass(
+        createPassFactory(
+            PassNames.PEEPHOLE_OPTIMIZATIONS,
+            (externs, root) -> {
+              passesRun.add(PassNames.PEEPHOLE_OPTIMIZATIONS);
+              if (remainingChanges[0]-- > 0) {
+                dummyScript.getLastChild().detach();
+                compiler.reportChangeToEnclosingScope(dummyScript);
+              }
+            },
+            false));
+
+    assertPasses(
+        PassNames.PEEPHOLE_OPTIMIZATIONS,
+        PassNames.PEEPHOLE_OPTIMIZATIONS,
+        PassNames.PEEPHOLE_OPTIMIZATIONS,
+        PassNames.PEEPHOLE_OPTIMIZATIONS);
+  }
+
+  @Test
   public void testIncrementalAstSizeMatchesFullCount() {
     Node function =
         IR.function(IR.name("f"), IR.paramList(), IR.block(IR.returnNode(IR.number(1))));

--- a/test/com/google/javascript/jscomp/PhaseOptimizerTest.java
+++ b/test/com/google/javascript/jscomp/PhaseOptimizerTest.java
@@ -95,6 +95,37 @@ public final class PhaseOptimizerTest {
   }
 
   @Test
+  public void testIncrementalAstSizeMatchesFullCount() {
+    Node function =
+        IR.function(IR.name("f"), IR.paramList(), IR.block(IR.returnNode(IR.number(1))));
+    dummyScript.addChildToBack(function);
+    Node secondScript = IR.script(IR.exprResult(IR.name("x")));
+    dummyRoot.addChildToBack(secondScript);
+
+    PhaseOptimizer.IncrementalAstSize astSize =
+        new PhaseOptimizer.IncrementalAstSize(dummyRoot, compiler.getChangeTracker());
+    assertThat(astSize.getAstSize()).isEqualTo(NodeUtil.countAstSize(dummyRoot));
+
+    Node addedExpression = IR.exprResult(IR.name("y"));
+    function.getLastChild().addChildToBack(addedExpression);
+    compiler.reportChangeToEnclosingScope(addedExpression);
+    assertThat(astSize.update()).isEqualTo(NodeUtil.countAstSize(dummyRoot));
+
+    addedExpression.detach();
+    compiler.reportChangeToChangeScope(function);
+    assertThat(astSize.update()).isEqualTo(NodeUtil.countAstSize(dummyRoot));
+
+    secondScript.detach();
+    compiler.reportChangeToChangeScope(secondScript);
+    assertThat(astSize.update()).isEqualTo(NodeUtil.countAstSize(dummyRoot));
+
+    Node thirdScript = IR.script(IR.exprResult(IR.name("z")));
+    dummyRoot.addChildToBack(thirdScript);
+    compiler.reportChangeToChangeScope(thirdScript);
+    assertThat(astSize.update()).isEqualTo(NodeUtil.countAstSize(dummyRoot));
+  }
+
+  @Test
   public void testNotInfiniteLoop() {
     Loop loop = optimizer.addFixedPointLoop();
     addLoopedPass(loop, "x", PhaseOptimizer.MAX_LOOPS - 2);

--- a/test/com/google/javascript/jscomp/PhaseOptimizerTest.java
+++ b/test/com/google/javascript/jscomp/PhaseOptimizerTest.java
@@ -95,6 +95,15 @@ public final class PhaseOptimizerTest {
   }
 
   @Test
+  public void testCapCodeMotionLoopIterations() {
+    compiler.getOptions().setMaxOptimizationMotionLoopIterations(1);
+    optimizer = new PhaseOptimizer(compiler, tracker);
+    Loop loop = optimizer.addFixedPointLoop();
+    addLoopedPass(loop, PassNames.CROSS_CHUNK_CODE_MOTION, 2);
+    assertPasses(PassNames.CROSS_CHUNK_CODE_MOTION);
+  }
+
+  @Test
   public void testOptimizationLoopSizeThresholdStopsSmallChangesEarly() {
     for (int i = 0; i < 1_000; i++) {
       dummyScript.addChildToBack(IR.empty());

--- a/test/com/google/javascript/jscomp/PolyfillUsageFinderTest.java
+++ b/test/com/google/javascript/jscomp/PolyfillUsageFinderTest.java
@@ -31,6 +31,7 @@ import com.google.javascript.jscomp.testing.TestExternsBuilder;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
 import com.google.javascript.rhino.testing.NodeSubject;
+import java.util.Set;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import org.junit.Test;
@@ -40,6 +41,89 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link PolyfillUsageFinder} */
 @RunWith(JUnit4.class)
 public final class PolyfillUsageFinderTest {
+
+  @Test
+  public void guardedUsageCache_rescansOnlyChangedScopes() {
+    SourceFile src =
+        SourceFile.builder()
+            .withPath("src.js")
+            .withContent(
+                """
+                if (Map) use(Map);
+                function f() { if (Promise) use(Promise); }
+                function g() { if (Symbol) use(Symbol); }
+                """)
+            .build();
+    Compiler compiler = new Compiler();
+    compiler.init(
+        ImmutableList.of(new TestExternsBuilder().buildExternsFile("externs.js")),
+        ImmutableList.of(src),
+        new CompilerOptions());
+    compiler.parse();
+
+    Node root = compiler.getJsRoot();
+    Node script = root.getFirstChild();
+    Node topLevelIf = script.getFirstChild();
+    Node functionF = topLevelIf.getNext();
+    Node functionG = functionF.getNext();
+    Node functionFIf = functionF.getLastChild().getFirstChild();
+    Node functionGIf = functionG.getLastChild().getFirstChild();
+
+    Node topLevelCondition = topLevelIf.getFirstChild();
+    Node topLevelGuardedUse = topLevelIf.getSecondChild().getFirstFirstChild().getSecondChild();
+    Node functionFCondition = functionFIf.getFirstChild();
+    Node functionFGuardedUse = functionFIf.getSecondChild().getFirstFirstChild().getSecondChild();
+    Node functionGCondition = functionGIf.getFirstChild();
+    Node functionGGuardedUse = functionGIf.getSecondChild().getFirstFirstChild().getSecondChild();
+
+    Polyfills polyfills =
+        Polyfills.fromTable(
+            """
+            Map es6 es3 es6/map
+            Promise es6 es3 es6/promise/promise
+            Symbol es6 es3 es6/symbol
+            """);
+    RemoveUnusedCode.GuardedPolyfillUsageCache cache =
+        new RemoveUnusedCode.GuardedPolyfillUsageCache();
+
+    assertThat(cache.getGuardedUsages(compiler, polyfills, root))
+        .containsExactly(
+            topLevelCondition,
+            topLevelGuardedUse,
+            functionFCondition,
+            functionFGuardedUse,
+            functionGCondition,
+            functionGGuardedUse);
+
+    // Invalidating f drops its now-unguarded Promise nodes, without rescanning or losing g.
+    functionFCondition.setString("notAPolyfill");
+    compiler.reportChangeToChangeScope(functionF);
+    assertThat(cache.getGuardedUsages(compiler, polyfills, root))
+        .containsExactly(
+            topLevelCondition, topLevelGuardedUse, functionGCondition, functionGGuardedUse);
+
+    // Rescanning the same scope can also add newly guarded usages.
+    functionFCondition.setString("Promise");
+    compiler.reportChangeToChangeScope(functionF);
+    assertThat(cache.getGuardedUsages(compiler, polyfills, root))
+        .containsExactly(
+            topLevelCondition,
+            topLevelGuardedUse,
+            functionFCondition,
+            functionFGuardedUse,
+            functionGCondition,
+            functionGGuardedUse);
+
+    // A script-level change similarly leaves cached results for its nested functions intact. Also
+    // invalidate f again to cover updating multiple independent scopes in one request.
+    functionFCondition.setString("notAPolyfill");
+    compiler.reportChangeToChangeScope(functionF);
+    topLevelCondition.setString("notAPolyfill");
+    compiler.reportChangeToChangeScope(script);
+    Set<Node> finalUsages = cache.getGuardedUsages(compiler, polyfills, root);
+    assertThat(finalUsages).containsExactly(functionGCondition, functionGGuardedUse);
+    assertThat(finalUsages).containsNoneOf(functionFCondition, functionFGuardedUse);
+  }
 
   /**
    * Covers testing of most common cases.

--- a/test/com/google/javascript/jscomp/RenameVarsTest.java
+++ b/test/com/google/javascript/jscomp/RenameVarsTest.java
@@ -51,6 +51,7 @@ public final class RenameVarsTest extends CompilerTestCase {
   private boolean generatePseudoNames = false;
   private boolean preferStableNames = false;
   private boolean withNormalize = false;
+  private int numParallelThreads = 1;
 
   // NameGenerator to use, or null for a default.
   private @Nullable DefaultNameGenerator nameGenerator = null;
@@ -66,6 +67,7 @@ public final class RenameVarsTest extends CompilerTestCase {
 
   @Override
   protected CompilerPass getProcessor(Compiler compiler) {
+    compiler.getOptions().setNumParallelThreads(numParallelThreads);
     CompilerPass pass;
     if (withClosurePass) {
       pass = new ClosurePassAndRenameVars(compiler);
@@ -120,6 +122,19 @@ public final class RenameVarsTest extends CompilerTestCase {
     generatePseudoNames = false;
     preferStableNames = false;
     nameGenerator = null;
+    numParallelThreads = 1;
+  }
+
+  @Test
+  public void testRenameAcrossScriptsConcurrently() {
+    numParallelThreads = 4;
+    test(
+        srcs(
+            "var low; var high; high; function foo(alpha) { return alpha; }",
+            "high; var middle; middle; function bar(beta) { return beta; }"),
+        expected(
+            "var b; var c; c; function d(a) { return a; }",
+            "c; var e; e; function f(a) { return a; }"));
   }
 
   @Test

--- a/test/com/google/javascript/jscomp/serialization/SerializeAndDeserializeAstTest.java
+++ b/test/com/google/javascript/jscomp/serialization/SerializeAndDeserializeAstTest.java
@@ -26,6 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.javascript.jscomp.AstValidator;
 import com.google.javascript.jscomp.Compiler;
@@ -534,6 +535,28 @@ public final class SerializeAndDeserializeAstTest extends CompilerTestCase {
 
     Result result = testAndReturnResult(srcs(code), expected(code));
     assertThat(result.compiler.getBase64SourceMapContents("testcode")).isNull();
+  }
+
+  @Test
+  public void testSourceMapsInSeparateMapFilesArePreserved() throws IOException {
+    Path directory = folder.newFolder("external-source-map").toPath();
+    Path sourceMap = directory.resolve("input.js.map");
+    Files.writeString(
+        sourceMap,
+        """
+        {"version":3,"file":"input.js","sources":["input.ts"],"names":[],"mappings":"AAAA"}
+        """,
+        UTF_8);
+    Path input = directory.resolve("input.js");
+    Files.writeString(input, "const x = 0;\n//# sourceMappingURL=input.js.map", UTF_8);
+    SourceFile inputFile = SourceFile.fromFile(input.toString(), UTF_8);
+
+    Result result =
+        testAndReturnResult(srcs(ImmutableList.of(inputFile)), expected(ImmutableList.of(inputFile)));
+
+    OriginalMapping mapping = result.compiler.getSourceMapping(input.toString(), 1, 0);
+    assertThat(mapping).isNotNull();
+    assertThat(mapping.getOriginalFile()).isEqualTo(directory.resolve("input.ts").toString());
   }
 
   @Test


### PR DESCRIPTION
This PR is a collection of LLM-driven optimizations to the compiler.

It does include a few changes to the tracer mode, which were used for making these improvements, but if you would like I can revert those changes and only leave the actual optimizations.

For our closure-compiler pipeline we were able to get it down from 290s to 100s for a byte-equivalent version, and even faster when using the exposed speed-size tuning knobs.  Not all of those speed improvements are local to the changes here, as those timings also include improvements to, for example, how we compress the assets after compilation completes.