### PR TITLE
stop truncating out-of-bmp identifier escapes in the scanner

### DIFF
--- a/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
+++ b/src/com/google/javascript/jscomp/parsing/parser/Scanner.java
@@ -882,8 +882,18 @@ public class Scanner {
           hexDigits = value.substring(escapeStart + 3, escapeEnd);
           escapeEnd++;
         }
+        // Identifiers are carried around the compiler as sequences of char (UTF-16 code units), so a
+        // code point that does not fit in a single char cannot be represented here. The value used
+        // to be cast straight to char, which silently kept only the low 16 bits: a braced escape for
+        // U+10041 was accepted as the identifier "A", and even code points above the U+10FFFF
+        // maximum (e.g. U+110041) slipped through the same way. Reject anything outside the BMP
+        // rather than aliasing it to a different character.
         // TODO(mattloring): Allow code points >= 0xFFFF (greater than the size of a char).
-        char ch = (char) Integer.parseInt(hexDigits, 0x10);
+        int codePoint = Integer.parseInt(hexDigits, 0x10);
+        if (codePoint > 0xFFFF) {
+          return null;
+        }
+        char ch = (char) codePoint;
         if (!Identifiers.isIdentifierPart(ch)) {
           return null;
         }

--- a/test/com/google/javascript/jscomp/parsing/ParserTest.java
+++ b/test/com/google/javascript/jscomp/parsing/ParserTest.java
@@ -5221,6 +5221,11 @@ public final class ParserTest extends BaseJSTypeTestCase {
     // Legal unicode but invalid in identifier
     parseError("Js\\u{99}ompiler", "Invalid escape sequence");
     parseError("Js\\u{10000}ompiler", "Invalid escape sequence");
+    // Code points outside the BMP must not be truncated to their low 16 bits. U+10041 shares its
+    // low bits with U+0041 ('A') and U+110041 is above the U+10FFFF maximum; both used to be
+    // silently accepted.
+    parseError("Js\\u{10041}ompiler", "Invalid escape sequence");
+    parseError("Js\\u{110041}ompiler", "Invalid escape sequence");
   }
 
   @Test


### PR DESCRIPTION
**Out-of-range identifier escapes get silently truncated to a char**

In `processUnicodeEscapes` a braced unicode escape inside an identifier has its parsed code point cast straight to a char, so only the low 16 bits survive. That means an escape like \u{10041} is quietly accepted as the identifier `A`, and even values above the U+10FFFF maximum such as \u{110041} slip through the same way, so two identifiers that ought to be distinct (or rejected outright) can end up collapsing onto one. The scanner already rejects \u{10000} here, and the string-literal path range-checks the code point, so this brings identifiers into line by rejecting anything that does not fit in a char rather than aliasing it to a different character.