### PR TITLE
Fix spelling of occurred in ProfilingReport header

### DIFF
--- a/src/com/google/javascript/jscomp/instrumentation/reporter/ProfilingReport.java
+++ b/src/com/google/javascript/jscomp/instrumentation/reporter/ProfilingReport.java
@@ -101,7 +101,7 @@ final class ProfilingReport {
     // Header row.
     output.add(
         ImmutableList.of(
-            "File", "Function name", "Line", "Type", "Total executed", "Reports occured"));
+            "File", "Function name", "Line", "Type", "Total executed", "Reports occurred"));
     // Body rows.
     for (Map.Entry<InstrumentationPoint, InstrumentationPointMetrics> entry : result) {
       output.add(

--- a/test/com/google/javascript/jscomp/instrumentation/reporter/testdata/expectedFinalResult.txt
+++ b/test/com/google/javascript/jscomp/instrumentation/reporter/testdata/expectedFinalResult.txt
@@ -1,4 +1,4 @@
-File	Function name	Line	Type	Total executed	Reports occured
+File	Function name	Line	Type	Total executed	Reports occurred
 InstrumentCode.js	module$contents$instrument$code_instrumentCode	13	FUNCTION	1	1
 InstrumentCode.js	module$contents$instrument$code_instrumentCode	15	BRANCH	1	1
 InstrumentCode.js	<Anonymous>	57	FUNCTION	1	1


### PR DESCRIPTION
Fixes a CSV header typo: `Reports occured` → `Reports occurred`.

No behavior change.